### PR TITLE
feat(sources): un-silence exception handlers — ERROR + exc_info + source tag

### DIFF
--- a/app/sources/adzuna_enrichment.py
+++ b/app/sources/adzuna_enrichment.py
@@ -42,7 +42,14 @@ async def fetch_full_description(
             html = response.text
             resolved_url = str(response.url)
     except Exception as exc:
-        await log.awarning("adzuna.enrichment.failed", url=redirect_url, error=str(exc))
+        await log.aerror(
+            "adzuna.enrichment.failed",
+            source_name="adzuna_enrichment",
+            url=redirect_url,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         return None, None, None
 
     is_adzuna_page = "adzuna.com" in resolved_url.lower()
@@ -72,8 +79,14 @@ def _extract_body(html: str, *, use_adzuna_selector: bool = True) -> str | None:
             section = soup.select_one("section.adp-body")
             if section:
                 return section.get_text(separator="\n", strip=True)
-        except Exception:
-            pass
+        except Exception as exc:
+            log.error(
+                "adzuna.enrichment.bs4_body_failed",
+                source_name="adzuna_enrichment",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                exc_info=True,
+            )
 
     return None
 
@@ -96,5 +109,12 @@ def _extract_card_info(html: str) -> dict | None:
             return None
 
         return {"salary": salary or None, "contract_type": contract_type or None}
-    except Exception:
+    except Exception as exc:
+        log.error(
+            "adzuna.enrichment.card_info_failed",
+            source_name="adzuna_enrichment",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         return None

--- a/app/sources/arbeitnow.py
+++ b/app/sources/arbeitnow.py
@@ -101,7 +101,13 @@ class ArbeitnowSource(JobSource):
                 response.raise_for_status()
                 data = response.json()
         except Exception as exc:
-            await log.awarning("arbeitnow.fetch_failed", error=str(exc))
+            await log.aerror(
+                "arbeitnow.fetch_failed",
+                source_name="arbeitnow",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                exc_info=True,
+            )
             return [], None
 
         if not data.get("data"):

--- a/app/sources/greenhouse.py
+++ b/app/sources/greenhouse.py
@@ -27,7 +27,16 @@ async def get_job_questions(board_token: str, job_id: str) -> list[dict]:
             if resp.status_code != 200:
                 return []
             data = resp.json()
-    except Exception:
+    except Exception as exc:
+        await log.aerror(
+            "greenhouse.questions_failed",
+            source_name="greenhouse",
+            board_token=board_token,
+            job_id=job_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         return []
 
     questions = []
@@ -150,6 +159,15 @@ async def try_submit(
             custom_answers=custom_answers,
         )
     except Exception as exc:
+        await log.aerror(
+            "greenhouse.submit_failed",
+            source_name="greenhouse",
+            board_token=board_token,
+            job_id=job_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         return {"success": False, "method": "greenhouse_api", "error": str(exc)}
     result["method"] = "greenhouse_api"
     return result

--- a/app/sources/greenhouse_board.py
+++ b/app/sources/greenhouse_board.py
@@ -133,7 +133,14 @@ class GreenhouseBoardSource(JobSource):
                 response.raise_for_status()
                 data = response.json()
         except Exception as exc:
-            await log.awarning("greenhouse_board.fetch_failed", slug=slug, error=str(exc))
+            await log.aerror(
+                "greenhouse_board.fetch_failed",
+                source_name="greenhouse_board",
+                slug=slug,
+                error=str(exc),
+                error_type=type(exc).__name__,
+                exc_info=True,
+            )
             return []
 
         if session is not None:
@@ -164,6 +171,13 @@ class GreenhouseBoardSource(JobSource):
                 jobs = await self._fetch_slug(slug, settings, session)
                 all_jobs.extend(jobs)
             except Exception as exc:
-                await log.awarning("greenhouse_board.fetch_failed", slug=slug, error=str(exc))
+                await log.aerror(
+                    "greenhouse_board.fetch_failed",
+                    source_name="greenhouse_board",
+                    slug=slug,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                    exc_info=True,
+                )
 
         return all_jobs, None

--- a/app/sources/lever_submit.py
+++ b/app/sources/lever_submit.py
@@ -51,5 +51,11 @@ async def try_submit(
                 "body": resp.text[:500],
             }
     except Exception as exc:
-        await log.awarning("lever_submit.failed", error=str(exc))
+        await log.aerror(
+            "lever_submit.failed",
+            source_name="lever_submit",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         return {"method": "manual", "apply_url": apply_url, "error": str(exc)}

--- a/app/sources/remoteok.py
+++ b/app/sources/remoteok.py
@@ -102,7 +102,13 @@ class RemoteOKSource(JobSource):
                 response.raise_for_status()
                 data = response.json()
         except Exception as exc:
-            await log.awarning("remoteok.fetch_failed", error=str(exc))
+            await log.aerror(
+                "remoteok.fetch_failed",
+                source_name="remoteok",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                exc_info=True,
+            )
             return [], None
 
         if session is not None:

--- a/app/sources/remotive.py
+++ b/app/sources/remotive.py
@@ -103,7 +103,13 @@ class RemotiveSource(JobSource):
                 response.raise_for_status()
                 data = response.json()
         except Exception as exc:
-            await log.awarning("remotive.fetch_failed", error=str(exc))
+            await log.aerror(
+                "remotive.fetch_failed",
+                source_name="remotive",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                exc_info=True,
+            )
             return [], None
 
         if session is not None:


### PR DESCRIPTION
## Summary

PR 5 of the [stabilization plan](../../.claude/plans/2026-04-21-stabilize-golden-path.md). Eleven exception handlers across \`app/sources/\` now log at ERROR level with \`source_name\` tag, \`error_type\`, and \`exc_info=True\` so stack traces land in GCP Cloud Error Reporting's \`exception\` field for auto-grouping.

## Changes

- **arbeitnow / remoteok / remotive** — existing \`awarning(\"…fetch_failed\")\` → \`aerror\` with \`source_name\`, \`error_type\`, \`exc_info=True\`
- **greenhouse_board** (two sites: \`_fetch_slug\` + \`search\`) — same upgrade, preserved \`slug\` tag
- **greenhouse.get_job_questions** (was silent: \`except Exception: return []\`) — new ERROR log \`greenhouse.questions_failed\` with \`board_token\` + \`job_id\`
- **greenhouse.try_submit** (returned error dict with no log) — new ERROR log \`greenhouse.submit_failed\` before the existing return
- **adzuna_enrichment.fetch_full_description** — upgrade
- **adzuna_enrichment._extract_body** + **_extract_card_info** (both silent \`pass\` / \`return None\`) — new ERROR logs \`adzuna.enrichment.bs4_body_failed\` / \`adzuna.enrichment.card_info_failed\` (sync log calls since helpers are sync)
- **lever_submit** — upgrade

Return shapes unchanged — sync service still iterates all sources and a single failure doesn't abort the batch.

## Left alone

\`app/sources/jsearch.py\` and \`app/sources/adzuna.py\` have no top-level \`except Exception\` in \`fetch\` — errors propagate up. That's intentional for config-level bugs (auth mismatch, missing API key). No silent swallows there.

## Verification

- \`grep -rE \"except Exception:\\s*\$|except Exception:\\s*pass|except Exception:\\s*return\" app/sources/\` → zero hits.
- \`uv run ruff check app/ tests/\` → clean.
- \`uv run pytest tests/unit/ -q\` → 147 passed (unchanged; existing \`*_http_error\` tests cover the error paths, return shapes unchanged).

## Next in plan

PR 5 acceptance mentions \"smoke step 4 proves ≥1 source returns jobs.\" That's a smoke-script assertion change, not a source-code change — deferred to its own PR to keep this one focused on the handler upgrade.

## Delegation note

Mechanical upgrade across 11 sites. Delegated to \`python-pro\` per the CLAUDE.md multi-file-prod-code rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)