### PR TITLE
chore(generation): delete _generate_direct fallback; require LangGraph checkpointer

### DIFF
--- a/app/api/internal_cron.py
+++ b/app/api/internal_cron.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Awaitable, Callable
 
 import structlog
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 
 from app.agents.llm_safe import BudgetExhausted
 from app.config import Settings, get_settings
@@ -77,8 +77,17 @@ async def cron_sync():
 
 
 @router.post("/generation-queue", dependencies=[Depends(verify_secret)])
-async def cron_generation_queue():
-    return await _run_cron("generation_queue", run_generation_queue)
+async def cron_generation_queue(request: Request):
+    # generate_materials requires a LangGraph checkpointer; resolve it from the
+    # app state (initialized in the FastAPI lifespan) and 503 loudly if missing.
+    checkpointer = getattr(request.app.state, "checkpointer", None)
+    if checkpointer is None:
+        raise HTTPException(status_code=503, detail="checkpointer not initialized")
+
+    async def task() -> dict:
+        return await run_generation_queue(checkpointer)
+
+    return await _run_cron("generation_queue", task)
 
 
 @router.post("/maintenance", dependencies=[Depends(verify_secret)])

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -53,8 +53,13 @@ async def run_job_sync() -> dict:
     }
 
 
-async def run_generation_queue() -> dict:
-    """Generate materials for applications stuck in pending status. Returns a summary dict."""
+async def run_generation_queue(checkpointer) -> dict:
+    """Generate materials for applications stuck in pending status. Returns a summary dict.
+
+    ``checkpointer`` must be a LangGraph checkpointer (typically
+    ``request.app.state.checkpointer`` initialized in the FastAPI lifespan).
+    ``generate_materials`` raises ``RuntimeError`` if it is None.
+    """
     from app.database import get_session_factory
     from app.models.application import Application
     from app.services.application_service import generate_materials
@@ -79,7 +84,7 @@ async def run_generation_queue() -> dict:
     for app_id in app_ids:
         try:
             async with factory() as session:
-                await generate_materials(app_id, session)
+                await generate_materials(app_id, session, checkpointer=checkpointer)
                 succeeded += 1
         except Exception as exc:
             failed += 1

--- a/app/services/application_service.py
+++ b/app/services/application_service.py
@@ -13,7 +13,6 @@ import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from app.agents.llm_safe import safe_ainvoke
 from app.models.application import Application, GeneratedDocument
 from app.models.job import Job
 from app.models.user_profile import UserProfile
@@ -66,7 +65,15 @@ async def generate_materials(
     """
     Background task: generate tailored resume, cover letter, custom answers.
     Updates generation_status on the Application row.
+
+    A LangGraph checkpointer is required — there is no direct-generation
+    fallback. Callers should resolve the checkpointer from
+    ``request.app.state.checkpointer`` (initialized in the FastAPI lifespan).
     """
+    if checkpointer is None:
+        raise RuntimeError(
+            "checkpointer required — generate_materials cannot run without a LangGraph checkpointer"
+        )
     t0 = time.perf_counter()
     await log.ainfo("generation.started", application_id=str(application_id))
     app = await session.get(Application, application_id)
@@ -98,51 +105,47 @@ async def generate_materials(
         experiences = await get_work_experiences(profile.id, session)
         profile_text = format_profile_text(profile, skills, experiences)
 
-        # Use generation agent via LangGraph if checkpointer available
-        if checkpointer is not None:
-            from app.agents.generation_agent import build_graph
+        # Use generation agent via LangGraph
+        from app.agents.generation_agent import build_graph
 
-            graph = build_graph(checkpointer)
-            thread_id = f"gen-{application_id}"
-            config = {"configurable": {"thread_id": thread_id}}
+        graph = build_graph(checkpointer)
+        thread_id = f"gen-{application_id}"
+        config = {"configurable": {"thread_id": thread_id}}
 
-            custom_questions: list = []
-            if job.ats_type == "greenhouse" and job.supports_api_apply and job.apply_url:
-                from app.sources.greenhouse import (
-                    GreenhouseUnavailable,
-                    get_job_questions_by_url,
+        custom_questions: list = []
+        if job.ats_type == "greenhouse" and job.supports_api_apply and job.apply_url:
+            from app.sources.greenhouse import (
+                GreenhouseUnavailable,
+                get_job_questions_by_url,
+            )
+
+            try:
+                custom_questions = await get_job_questions_by_url(job.apply_url)
+            except GreenhouseUnavailable as exc:
+                await log.awarning(
+                    "generation.greenhouse_questions_unavailable",
+                    application_id=str(application_id),
+                    apply_url=job.apply_url,
+                    error=str(exc),
                 )
+                custom_questions = []
 
-                try:
-                    custom_questions = await get_job_questions_by_url(job.apply_url)
-                except GreenhouseUnavailable as exc:
-                    await log.awarning(
-                        "generation.greenhouse_questions_unavailable",
-                        application_id=str(application_id),
-                        apply_url=job.apply_url,
-                        error=str(exc),
-                    )
-                    custom_questions = []
+        initial_state = {
+            "application_id": str(application_id),
+            "profile_text": profile_text,
+            "job_title": job.title,
+            "job_company": job.company_name,
+            "job_description": job.description_md or "",
+            "base_resume_md": profile.base_resume_md or "",
+            "custom_questions": custom_questions,
+            "documents": [],
+            "generation_status": "pending",
+            "user_decision": {},
+        }
 
-            initial_state = {
-                "application_id": str(application_id),
-                "profile_text": profile_text,
-                "job_title": job.title,
-                "job_company": job.company_name,
-                "job_description": job.description_md or "",
-                "base_resume_md": profile.base_resume_md or "",
-                "custom_questions": custom_questions,
-                "documents": [],
-                "generation_status": "pending",
-                "user_decision": {},
-            }
-
-            # Run until interrupt (before review node)
-            await graph.ainvoke(initial_state, config)
-            # Graph is now paused at review interrupt — docs saved by save_documents_node
-        else:
-            # Fallback: direct generation without checkpointer (no interrupt/resume)
-            await _generate_direct(app, job, profile, profile_text, session)
+        # Run until interrupt (before review node)
+        await graph.ainvoke(initial_state, config)
+        # Graph is now paused at review interrupt — docs saved by save_documents_node
 
     except Exception as exc:
         await log.aexception(
@@ -168,74 +171,3 @@ async def generate_materials(
         status=app.generation_status,
         duration_ms=int((time.perf_counter() - t0) * 1000),
     )
-
-
-async def _generate_direct(
-    app: Application,
-    job: Job,
-    profile: UserProfile,
-    profile_text: str,
-    session: AsyncSession,
-) -> None:
-    """
-    Direct generation path (no LangGraph checkpointer).
-    Used when checkpointer is not available (e.g. unit tests).
-    """
-    from langchain_core.messages import HumanMessage
-    from langchain_google_genai import ChatGoogleGenerativeAI
-
-    from app.agents.generation_agent import (
-        COVER_LETTER_PROMPT,
-        RESUME_PROMPT,
-        _extract_text,
-        truncate_description,
-    )
-    from app.config import get_settings
-
-    settings = get_settings()
-    if settings.environment == "test":
-        from app.agents.test_llm import get_fake_llm
-
-        llm = get_fake_llm("generation")
-    else:
-        llm = ChatGoogleGenerativeAI(
-            model=settings.llm_generation_model,
-            google_api_key=settings.google_api_key.get_secret_value(),
-        )
-    model_name = settings.llm_generation_model
-
-    documents = []
-
-    # Resume
-    resume_prompt = RESUME_PROMPT.format(
-        base_resume_md=(profile.base_resume_md or "")[:6000],
-        title=job.title,
-        company=job.company_name,
-        description=truncate_description(job.description_md or ""),
-    )
-    resume_result = await safe_ainvoke(llm, [HumanMessage(content=resume_prompt)])
-    documents.append(
-        {
-            "doc_type": "tailored_resume",
-            "content_md": _extract_text(resume_result),
-            "generation_model": model_name,
-        }
-    )
-
-    # Cover letter
-    cl_prompt = COVER_LETTER_PROMPT.format(
-        profile_text=profile_text[:3000],
-        title=job.title,
-        company=job.company_name,
-        description=truncate_description(job.description_md or ""),
-    )
-    cl_result = await safe_ainvoke(llm, [HumanMessage(content=cl_prompt)])
-    documents.append(
-        {
-            "doc_type": "cover_letter",
-            "content_md": _extract_text(cl_result),
-            "generation_model": model_name,
-        }
-    )
-
-    await save_documents(str(app.id), documents, session)

--- a/tests/integration/test_application_service.py
+++ b/tests/integration/test_application_service.py
@@ -1,13 +1,15 @@
 """
 Integration tests for generate_materials() with a mocked LLM.
 
-Uses FakeListChatModel to avoid real API calls while exercising
-the full DB read/write path through the generation pipeline.
+Uses FakeListChatModel (injected via ENVIRONMENT=test in get_llm()) to avoid
+real API calls while exercising the full DB read/write path through the
+generation pipeline.
 """
 
 import uuid
 
 import pytest
+from langgraph.checkpoint.memory import MemorySaver
 from sqlmodel import select
 
 from app.models.application import Application, GeneratedDocument
@@ -106,15 +108,16 @@ async def test_save_documents_upserts_on_retry(db_session):
 
 
 @pytest.mark.asyncio
-async def test_generate_materials_direct_path_with_fake_llm(db_session):
+async def test_generate_materials_graph_path_with_fake_llm(db_session):
     """
-    generate_materials() without checkpointer falls back to _generate_direct().
-    Patch get_llm / ChatAnthropic to use FakeListChatModel.
+    generate_materials() exercises the LangGraph path (the only path since
+    PR 9a removed _generate_direct). ENVIRONMENT=test activates the
+    FakeListChatModel shim in get_llm(), so no real API calls are made.
     """
     _, profile, _, application = await _seed_db(db_session)
 
-    # ENVIRONMENT=test activates the FakeListChatModel shim in get_llm()
-    await generate_materials(application.id, db_session, checkpointer=None)
+    checkpointer = MemorySaver()
+    await generate_materials(application.id, db_session, checkpointer=checkpointer)
 
     await db_session.refresh(application)
     assert application.generation_status == "ready"
@@ -138,7 +141,8 @@ async def test_generate_materials_max_attempts_guard(db_session):
     await db_session.commit()
 
     # Should return without setting status to "ready"
-    await generate_materials(application.id, db_session, checkpointer=None)
+    checkpointer = MemorySaver()
+    await generate_materials(application.id, db_session, checkpointer=checkpointer)
 
     await db_session.refresh(application)
     # Status unchanged (still "none" — model default since generation never started)

--- a/tests/integration/test_application_service_lifecycle.py
+++ b/tests/integration/test_application_service_lifecycle.py
@@ -92,7 +92,8 @@ async def test_save_documents_upserts_on_retry(db_session):
 @pytest.mark.asyncio
 async def test_generate_materials_not_found_no_error(db_session):
     """generate_materials() with a nonexistent UUID returns silently."""
-    await generate_materials(uuid.uuid4(), db_session, checkpointer=None)
+    checkpointer = MemorySaver()
+    await generate_materials(uuid.uuid4(), db_session, checkpointer=checkpointer)
     # No exception = pass
 
 
@@ -104,7 +105,8 @@ async def test_generate_materials_max_attempts_skipped(db_session):
     db_session.add(app_row)
     await db_session.commit()
 
-    await generate_materials(app_row.id, db_session, checkpointer=None)
+    checkpointer = MemorySaver()
+    await generate_materials(app_row.id, db_session, checkpointer=checkpointer)
 
     await db_session.refresh(app_row)
     # status should still be the default "none" (not "generating" or "ready")
@@ -113,35 +115,12 @@ async def test_generate_materials_max_attempts_skipped(db_session):
 
 
 @pytest.mark.asyncio
-async def test_generate_materials_sets_status_to_ready(db_session):
-    """
-    generate_materials() with checkpointer=None uses _generate_direct.
-    Since ENVIRONMENT=test, get_fake_llm("generation") is used — no real LLM call.
-    After completion: generation_status="ready" and GeneratedDocument rows exist.
-    """
-    app_row, _, _ = await _seed_application(db_session)
-
-    await generate_materials(app_row.id, db_session, checkpointer=None)
-
-    await db_session.refresh(app_row)
-    assert app_row.generation_status == "ready"
-
-    result = await db_session.execute(
-        select(GeneratedDocument).where(GeneratedDocument.application_id == app_row.id)
-    )
-    docs = result.scalars().all()
-    assert len(docs) >= 2  # at minimum: tailored_resume + cover_letter
-    doc_types = {d.doc_type for d in docs}
-    assert "tailored_resume" in doc_types
-    assert "cover_letter" in doc_types
-
-
-@pytest.mark.asyncio
 async def test_generate_materials_graph_path_sets_ready(db_session):
     """
     generate_materials() with a MemorySaver checkpointer exercises the LangGraph
-    code path (the production route). Since ENVIRONMENT=test, the fake LLM is used.
-    Verifies that the graph path correctly saves documents and sets status to "ready".
+    code path (the only route since PR 9a removed _generate_direct). Since
+    ENVIRONMENT=test, the fake LLM is used. Verifies that the graph path
+    correctly saves documents and sets status to "ready".
     """
     app_row, _, _ = await _seed_application(db_session)
 

--- a/tests/integration/test_cron_endpoints.py
+++ b/tests/integration/test_cron_endpoints.py
@@ -9,6 +9,7 @@ These tests verify:
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from langgraph.checkpoint.memory import MemorySaver
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
 
@@ -24,8 +25,24 @@ async def client(patch_settings, asyncpg_url):
 
     from app.main import app
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        yield ac
+    # ASGITransport bypasses the lifespan, so app.state.checkpointer is never
+    # initialized. The /internal/cron/generation-queue endpoint 503s without
+    # one; seed a MemorySaver to exercise the ok path in tests. Clean up after
+    # so subsequent tests (e.g. e2e/test_chat_flow) see a fresh app singleton.
+    had_checkpointer = hasattr(app.state, "checkpointer")
+    prior_checkpointer = getattr(app.state, "checkpointer", None)
+    app.state.checkpointer = MemorySaver()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+    finally:
+        if had_checkpointer:
+            app.state.checkpointer = prior_checkpointer
+        else:
+            try:
+                del app.state.checkpointer
+            except AttributeError:
+                pass
 
 
 CRON_SECRET = "dev-cron-secret"  # matches default SecretStr("dev-cron-secret") in config.py

--- a/tests/integration/test_generation_interrupt_resume.py
+++ b/tests/integration/test_generation_interrupt_resume.py
@@ -7,9 +7,10 @@ Tests 1-3 are xfail: generate_materials() currently transitions straight to
 "awaiting_review".  The correct lifecycle is:
   pending -> generating -> awaiting_review (interrupt) -> ready (after resume)
 
-Test 4 is NOT xfail: it asserts the existing _generate_direct fallback
-(checkpointer=None) and acts as a regression gate for the follow-up PR that
-removes that path.
+Test 4 is NOT xfail: it asserts that generate_materials() raises
+RuntimeError when called without a checkpointer.  The _generate_direct
+fallback was removed in PR 9a of the stabilization plan (this file's
+companion change) so the LangGraph path is now mandatory.
 """
 
 import uuid
@@ -281,40 +282,45 @@ async def test_generation_regenerate_loops_back_to_load_context(db_session):
 
 
 # ---------------------------------------------------------------------------
-# Test 4 -- NOT xfail: checkpointer=None falls through to _generate_direct
+# Test 4 -- NOT xfail: checkpointer=None raises RuntimeError
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_generation_without_checkpointer_falls_through_to_direct(db_session):
+async def test_generation_without_checkpointer_raises(db_session):
     """
-    When checkpointer=None, generate_materials() skips the LangGraph path and
-    calls _generate_direct(), which completes in a single pass with no interrupt.
+    generate_materials() requires a LangGraph checkpointer. The silent
+    _generate_direct fallback was removed in PR 9a of the stabilization
+    plan, so calling with checkpointer=None now raises RuntimeError
+    before any status mutation happens.
 
-    Expected outcome (current behavior):
-    - generation_status = "ready"
-    - At least two GeneratedDocument rows (tailored_resume + cover_letter)
-
-    This test is a REGRESSION GATE for the PR 9 refactor that will delete
-    _generate_direct.  If that PR removes the fallback entirely it must also
-    update or delete this test; if it replaces the fallback with a graph-based
-    path it must ensure the same assertions still hold.
+    Expected outcome:
+    - RuntimeError raised with message matching "checkpointer required"
+    - generation_status remains at its seeded default ("pending" for a
+      freshly-created Application row; the early-exit guard runs before
+      the "generating" transition)
     """
     app_row, _, _ = await _seed_application(db_session)
+    # Seed an explicit "pending" value so we can assert it is untouched.
+    app_row.generation_status = "pending"
+    db_session.add(app_row)
+    await db_session.commit()
 
-    await generate_materials(app_row.id, db_session, checkpointer=None)
+    with pytest.raises(RuntimeError, match="checkpointer required"):
+        await generate_materials(app_row.id, db_session, checkpointer=None)
 
     await db_session.refresh(app_row)
-    assert app_row.generation_status == "ready", (
-        f"Expected 'ready' from _generate_direct path, got '{app_row.generation_status}'"
+    assert app_row.generation_status == "pending", (
+        f"Status should remain 'pending' when the checkpointer guard fires, "
+        f"got '{app_row.generation_status}'"
     )
-    assert app_row.generation_attempts == 1
+    assert app_row.generation_attempts == 0, (
+        "generation_attempts should not be incremented before the guard"
+    )
 
+    # No GeneratedDocument rows should have been written
     result = await db_session.execute(
         select(GeneratedDocument).where(GeneratedDocument.application_id == app_row.id)
     )
     docs = result.scalars().all()
-    assert len(docs) >= 2, f"Expected at least 2 docs from direct path, got {len(docs)}"
-    doc_types = {d.doc_type for d in docs}
-    assert "tailored_resume" in doc_types
-    assert "cover_letter" in doc_types
+    assert docs == [], f"Expected no documents, got {len(docs)}"

--- a/tests/unit/test_internal_cron.py
+++ b/tests/unit/test_internal_cron.py
@@ -11,6 +11,7 @@ from app.config import Settings
 def make_app(
     secret: str = "test-secret",
     raise_server_exceptions: bool = True,
+    checkpointer: object | None = object(),
 ):
     from app.api.internal_cron import get_cron_settings, router
 
@@ -23,6 +24,11 @@ def make_app(
         google_api_key="fake",
     )
     test_app.dependency_overrides[get_cron_settings] = lambda: override_settings
+    # Emulate lifespan: the /generation-queue endpoint resolves the checkpointer
+    # from app.state.checkpointer and 503s if absent. Tests pass a sentinel
+    # object by default; pass checkpointer=None to exercise the guard.
+    if checkpointer is not None:
+        test_app.state.checkpointer = checkpointer
     return TestClient(test_app, raise_server_exceptions=raise_server_exceptions)
 
 
@@ -117,6 +123,24 @@ def test_generation_queue_budget_exhausted_returns_structured_response():
     body = resp.json()
     assert body["status"] == "budget_exhausted"
     assert body["resumes_at"] == resumes_at.isoformat()
+
+
+def test_generation_queue_missing_checkpointer_returns_503():
+    # If the FastAPI lifespan never set app.state.checkpointer, the cron endpoint
+    # 503s loudly instead of calling run_generation_queue (which would hit the
+    # RuntimeError in generate_materials).
+    client = make_app(secret="real-secret", checkpointer=None)
+    with patch(
+        "app.api.internal_cron.run_generation_queue",
+        new=AsyncMock(return_value={"attempted": 0, "succeeded": 0, "failed": 0}),
+    ) as mock:
+        resp = client.post(
+            "/internal/cron/generation-queue",
+            headers={"X-Cron-Secret": "real-secret"},
+        )
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "checkpointer not initialized"
+    mock.assert_not_called()
 
 
 def test_sync_unexpected_exception_returns_500():


### PR DESCRIPTION
## Summary

PR 9a of the [stabilization plan](../../.claude/plans/2026-04-21-stabilize-golden-path.md). Removes the silent-success \`_generate_direct\` fallback from \`generate_materials\` and plumbs the LangGraph \`AsyncPostgresSaver\` checkpointer through the cron path. This unblocks PR 9b — the proper \`awaiting_review\` interrupt/resume state machine — which couldn't be written while the fallback was swallowing the graph path.

## What changes

- **\`app/services/application_service.py\`**: \`generate_materials\` now raises \`RuntimeError(\"checkpointer required — …\")\` at the top when \`checkpointer is None\`. Deleted \`_generate_direct\` (~70 lines) entirely. The \`if checkpointer is not None\` branch is now unconditional.
- **\`app/scheduler/tasks.py::run_generation_queue\`**: signature now takes a \`checkpointer\` arg and passes it through to \`generate_materials\`.
- **\`app/api/internal_cron.py::cron_generation_queue\`**: resolves \`checkpointer\` from \`request.app.state\` (initialized in \`app/main.py::lifespan\`) and returns **503** if absent. Uses an inline closure so \`_run_cron\`'s \`(name, task)\` signature stays untouched. \`/sync\` and \`/maintenance\` endpoints unchanged.

## Tests

- \`tests/integration/test_generation_interrupt_resume.py\` — test 4 flipped from \"asserts direct fallback\" → \"asserts RuntimeError when checkpointer missing.\" (Regression gate from PR #23 still serves its purpose.)
- \`tests/unit/test_internal_cron.py\` — new \`test_generation_queue_missing_checkpointer_returns_503\`; existing cron tests seed \`app.state.checkpointer = MemorySaver()\`.
- \`tests/integration/test_cron_endpoints.py\` — fixture seeds + tears down \`app.state.checkpointer\` (avoids leaking into e2e tests that rely on it being absent).
- 5 existing integration tests that passed \`checkpointer=None\` were updated to pass \`MemorySaver\` — a minor scope bump required to keep the suite green. One duplicate test (\`test_generate_materials_sets_status_to_ready\`) deleted since it was superseded.

## Verification

- \`uv run pytest tests/unit/ tests/integration/ tests/e2e/\` → **264 passed, 3 xfailed** (PR #23 xfails unchanged — they flip green in PR 9b).
- \`grep -rn \"_generate_direct\" app/\` → zero hits.
- \`uv run ruff check app/ tests/\` → clean.

## Follow-up

PR 9b: introduce \`generation_status = \"awaiting_review\"\`, add a resume endpoint that calls \`graph.ainvoke(Command(resume=...), config)\`, and update frontend + smoke to handle the new state. The 3 xfails from PR #23 will flip to green.

## Delegation note

Multi-file prod refactor — delegated to \`python-pro\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)