### PR TITLE
feat(auth): differentiate token-failure paths with structured logs

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,6 +1,7 @@
 import uuid
 
 import jwt
+import structlog
 from fastapi import Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,6 +10,8 @@ from app.config import Settings, get_settings
 from app.database import get_db
 from app.models.user import User
 from app.models.user_profile import UserProfile
+
+log = structlog.get_logger()
 
 SINGLE_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 
@@ -47,14 +50,26 @@ async def get_current_user(
             audience=["fastapi-users:auth"],
         )
         user_id_str = data.get("sub")
-    except jwt.PyJWTError:
+    except jwt.ExpiredSignatureError:
+        await log.awarning("auth.token_expired")
+        raise HTTPException(status_code=401, detail="Invalid token")
+    except jwt.InvalidSignatureError:
+        await log.awarning("auth.token_invalid_signature")
+        raise HTTPException(status_code=401, detail="Invalid token")
+    except jwt.PyJWTError as exc:
+        await log.awarning("auth.token_invalid", error_type=type(exc).__name__)
         raise HTTPException(status_code=401, detail="Invalid token")
 
     if user_id_str is None:
+        await log.awarning("auth.token_missing_sub")
         raise HTTPException(status_code=401, detail="Invalid token")
 
     user = await session.get(User, uuid.UUID(user_id_str))
-    if user is None or not user.is_active:
+    if user is None:
+        await log.awarning("auth.user_not_found", user_id=user_id_str)
+        raise HTTPException(status_code=401, detail="User not found or inactive")
+    if not user.is_active:
+        await log.awarning("auth.user_inactive", user_id=user_id_str)
         raise HTTPException(status_code=401, detail="User not found or inactive")
     return user
 

--- a/tests/unit/test_auth_deps.py
+++ b/tests/unit/test_auth_deps.py
@@ -1,0 +1,288 @@
+"""
+Unit tests for get_current_user in app/api/deps.py.
+
+Approach:
+- Each test builds a minimal FastAPI app with get_current_user mounted on a
+  dummy endpoint so the full Depends() chain runs through TestClient.
+- The DB session is overridden with a lightweight AsyncMock that returns
+  pre-staged User objects (or None), keeping these tests at unit tier
+  (no testcontainers, no real Postgres).
+- structlog.testing.capture_logs() is used to assert server-side log events
+  without touching stdlib logging handlers.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
+
+from app.api.deps import SINGLE_USER_ID, get_current_user
+from app.config import Settings, get_settings
+from app.database import get_db
+from app.models.user import User
+
+# The JWT secret used across all tests that craft valid or intentionally
+# wrong-secret tokens.
+TEST_SECRET = "unit-test-jwt-secret-that-is-32-bytes-long!!"
+WRONG_SECRET = "wrong-secret-that-is-also-32-bytes-long!!!"
+
+# Audience claim that deps.py expects.
+AUDIENCE = ["fastapi-users:auth"]
+
+# A stable UUID for a fictional active user.
+ACTIVE_USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_token(
+    sub: str | None = str(ACTIVE_USER_ID),
+    secret: str = TEST_SECRET,
+    exp_delta: timedelta = timedelta(hours=1),
+    aud: list[str] = AUDIENCE,
+    include_exp: bool = True,
+) -> str:
+    """Craft a HS256 JWT with the same claim shape as make_smoke_token.py."""
+    now = datetime.now(UTC)
+    payload: dict = {"aud": aud, "iat": int(now.timestamp())}
+    if sub is not None:
+        payload["sub"] = sub
+    if include_exp:
+        payload["exp"] = int((now + exp_delta).timestamp())
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _make_settings(auth_enabled: bool = True) -> Settings:
+    return Settings(
+        database_url="postgresql+asyncpg://x:x@localhost/x",
+        jwt_secret=TEST_SECRET,
+        google_api_key="fake",
+        auth_enabled=auth_enabled,
+    )
+
+
+def _make_session_mock(returned_user: User | None) -> AsyncMock:
+    """
+    Return an AsyncMock that satisfies session.get(User, id) → returned_user.
+    Also stubs add/commit/refresh for the single-user-mode path.
+    """
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=returned_user)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+def _make_app(
+    session_mock: AsyncMock | None = None,
+    auth_enabled: bool = True,
+) -> TestClient:
+    """
+    Build a minimal FastAPI app with a single GET /me endpoint that exercises
+    get_current_user, wiring in overrides for get_db and get_settings.
+    """
+    app = FastAPI()
+    settings = _make_settings(auth_enabled=auth_enabled)
+
+    @app.get("/me")
+    async def me(user: User = __import__("fastapi").Depends(get_current_user)):
+        return {"id": str(user.id), "email": user.email}
+
+    if session_mock is not None:
+        app.dependency_overrides[get_db] = lambda: session_mock
+    app.dependency_overrides[get_settings] = lambda: settings
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. Expired token → auth.token_expired
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_user_token_expired():
+    token = _make_token(exp_delta=timedelta(seconds=-60))  # already expired
+    session = _make_session_mock(None)
+    client = _make_app(session_mock=session)
+
+    with capture_logs() as captured:
+        resp = client.get("/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 401
+    assert any(e["event"] == "auth.token_expired" for e in captured), captured
+
+
+# ---------------------------------------------------------------------------
+# 2. Wrong signature → auth.token_invalid_signature
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_user_token_invalid_signature():
+    token = _make_token(secret=WRONG_SECRET)
+    session = _make_session_mock(None)
+    client = _make_app(session_mock=session)
+
+    with capture_logs() as captured:
+        resp = client.get("/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 401
+    assert any(e["event"] == "auth.token_invalid_signature" for e in captured), captured
+
+
+# ---------------------------------------------------------------------------
+# 3. Missing sub claim → auth.token_missing_sub
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_user_token_missing_sub():
+    token = _make_token(sub=None)  # omit sub
+    session = _make_session_mock(None)
+    client = _make_app(session_mock=session)
+
+    with capture_logs() as captured:
+        resp = client.get("/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 401
+    assert any(e["event"] == "auth.token_missing_sub" for e in captured), captured
+
+
+# ---------------------------------------------------------------------------
+# 4. Valid token but user not in DB → auth.user_not_found
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_user_user_not_found():
+    unknown_id = uuid.uuid4()
+    token = _make_token(sub=str(unknown_id))
+    session = _make_session_mock(returned_user=None)  # DB returns nothing
+    client = _make_app(session_mock=session)
+
+    with capture_logs() as captured:
+        resp = client.get("/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 401
+    assert any(e["event"] == "auth.user_not_found" for e in captured), captured
+
+
+# ---------------------------------------------------------------------------
+# 5. Valid token but user.is_active=False → auth.user_inactive
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_user_inactive_user():
+    inactive = User(
+        id=ACTIVE_USER_ID,
+        email="inactive@example.com",
+        is_active=False,
+        hashed_password="",
+    )
+    token = _make_token(sub=str(ACTIVE_USER_ID))
+    session = _make_session_mock(returned_user=inactive)
+    client = _make_app(session_mock=session)
+
+    with capture_logs() as captured:
+        resp = client.get("/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 401
+    assert any(e["event"] == "auth.user_inactive" for e in captured), captured
+
+
+# ---------------------------------------------------------------------------
+# 6. Happy path — valid token, active user → 200
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_user_happy_path():
+    active = User(
+        id=ACTIVE_USER_ID,
+        email="active@example.com",
+        is_active=True,
+        hashed_password="",
+    )
+    token = _make_token(sub=str(ACTIVE_USER_ID))
+    session = _make_session_mock(returned_user=active)
+    client = _make_app(session_mock=session)
+
+    with capture_logs() as captured:
+        resp = client.get("/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(ACTIVE_USER_ID)
+    # No auth-error log events should appear on the happy path.
+    auth_errors = [e for e in captured if e.get("event", "").startswith("auth.")]
+    assert auth_errors == [], auth_errors
+
+
+# ---------------------------------------------------------------------------
+# 7. No Authorization header when auth is enabled → 401
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_user_no_token_when_auth_enabled():
+    session = _make_session_mock(None)
+    client = _make_app(session_mock=session, auth_enabled=True)
+
+    resp = client.get("/me")  # no Authorization header
+
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 8. auth_enabled=False → single-user bypass, returns SINGLE_USER_ID user
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_user_single_user_mode_bypass():
+    # Simulate: user already exists in DB (common case after first boot).
+    single_user = User(
+        id=SINGLE_USER_ID,
+        email="dev@local",
+        is_active=True,
+        is_superuser=True,
+        is_verified=True,
+        hashed_password="",
+    )
+    session = _make_session_mock(returned_user=single_user)
+    client = _make_app(session_mock=session, auth_enabled=False)
+
+    resp = client.get("/me")  # no token needed
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(SINGLE_USER_ID)
+
+
+def test_get_current_user_single_user_mode_autocreates():
+    """
+    When auth_enabled=False and the DB has no user yet, get_current_user
+    should create the SINGLE_USER_ID user and return it.
+    """
+    # First .get() returns None (no user yet); deps.py constructs the User
+    # internally, adds it, commits, and refreshes — we verify those calls.
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=None)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    # Simulate session.refresh populating the object that was added.
+    session.refresh = AsyncMock(side_effect=lambda u: None)
+
+    # After refresh the function returns the user that was session.add()-ed.
+    # We override get_current_user's return to verify the flow instead.
+    # Actually, we just need the endpoint to return 200; the user object is
+    # constructed inside deps.py so we trust the logic and verify status.
+    client = _make_app(session_mock=session, auth_enabled=False)
+
+    resp = client.get("/me")
+
+    assert resp.status_code == 200
+    session.add.assert_called_once()
+    session.commit.assert_awaited_once()


### PR DESCRIPTION
## Summary

PR 6 of the [stabilization plan](../../.claude/plans/2026-04-21-stabilize-golden-path.md). \`get_current_user\` in \`app/api/deps.py\` previously caught \`jwt.PyJWTError\` broadly and raised 401 with no log — making auth failures impossible to diagnose without reproducing the client request.

## What lands

\`get_current_user\` now emits a distinct structured \`log.awarning\` per failure mode:

- \`auth.token_expired\` — JWT \`exp\` in the past
- \`auth.token_invalid_signature\` — wrong \`JWT_SECRET\`
- \`auth.token_invalid\` — other \`PyJWTError\` (carries \`error_type\`)
- \`auth.token_missing_sub\` — token decoded but no \`sub\` claim
- \`auth.user_not_found\` — \`sub\` resolves to a nonexistent user (carries \`user_id\`)
- \`auth.user_inactive\` — user exists but \`is_active=False\` (carries \`user_id\`)

The HTTP response is unchanged — 401 with generic \"Invalid token\" or \"User not found or inactive\" — so there's no new timing/info disclosure to clients. Server-side logs become filterable by \`event\` in GCP Logs Explorer.

Level stays at **WARNING**: these are client-side auth failures, not server bugs. Error Reporting (which ingests on ERROR+) stays quiet for these.

## Tests

9 new unit tests in \`tests/unit/test_auth_deps.py\` covering:

- token_expired / invalid_signature / missing_sub / user_not_found / user_inactive (5 failure paths)
- happy_path + no_token_401 (2 boundary cases)
- single_user_mode_bypass + single_user_mode_autocreates (2 \`AUTH_ENABLED=false\` sub-paths)

Uses \`structlog.testing.capture_logs\` to assert log event emission without touching stdlib handlers.

## Verification

- \`uv run ruff check app/ tests/\` — clean.
- \`uv run pytest tests/unit/ -q\` — 147 → 156 (+9).

## Delegation note

Auth/token handling per CLAUDE.md's delegation rule — delegated to \`backend-security-coder\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)