### PR TITLE
PR 6/6: docs rewrite + drop dead 'approved' status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Job Application Agent
 
-AI-powered job search automation: monitors job boards, scores matches against your profile, and pre-generates tailored resume and cover letter before you even open the listing.
+AI-powered job search assistant: ingests Greenhouse company boards, scores each role against your profile, and generates a tailored cover letter on demand.
 
 **Live demo:** https://api-2twfzafrta-uc.a.run.app
 
@@ -9,25 +9,23 @@ AI-powered job search automation: monitors job boards, scores matches against yo
 ```
 Resume upload + onboarding chat
         ↓
-  Adzuna job sync  ──→  ATS detection (Greenhouse / Lever / Ashby)
+  Greenhouse public board sync (target_company_slugs)
         ↓
-  Matching agent scores each job against your profile  (Gemini Flash)
+  Matching agent scores each job (Gemini Flash, parallel Send fan-out)
         ↓
-  Generation agent produces tailored resume + cover letter  (Gemini Pro)
-  (runs in background — documents ready when you open the match card)
+  Visitor reviews matches → clicks "Generate cover letter" (Gemini Pro, ~15s)
         ↓
-  Review + edit inline → Approve → Submit
-  (Greenhouse: API submit · Others: open apply URL)
+  "Open application" → Greenhouse form → "Mark as applied"
 ```
 
 ## Key features
 
-- **Conversational onboarding** — chat agent asks about target roles, location, preferences; updates your profile via tool calls; persists conversation state across browser sessions (LangGraph + AsyncPostgresSaver)
+- **Conversational onboarding** — chat agent asks about target roles, location, preferences; updates your profile via tool calls; persists conversation state across browser sessions (LangGraph + AsyncPostgresSaver, onboarding only)
 - **Parallel job scoring** — LangGraph `Send` fan-out scores multiple jobs concurrently; results collected via state reducer
-- **Human-in-the-loop generation** — generation graph pauses at an `awaiting_review` interrupt after producing documents; `POST /api/applications/{id}/resume` with `approve` or `regenerate` unparks the graph (status lifecycle: `pending → generating → awaiting_review → ready`)
+- **Synchronous cover-letter generation** — `POST /api/applications/{id}/cover-letter` runs the linear graph in-request; `none → generating → ready/failed`
 - **Externalised scheduler** — no in-process scheduler; GitHub Actions cron hits `/internal/cron/*` endpoints (compatible with Cloud Run scale-to-zero)
 - **Budget safety** — Gemini `ResourceExhausted` errors are caught, stored in `llm_status`, surfaced as an amber banner; job collection keeps running
-- **Rate limiting** — Postgres-backed sliding window limits on profile edits, resume uploads, and manual syncs; per-user daily quotas
+- **Rate limiting** — Postgres-backed sliding-window limits on profile edits, resume uploads, and manual syncs; per-user daily quotas (production only)
 - **Observability** — errors flow to GCP Cloud Error Reporting via structlog (`severity=ERROR` + `@type: …ReportedErrorEvent` markers); no third-party SaaS
 
 ## Tech stack
@@ -56,7 +54,7 @@ cd frontend && npm install && npm run dev
 # → http://localhost:5173
 ```
 
-No login required locally (`AUTH_ENABLED=false`).
+Google OAuth is required: set `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` (see `app/config.py::Settings`).
 
 ## Dev commands
 
@@ -78,7 +76,7 @@ app/
   api/         FastAPI routers — profile, jobs, applications, chat, cron, auth, status
   models/      SQLModel table definitions
   services/    Business logic (job sync, matching, generation, rate limiting)
-  sources/     Job source adapters (Adzuna, JSearch) + ATS detection + resume parser
+  sources/     Job source adapters (Greenhouse Board) + resume parser
   scheduler/   Async task functions (called by cron endpoints)
 frontend/
   src/
@@ -92,7 +90,7 @@ tests/
   smoke/       Live HTTP smoke tests (requires running server)
 .github/
   workflows/
-    ci.yml     test → frontend → e2e-browser → deploy (main only)
+    ci.yml     test → frontend → e2e-browser → migrate → deploy (main only)
     cron.yml   GitHub Actions cron hitting /internal/cron/* endpoints
 ```
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -22,13 +22,13 @@ gcloud artifacts repositories create app --repository-format=docker --location=u
 ### 3a. Required
 
 ```bash
-printf "%s" "GEMINI_KEY"          | gcloud secrets create google-api-key --data-file=-         # https://aistudio.google.com/apikey
-printf "%s" "ADZUNA_APP_ID"       | gcloud secrets create adzuna-app-id --data-file=-
-printf "%s" "ADZUNA_API_KEY"      | gcloud secrets create adzuna-api-key --data-file=-
+printf "%s" "GEMINI_KEY"                    | gcloud secrets create google-api-key --data-file=-      # https://aistudio.google.com/apikey
 printf "%s" "postgresql+asyncpg://..."      | gcloud secrets create database-url --data-file=-
 printf "%s" "$(openssl rand -hex 32)"       | gcloud secrets create cron-shared-secret --data-file=-
 printf "%s" "$(openssl rand -hex 32)"       | gcloud secrets create jwt-secret --data-file=-
 ```
+
+Google OAuth credentials are required in production; see §3b.
 
 The `cron-shared-secret` value also goes into GHA as `CRON_SHARED_SECRET` (§4):
 
@@ -36,11 +36,9 @@ The `cron-shared-secret` value also goes into GHA as `CRON_SHARED_SECRET` (§4):
 gcloud secrets versions access latest --secret=cron-shared-secret
 ```
 
-### 3b. Optional
+### 3b. Google OAuth (required)
 
-Deploy probes these with `gcloud secrets describe` and includes only what exists.
-
-**Google OAuth** — required for real Google sign-in; without it, `AUTH_ENABLED=false` (single-user mode).
+Required for sign-in (single-user fallback was removed). Deploy probes these with `gcloud secrets describe` and fails closed if absent.
 
 1. <https://console.cloud.google.com/apis/credentials> → OAuth consent screen: External, scopes `email openid profile`, add yourself as a test user.
 2. Create credentials → OAuth client ID → Web application.

--- a/frontend/src/pages/Applied.tsx
+++ b/frontend/src/pages/Applied.tsx
@@ -7,16 +7,12 @@ export default function Applied() {
     queryKey: ['applications', 'applied'],
     queryFn: () => api.listApplications({ status: 'applied' }),
   })
-  const { data: approved, isLoading: loadingApproved } = useQuery({
-    queryKey: ['applications', 'approved'],
-    queryFn: () => api.listApplications({ status: 'approved' }),
-  })
   const { data: dismissed, isLoading: loadingDismissed } = useQuery({
     queryKey: ['applications', 'dismissed'],
     queryFn: () => api.listApplications({ status: 'dismissed' }),
   })
 
-  if (loadingApplied || loadingApproved || loadingDismissed) {
+  if (loadingApplied || loadingDismissed) {
     return <div className="flex items-center justify-center h-48 text-gray-400">Loading...</div>
   }
 
@@ -37,28 +33,6 @@ export default function Applied() {
                 key={app.id}
                 to={`/matches/${app.id}`}
                 className="block p-3 bg-white rounded-md border border-gray-200 hover:border-gray-300 transition-colors"
-              >
-                <p className="font-medium text-gray-900 text-sm">{app.job?.title}</p>
-                <p className="text-xs text-gray-500">{app.job?.company_name}</p>
-              </Link>
-            ))}
-          </div>
-        )}
-      </section>
-
-      <section className="mb-8">
-        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
-          Approved ({approved?.length ?? 0})
-        </h2>
-        {!approved?.length ? (
-          <p className="text-sm text-gray-400">No approved applications.</p>
-        ) : (
-          <div className="space-y-2">
-            {approved.map((app) => (
-              <Link
-                key={app.id}
-                to={`/matches/${app.id}`}
-                className="block p-3 bg-white rounded-md border border-blue-200 hover:border-blue-300 transition-colors"
               >
                 <p className="font-medium text-gray-900 text-sm">{app.job?.title}</p>
                 <p className="text-xs text-gray-500">{app.job?.company_name}</p>


### PR DESCRIPTION
## Summary

Final PR of the simplification series. Brings docs and the History page in line with the new flow.

- **README**: rewrite \"How it works\" diagram for the simplified flow (Greenhouse-only sync, sync cover-letter generation, manual mark-applied); drop dropped-source mentions; OAuth-required note for the local dev path
- **DEPLOYMENT.md**: drop the Adzuna secret-create lines (no longer used); §3b is now \"Google OAuth (required)\" — single-user fallback was removed in PR 1
- **frontend/src/pages/Applied.tsx**: drop the \"Approved\" section. \`approved\` was retired with the auto-submit pipeline in PR 3; the API only returns \`pending_review\`/\`dismissed\`/\`applied\` now

## Test plan

- [x] \`uv run ruff check app/ tests/\` — clean
- [x] \`uv run pytest tests/unit/ tests/integration/ tests/e2e/ -q\` — 155 passed
- [x] \`cd frontend && npm run test -- --run\` — 28 passed
- [x] \`cd frontend && npm run build\` — 236 kB bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)