### PR TITLE
test(e2e): disable public sources in test_app fixture

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -57,6 +57,13 @@ async def test_app(asyncpg_url, psycopg_url, monkeypatch):
     monkeypatch.setenv("ADZUNA_APP_ID", "fake-app-id")
     monkeypatch.setenv("ADZUNA_API_KEY", "fake-api-key")
     monkeypatch.setenv("JSEARCH_API_KEY", "fake-jsearch-key")
+    # Disable public sources so e2e tests only see sources explicitly mocked
+    # in the test (adzuna, jsearch). Without this, job_sync_service hits the
+    # real remotive/remoteok/arbeitnow HTTP APIs, polluting assertions.
+    monkeypatch.setenv("REMOTIVE_ENABLED", "false")
+    monkeypatch.setenv("REMOTEOK_ENABLED", "false")
+    monkeypatch.setenv("ARBEITNOW_ENABLED", "false")
+    monkeypatch.setenv("GREENHOUSE_BOARD_ENABLED", "false")
 
     # Reset settings singleton so the env vars above take effect
     import app.config as cfg


### PR DESCRIPTION
## Summary

Unblocks main CI, which has been failing since public-source additions landed.

## Root cause

`test_app` fixture in `tests/e2e/conftest.py` doesn't disable the public sources (remotive, remoteok, arbeitnow, greenhouse_board) that default to enabled in Settings. Individual tests only mock `AdzunaSource` and `JSearchSource`, so assertions like `new_jobs == 3` see 211 instead (3 mocked + ~208 real).

## Fix

Four env vars in the monkeypatch block: \`REMOTIVE_ENABLED=false\`, \`REMOTEOK_ENABLED=false\`, \`ARBEITNOW_ENABLED=false\`, \`GREENHOUSE_BOARD_ENABLED=false\`.

## Why now

Deploy pipeline is gated on CI — as long as test is red, Cloud Run never updates. The `*/10min` cron workflow has been failing for hours because the production app is running pre-merge-fix handler code. Once this passes CI and main deploys, PRs #7/#8/#9 fixes actually ship and the cron gets tagged Sentry events instead of silent 500s.

## Test plan

- [x] \`uv run pytest tests/e2e/ tests/integration/ tests/unit/\` → 229 passed (was: 6 e2e FAILED + 229 passing after fix).
- [ ] Post-merge: CI test job goes green → deploy job runs → Cloud Run gets updated cron handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)