### PR TITLE
fix(ui): bound generation-status poll; align with backend 5min stream timeout

### DIFF
--- a/app/api/applications.py
+++ b/app/api/applications.py
@@ -251,7 +251,10 @@ async def stream_generation_status(
         from app.database import get_session_factory
 
         factory = get_session_factory()
-        for _ in range(60):  # max 5 minutes
+        # Poll the DB for up to 5 minutes (60 × 5s). If you bump this, also bump
+        # GENERATION_POLL_TIMEOUT_MS in frontend/src/pages/ApplicationReview.tsx
+        # (frontend must give up AFTER the server does — currently backend + 30s).
+        for _ in range(60):
             async with factory() as s:
                 a = await s.get(Application, uuid.UUID(app_id))
                 status = a.generation_status if a else "failed"

--- a/frontend/src/pages/ApplicationReview.tsx
+++ b/frontend/src/pages/ApplicationReview.tsx
@@ -188,19 +188,37 @@ function submissionMethodLabel(method: string | null): string {
   }[method] ?? `Submitted (${method})`
 }
 
+// Backend's /api/applications/{id}/status/stream gives up at ~300s
+// (60 iterations × 5s sleep in app/api/applications.py::stream_generation_status).
+// Frontend poll timeout is backend + 30s safety margin so we don't stop before
+// the server does. If you bump one, bump the other in lockstep.
+const GENERATION_POLL_TIMEOUT_MS = 330_000
+
 export default function ApplicationReview() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const qc = useQueryClient()
   const [activeTab, setActiveTab] = useState(0)
   const [customAnswers, setCustomAnswers] = useState<Record<string, string>>({})
+  const pollStartRef = useRef<number | null>(null)
+  const [pollTimedOut, setPollTimedOut] = useState(false)
 
   const { data: app, isLoading } = useQuery({
     queryKey: ['application', id],
     queryFn: () => api.getApplication(id!),
     refetchInterval: (query) => {
       const status = query?.state?.data?.generation_status
-      return (status === 'generating' || status === 'pending') ? 3000 : false
+      const isPolling = status === 'generating' || status === 'pending'
+      if (!isPolling) {
+        pollStartRef.current = null
+        return false
+      }
+      if (pollStartRef.current === null) pollStartRef.current = Date.now()
+      if (Date.now() - pollStartRef.current > GENERATION_POLL_TIMEOUT_MS) {
+        setPollTimedOut(true)
+        return false
+      }
+      return 3000
     },
   })
 
@@ -326,9 +344,21 @@ export default function ApplicationReview() {
       )}
 
       {/* Generation status */}
-      {(isGenerating || app.generation_status === 'pending') && (
+      {(isGenerating || app.generation_status === 'pending') && !pollTimedOut && (
         <div className="mb-4 p-3 bg-blue-50 text-blue-700 text-sm rounded-md animate-pulse">
           Generating tailored documents...
+        </div>
+      )}
+      {pollTimedOut && isGenerating && (
+        <div className="mb-4 p-3 bg-amber-50 text-amber-700 text-sm rounded-md flex items-center justify-between">
+          <span>Generation is taking longer than expected. The server may still be working — refresh to check, or retry.</span>
+          <button
+            onClick={() => { setPollTimedOut(false); regen.mutate() }}
+            disabled={regen.isPending || app.generation_attempts >= 3}
+            className="text-sm font-medium underline disabled:opacity-50"
+          >
+            Retry
+          </button>
         </div>
       )}
       {approve.isSuccess && app.generation_status === 'none' && (


### PR DESCRIPTION
## Summary

Plan PR 11 — align frontend generation-status poll with the backend's stream timeout.

Current bug: \`ApplicationReview\` polls \`/api/applications/{id}\` every 3s while \`generation_status\` is \`generating\` or \`pending\` **indefinitely**. A stuck generation (agent hang, LLM timeout, missed status update) leaves the user staring at a forever-pulsing \"Generating tailored documents…\" banner with no recourse.

## Changes

- **Frontend** (\`ApplicationReview.tsx\`): track poll-start timestamp via \`useRef\`; after \`GENERATION_POLL_TIMEOUT_MS = 330_000\` (5min 30s) set \`pollTimedOut\` and return \`false\` from \`refetchInterval\`. Show an amber \"taking longer than expected\" banner with a Retry button that clears \`pollTimedOut\` and calls \`regen.mutate()\`.
- **Backend** (\`app/api/applications.py::stream_generation_status\`): comment updated to reference the frontend constant. The \`60 × 5s = 300s\` cap is unchanged; the new comment flags that frontend must give up **after** the backend.

## Why 330s

Backend SSE stream returns \`{\"generation_status\": \"timeout\"}\` at ~300s. Frontend needs to keep polling long enough to catch that terminal state + a safety margin for network/clock drift. 30s is the margin. Both constants now carry adjacent comments referencing each other so future tuning stays in sync.

## Test plan

- [x] \`uv run pytest tests/unit/\` — 182 passed.
- [x] \`cd frontend && npm run test -- --run\` — 28 passed.
- [x] Manual: set \`GENERATION_POLL_TIMEOUT_MS = 5_000\` locally and simulate a stuck generation → banner appears after 5s with a Retry button that triggers regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)