### PR TITLE
fix(cron): defensive dict-spread order so contract keys always win

### DIFF
--- a/app/api/internal_cron.py
+++ b/app/api/internal_cron.py
@@ -80,7 +80,9 @@ async def _run_cron(name: str, task: Callable[[], Awaitable[dict]]) -> dict:
         raise
     duration_ms = int((time.perf_counter() - t0) * 1000)
     await log.ainfo(f"cron.{name}.completed", duration_ms=duration_ms, **result)
-    return {"status": "ok", "duration_ms": duration_ms, **result}
+    # Spread task result first so the handler-level contract keys (status, duration_ms)
+    # always win if a task ever starts returning a key with the same name.
+    return {**result, "status": "ok", "duration_ms": duration_ms}
 
 
 @router.post("/sync", dependencies=[Depends(verify_secret)])


### PR DESCRIPTION
## Summary

Follow-up to PR #7 review nit. Flips the dict-spread order in `_run_cron()` so the handler's contract keys (`status`, `duration_ms`) always win on collision:

```python
# Before
return {"status": "ok", "duration_ms": duration_ms, **result}
# After
return {**result, "status": "ok", "duration_ms": duration_ms}
```

## Why

If a task function (`run_job_sync`, `run_generation_queue`, `run_daily_maintenance`) ever starts returning a `"status"` or `"duration_ms"` key in its result dict, the old order let the task clobber the handler contract. Verified no collision today — this is purely defensive hardening for future schema additions.

## Test plan

- [x] `uv run pytest tests/unit/test_internal_cron.py` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)