### PR TITLE
docs(portfolio): generation interrupt/resume contract + observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,14 @@ Matching agent uses `asyncio.Semaphore` + 1.5s sleep + 10s/30s exponential backo
 
 No in-process scheduler. `app/scheduler/tasks.py` is invoked via `POST /internal/cron/{sync,generation-queue,maintenance}` with `X-Cron-Secret`, triggered by `.github/workflows/cron.yml`.
 
+### Generation interrupt/resume contract
+
+`generate_materials()` (`app/services/application_service.py`) drives the generation graph until it pauses at the `review` interrupt, then leaves `Application.generation_status = "awaiting_review"` — **not** `"ready"`. `POST /api/applications/{id}/resume` with `{"decision": "approve"|"regenerate"}` calls `graph.ainvoke(Command(resume=...), config)` to unpark the graph; approve → `ready`, regenerate → another `awaiting_review`. Valid `generation_status` values: `none · pending · generating · awaiting_review · ready · failed`. Single-writer rule: `resume_generation` / `generate_materials` own the status write; `finalize_node` returns state only. The status transition at `/resume` is an atomic conditional UPDATE (`WHERE generation_status='awaiting_review'`) so two concurrent POSTs cannot both dispatch to the same LangGraph thread_id.
+
+### Observability
+
+No Sentry / no external SaaS. Errors flow to GCP Cloud Error Reporting via structlog: `app/main.py::_add_cloud_run_severity` injects `severity=ERROR` + `@type: …ReportedErrorEvent`, and `structlog.processors.format_exc_info` turns `exc_info=True` / `log.aexception` into a readable traceback. `gcloud services enable clouderrorreporting.googleapis.com` is a one-time op per project.
+
 ## Hard app-level limits (not DB constraints)
 
 50 work experiences/profile · 500 matched applications/user · 5 MB resume · 14-day job staleness · 7-day search auto-pause.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Resume upload + onboarding chat
 
 - **Conversational onboarding** — chat agent asks about target roles, location, preferences; updates your profile via tool calls; persists conversation state across browser sessions (LangGraph + AsyncPostgresSaver)
 - **Parallel job scoring** — LangGraph `Send` fan-out scores multiple jobs concurrently; results collected via state reducer
-- **Human-in-the-loop generation** — generation graph pauses after producing documents; resumes when you approve or edit in the UI
+- **Human-in-the-loop generation** — generation graph pauses at an `awaiting_review` interrupt after producing documents; `POST /api/applications/{id}/resume` with `approve` or `regenerate` unparks the graph (status lifecycle: `pending → generating → awaiting_review → ready`)
 - **Externalised scheduler** — no in-process scheduler; GitHub Actions cron hits `/internal/cron/*` endpoints (compatible with Cloud Run scale-to-zero)
 - **Budget safety** — Gemini `ResourceExhausted` errors are caught, stored in `llm_status`, surfaced as an amber banner; job collection keeps running
 - **Rate limiting** — Postgres-backed sliding window limits on profile edits, resume uploads, and manual syncs; per-user daily quotas
+- **Observability** — errors flow to GCP Cloud Error Reporting via structlog (`severity=ERROR` + `@type: …ReportedErrorEvent` markers); no third-party SaaS
 
 ## Tech stack
 


### PR DESCRIPTION
## Summary
- CLAUDE.md gains a **Generation interrupt/resume contract** subsection covering the `awaiting_review` status, the `POST /api/applications/{id}/resume` decision API, the full lifecycle (`none → pending → generating → awaiting_review → ready`), the single-writer rule (`resume_generation` / `generate_materials` own the status write; `finalize_node` returns state only), and the atomic conditional UPDATE that prevents two concurrent POSTs from racing on the same LangGraph `thread_id`.
- CLAUDE.md gains a short **Observability** subsection naming GCP Cloud Error Reporting as the error sink, the two structlog hooks (`_add_cloud_run_severity` + `format_exc_info`), and the one-time `gcloud services enable clouderrorreporting.googleapis.com` step.
- README.md: Human-in-the-loop feature bullet now names the contract + lifecycle; a new Observability bullet says no SaaS, errors flow through Cloud Error Reporting.

## Why
PR #25 shipped the new interrupt/resume contract — the most distinctive architectural feature of this repo — but it was not yet surfaced in the portfolio-facing docs. CLAUDE.md exists specifically to capture non-obvious cross-file behaviors; the single-writer rule and the atomic status transition qualify. Observability likewise moved from Sentry to Cloud Error Reporting in PR #13 but was never named in the README.

This is plan PR 13 of the stabilization plan — the portfolio-legibility review pass.

## Test plan
- [x] Diff reviewed locally — docs-only, no code, no tests affected
- [x] CI will run tests/lint/frontend build anyway — expected green

🤖 Generated with [Claude Code](https://claude.com/claude-code)