### PR TITLE
fix(scripts): make seed + smoke-token scripts runnable without PYTHONPATH

### DIFF
--- a/scripts/make_smoke_token.py
+++ b/scripts/make_smoke_token.py
@@ -16,6 +16,11 @@ Usage (usually via Makefile):
 
 import datetime
 import sys
+from pathlib import Path
+
+# Make the `app` package importable when this file is run as a script
+# (e.g. via `make smoke-token`) without needing PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 try:
     import jwt

--- a/scripts/seed_demo_profile.py
+++ b/scripts/seed_demo_profile.py
@@ -2,9 +2,14 @@
 
 import asyncio
 import json
+import sys
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
+
+# Make the `app` package importable when this file is run as a script
+# without needing PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from app.config import get_settings
 from app.database import get_session_factory
@@ -60,7 +65,7 @@ async def main() -> None:
                     val = exp.get(field)
                     if isinstance(val, str):
                         dt = datetime.fromisoformat(val)
-                        exp[field] = dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+                        exp[field] = dt if dt.tzinfo else dt.replace(tzinfo=UTC)
                 parsed_exps.append(exp)
             await replace_all_work_experiences(profile.id, parsed_exps, session)
 

--- a/scripts/seed_smoke_user.py
+++ b/scripts/seed_smoke_user.py
@@ -15,7 +15,13 @@ Both AUTH_ENABLED modes are handled:
 """
 
 import asyncio
+import sys
 import uuid
+from pathlib import Path
+
+# Make the `app` package importable when this file is run as a script
+# (e.g. `uv run python scripts/seed_smoke_user.py`) without needing PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
## Summary

Reproduced the user-reported error: running \`DATABASE_URL=... uv run python scripts/seed_smoke_user.py\` fails with:

\`\`\`
ModuleNotFoundError: No module named 'app'
\`\`\`

Root cause: when Python is invoked with an absolute script path, the repo root isn't on \`sys.path\` (only the script's directory is). The docs in §7a and §3b rely on this invocation pattern for provisioning, so the bug blocks every new operator.

## Fix

Each script prepends the repo root to \`sys.path\` before importing \`app.*\`:

\`\`\`python
sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
\`\`\`

Three scripts had the same bug — all fixed:
- \`scripts/seed_smoke_user.py\` (surfaced by user)
- \`scripts/seed_demo_profile.py\` (same pattern — silently broken)
- \`scripts/make_smoke_token.py\` (same pattern; caught by an existing try/except that reported a misleading \"Could not load jwt_secret\" message instead of the real import error)

Also fixes a pre-existing UP017 lint error in \`seed_demo_profile.py\` (\`timezone.utc\` → \`datetime.UTC\`) that the pre-commit hook started flagging once the file was touched.

## Test plan

- [x] \`DATABASE_URL=... uv run python scripts/seed_smoke_user.py\` → seeds successfully; second run is a no-op (idempotency verified).
- [x] \`DATABASE_URL=... uv run python scripts/seed_demo_profile.py\` → seeds successfully.
- [x] \`JWT_SECRET=... uv run python scripts/make_smoke_token.py\` → prints a valid JWT.
- [x] \`uv run ruff check scripts/\` → clean.
- [x] Works both ways: from repo root and from inside \`scripts/\` dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)