### PR TITLE
ci+smoke: surface gcloud probe errors; bump cron-sync timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,11 +204,15 @@ jobs:
           done
           for entry in "${OPTIONAL[@]}"; do
             secret_name="${entry#*=}"
-            if gcloud secrets describe "$secret_name" --quiet >/dev/null 2>&1; then
+            # Capture stderr so we can distinguish "NotFound" (secret absent)
+            # from "PermissionDenied" (IAM miss on the CI service account).
+            # The old silent-skip hid both behind the same message.
+            if err=$(gcloud secrets describe "$secret_name" --quiet 2>&1 >/dev/null); then
               PAIRS+=("${entry}:latest")
               echo "included optional secret: $secret_name"
             else
-              echo "skipped optional secret (not in Secret Manager): $secret_name"
+              echo "skipped optional secret: $secret_name"
+              echo "  gcloud stderr: ${err:0:500}"
             fi
           done
           joined=$(IFS=','; echo "${PAIRS[*]}")

--- a/scripts/smoke/golden_path.py
+++ b/scripts/smoke/golden_path.py
@@ -49,8 +49,9 @@ Step mapping (matches stabilisation plan):
                                            → endpoint exists, token accepted (XFAIL — PR 7)
     Step 10 Cleanup: reset profile full_name to 'Smoke Test' (idempotent teardown)
 
-Note on Step 6: job sync calls external APIs (Adzuna, Remotive, etc.) and may take 10–30 s in
-production.  The script uses a 90 s timeout for that step only.
+Note on Step 6: job sync calls external APIs (Adzuna, Remotive, etc.) and may take 60–180 s in
+production (observed 2026-04-22: server completed in ~150 s while client timed out at 90 s).
+The script uses a 240 s timeout for that step only.
 
 Note on Steps 8a–8d: all four sub-steps are marked XFAIL until PR 8/9 land.  Individual
 sub-step failures are diagnosable from the JSON details in the output.
@@ -74,7 +75,7 @@ import httpx
 # ---------------------------------------------------------------------------
 
 DEFAULT_BASE_URL = "https://api-<revision>-uc.a.run.app"  # placeholder; override via env
-SYNC_TIMEOUT_S = 90
+SYNC_TIMEOUT_S = 240
 CHAT_TIMEOUT_S = 60
 DEFAULT_TIMEOUT_S = 20
 GENERATION_POLL_INTERVAL_S = 3


### PR DESCRIPTION
## Summary
- **CI optional-secrets probe** now captures `gcloud` stderr on failure and prints the first 500 chars, so a PermissionDenied (IAM miss on the CI service account) is visibly distinct from NotFound (secret actually absent). Old log line "skipped optional secret (not in Secret Manager)" was misleading when the secret existed but the SA couldn't describe it.
- **Smoke `SYNC_TIMEOUT_S`** bumped 90 → 240 s. Real cron.sync on prod completed in ~150 s (Cloud Run logs show 200 OK at 07:38:56 for a request the client abandoned at 07:37:57). Docstring updated to reflect observed latency.

## Why
First real smoke-prod run after OAuth secrets were provisioned surfaced both gaps. User reported `gcloud secrets list` shows `google-oauth-client-id` and `google-oauth-client-secret` do exist in project `job-application-agent-493810`, but the CI probe still skips them — almost certainly because the CI service account (used via Workload Identity Federation) lacks `secretmanager.secrets.get` on those specific secrets. This PR makes that diagnosis visible in the deploy log instead of silent.

## Test plan
- [x] Diff reviewed locally — ci.yml is a bash one-liner; smoke is a constant change
- [ ] After merge, next main CI's deploy step will log the real gcloud error on OAuth secrets — user can grant `roles/secretmanager.viewer` (or add the SA to a binding on each secret) based on what's shown
- [ ] After that, smoke step 6 should clear (server reliably completes in <240 s)

## Follow-up not in this PR
XFAIL markers in `scripts/smoke/golden_path.py` for steps 8a-d (interrupt/resume) and step 9 (X-Smoke-DryRun) are now stale — PR #25 and PR #20 shipped the underlying features. Flipping those to real assertions is a ~200-line rewrite and belongs in its own PR after prod path is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)