### PR TITLE
fix: bundle of manual-test bug fixes (#40, #41, #42, #43)

### DIFF
--- a/app/agents/generation_agent.py
+++ b/app/agents/generation_agent.py
@@ -103,9 +103,11 @@ Company: {job_company}
 Description:
 {job_description}
 
-Write a 250–350 word cover letter in Markdown. Address it to the hiring team at the
-company. Reference 2–3 specific candidate accomplishments that map to the job
-requirements. Skip generic opener phrases like "I am writing to express interest"."""
+Write a 100–140 word cover letter in Markdown. Be punchy and direct — hiring
+managers spend under 30 seconds on each letter. Address it to the hiring team
+at the company. Reference 1–2 specific candidate accomplishments that map to
+the most important job requirements. Skip generic openers like "I am writing
+to express interest" and avoid filler phrases."""
 
 
 async def _load_context(state: GenerationState) -> GenerationState:

--- a/app/agents/onboarding.py
+++ b/app/agents/onboarding.py
@@ -37,23 +37,47 @@ Your goals:
    - Ask for a city or metro area (e.g. "San Francisco Bay Area", "New York", "Austin")
    - OR confirm they want remote-only positions (set remote_ok=true, leave target_locations empty)
    - A vague answer like "open to anything" is not enough — pin down a location or remote-only
-4. Understand their key skills and experience highlights they want to emphasize.
-5. Note any companies or industries to exclude.
-6. Confirm their contact info (LinkedIn, GitHub, portfolio).
+4. Learn which companies' job boards to follow — REQUIRED. Job sourcing is built
+   on Greenhouse public boards, so an empty company list = zero jobs ever. Always
+   ask for at least one target company, even if the user did not volunteer any.
+   Offer concrete suggestions to make the ask actionable, e.g. stripe, openai,
+   anthropic, datadog, figma, notion, vercel, airtable. Store the slugs as
+   {"greenhouse": ["slug1", "slug2"]} in target_company_slugs. Slugs are
+   lowercase, no spaces (boards.greenhouse.io/{slug}). Confirm any slug that is
+   not obvious.
+5. Understand their key skills and experience highlights they want to emphasize.
+6. Note any companies or industries to exclude.
+7. Confirm their contact info (LinkedIn, GitHub, portfolio).
 
 Ask one or two questions at a time. Be conversational and concise.
-When you have enough information to update the profile, call the `save_profile_updates` tool.
-You can call it multiple times as you learn more.
 
-Do not consider the profile search-ready until target_locations is set OR remote_ok is true.
+# Mandatory tool-call discipline
 
-Once the profile feels complete, summarize what you've captured and tell the user they can
-update preferences anytime by chatting here.
+You MUST call the `save_profile_updates` tool BEFORE acknowledging any profile change
+in your reply. If the user states a preference, correction, or new value for any
+profile field — roles, seniority, location, remote_ok, search_keywords, target
+companies, exclusions, or contact info — you MUST invoke `save_profile_updates`
+in the same turn that you confirm the change.
 
-Target companies: If the user names specific companies they want to follow, ask them for
-the Greenhouse board slug (visible at boards.greenhouse.io/{slug}). Store as
-{"greenhouse": ["slug1", "slug2"]} in target_company_slugs. Common slugs are lowercase,
-no spaces (e.g., stripe, airbnb, openai). Ask for confirmation if the slug is not obvious."""
+NEVER claim a change is saved if no tool call was made in this turn. Phrases like
+"I've updated", "I've saved", "I've adjusted", "I've corrected", or "Done" are
+forbidden unless the corresponding tool call was actually issued. If you are
+unsure what is currently saved, prefer over-saving (re-issue the tool call)
+over under-saving — the tool is idempotent.
+
+You can call `save_profile_updates` multiple times as you learn more.
+
+# Search-ready gate
+
+Do not consider the profile search-ready until ALL of the following hold:
+  - target_locations is set OR remote_ok is true, AND
+  - target_company_slugs.greenhouse contains at least one slug.
+
+A profile that satisfies only the location gate but has zero greenhouse slugs
+will produce zero job matches forever — finish the slug ask before wrapping up.
+
+Once the profile is search-ready, summarize what you've captured and tell the
+user they can update preferences anytime by chatting here."""
 
 PROFILE_SCALAR_FIELDS = frozenset(
     {
@@ -80,6 +104,71 @@ class OnboardingState(TypedDict):
     profile_id: str
     profile_updates: dict
     resume_md: str | None
+
+
+def _format_current_profile(data: dict) -> str:
+    """Render a compact, LLM-readable snapshot of the current saved profile state.
+
+    Empty/None fields are rendered explicitly as "(none)" so the LLM can tell
+    the difference between unset and a value it might have hallucinated saving.
+    """
+
+    def _val(v):
+        if v is None:
+            return "(none)"
+        if isinstance(v, list):
+            return ", ".join(str(x) for x in v) if v else "(none)"
+        if isinstance(v, dict):
+            return ", ".join(f"{k}={v}" for k, v in v.items()) if v else "(none)"
+        if isinstance(v, bool):
+            return "true" if v else "false"
+        s = str(v).strip()
+        return s if s else "(none)"
+
+    greenhouse_slugs = (data.get("target_company_slugs") or {}).get("greenhouse", [])
+    lines = [
+        "## Current Profile (ground truth from the database)",
+        f"- full_name: {_val(data.get('full_name'))}",
+        f"- target_roles: {_val(data.get('target_roles'))}",
+        f"- seniority: {_val(data.get('seniority'))}",
+        f"- target_locations: {_val(data.get('target_locations'))}",
+        f"- remote_ok: {_val(data.get('remote_ok'))}",
+        f"- search_keywords: {_val(data.get('search_keywords'))}",
+        f"- target_company_slugs.greenhouse: {_val(greenhouse_slugs)}",
+    ]
+    return "\n".join(lines)
+
+
+async def _fetch_profile_snapshot(state: dict, config: RunnableConfig) -> dict | None:
+    """Load the profile row referenced by state['profile_id'] and return its
+    relevant fields as a plain dict. Returns None when profile_id or db_factory
+    is missing (e.g. legacy tests that don't wire either)."""
+    profile_id_str = state.get("profile_id")
+    if not profile_id_str:
+        return None
+    db_factory = (config or {}).get("configurable", {}).get("db_factory")
+    if db_factory is None:
+        return None
+    try:
+        profile_uuid = uuid.UUID(profile_id_str)
+    except (ValueError, TypeError):
+        return None
+
+    from app.models.user_profile import UserProfile
+
+    async with db_factory() as session:
+        profile = await session.get(UserProfile, profile_uuid)
+        if profile is None:
+            return None
+        return {
+            "full_name": profile.full_name,
+            "target_roles": list(profile.target_roles or []),
+            "seniority": profile.seniority,
+            "target_locations": list(profile.target_locations or []),
+            "remote_ok": profile.remote_ok,
+            "search_keywords": list(profile.search_keywords or []),
+            "target_company_slugs": dict(profile.target_company_slugs or {}),
+        }
 
 
 def get_llm():
@@ -121,6 +210,15 @@ def build_graph(checkpointer: AsyncPostgresSaver) -> StateGraph:
         resume_md = state.get("resume_md")
 
         system_content = SYSTEM_PROMPT
+
+        # Inject the live profile snapshot so the LLM has ground truth on every
+        # turn — prevents the "I've already saved that" hallucination that drove
+        # issue #40. Re-fetch from the DB on every call so newly persisted
+        # tool-call updates show up immediately on the next turn.
+        profile_data = await _fetch_profile_snapshot(state, config)
+        if profile_data is not None:
+            system_content += "\n\n" + _format_current_profile(profile_data)
+
         if resume_md:
             system_content += f"\n\n## User's Current Resume\n{resume_md}"
 

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -14,6 +14,10 @@ from app.services.rate_limit_service import check_daily_quota
 log = structlog.get_logger()
 router = APIRouter(prefix="/api/jobs", tags=["jobs"])
 
+# Daily ceiling on user-initiated /api/jobs/sync calls. Previous value of 1
+# made the dashboard button unusable after the first click of the day.
+MANUAL_SYNC_DAILY_LIMIT = 25
+
 
 @router.post("/sync")
 async def trigger_sync(
@@ -28,7 +32,7 @@ async def trigger_sync(
     In prod: would run via scheduler.
     """
     if settings.environment == "production":
-        await check_daily_quota(profile.user_id, "manual_sync", 1, session)
+        await check_daily_quota(profile.user_id, "manual_sync", MANUAL_SYNC_DAILY_LIMIT, session)
     result = await job_sync_service.sync_profile(profile, session)
 
     # After sync, score new jobs

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -29,6 +29,7 @@ async def run_job_sync() -> dict:
         profiles = result.scalars().all()
 
     profiles_synced = 0
+    profiles_without_slugs = 0
     total_new = 0
     total_updated = 0
     total_stale = 0
@@ -41,12 +42,15 @@ async def run_job_sync() -> dict:
                 total_new += sync_result.get("new_jobs", 0)
                 total_updated += sync_result.get("updated_jobs", 0)
                 total_stale += sync_result.get("stale_jobs", 0)
+                if "no_target_slugs" in sync_result.get("warnings", []):
+                    profiles_without_slugs += 1
                 await match_service.score_and_match(profile, session)
         except Exception as exc:
             await log.aexception("scheduler.sync_error", profile_id=str(profile.id), error=str(exc))
 
     return {
         "profiles_synced": profiles_synced,
+        "profiles_without_slugs": profiles_without_slugs,
         "total_new_jobs": total_new,
         "total_updated_jobs": total_updated,
         "total_stale_jobs": total_stale,

--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -1,8 +1,8 @@
 """Greenhouse-public-board sync. Single source.
 
-  1. From profile.target_company_slugs.greenhouse, fetch jobs via GreenhouseBoardSource.
-  2. Per-source dedup by (title, company).
-  3. Upsert + mark stale.
+1. From profile.target_company_slugs.greenhouse, fetch jobs via GreenhouseBoardSource.
+2. Per-source dedup by (title, company).
+3. Upsert + mark stale.
 """
 
 import re
@@ -49,6 +49,7 @@ async def sync_profile(
             "updated_jobs": 0,
             "stale_jobs": 0,
             "sources": ["greenhouse_board"],
+            "warnings": ["no_target_slugs"],
         }
 
     source = sources[0] if sources else GreenhouseBoardSource()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -97,7 +97,16 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   })
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(`${res.status}: ${text}`)
+    let detail: string | null = null
+    try {
+      const parsed = JSON.parse(text)
+      if (parsed && typeof parsed.detail === 'string') {
+        detail = parsed.detail
+      }
+    } catch {
+      // body wasn't JSON; fall through to raw text
+    }
+    throw new Error(detail ?? `${res.status}: ${text}`)
   }
   return res.json()
 }

--- a/frontend/src/pages/Matches.test.tsx
+++ b/frontend/src/pages/Matches.test.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { MemoryRouter } from 'react-router-dom'
+import { server } from '../test/server'
+import Matches from './Matches'
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Matches />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('Matches sync errors', () => {
+  it('surfaces the daily-limit message when /api/jobs/sync returns 429', async () => {
+    server.use(
+      http.post('/api/jobs/sync', () =>
+        HttpResponse.json(
+          { detail: "Daily limit of 25 for 'manual_sync' reached. Try again tomorrow." },
+          { status: 429 }
+        )
+      )
+    )
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: /sync jobs/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Daily limit of 25/i)).toBeInTheDocument()
+      expect(screen.getByText(/try again tomorrow/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/Matches.tsx
+++ b/frontend/src/pages/Matches.tsx
@@ -51,6 +51,12 @@ export default function Matches() {
         </div>
       )}
 
+      {sync.isError && (
+        <div className="mb-4 p-3 bg-red-50 text-red-700 text-sm rounded-md">
+          {(sync.error as Error)?.message ?? 'Sync failed.'}
+        </div>
+      )}
+
       {isLoading ? (
         <div className="grid gap-3">
           {Array.from({ length: 6 }).map((_, i) => <SkeletonCard key={i} />)}

--- a/tests/integration/test_cron_endpoints.py
+++ b/tests/integration/test_cron_endpoints.py
@@ -59,6 +59,10 @@ async def test_cron_sync_returns_structured_summary(client):
     assert data["status"] == "ok"
     assert isinstance(data["profiles_synced"], int)
     assert isinstance(data["duration_ms"], int)
+    # profiles_without_slugs is always reported so the operator can see at a glance
+    # how many active searches are misconfigured (empty target_company_slugs.greenhouse).
+    assert "profiles_without_slugs" in data
+    assert isinstance(data["profiles_without_slugs"], int)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -107,9 +107,7 @@ async def test_sync_profile_with_mocked_source(db_session):
     assert result["new_jobs"] == 1
     assert result["updated_jobs"] == 0
 
-    jobs_result = await db_session.execute(
-        select(Job).where(Job.source == "greenhouse_board")
-    )
+    jobs_result = await db_session.execute(select(Job).where(Job.source == "greenhouse_board"))
     jobs = jobs_result.scalars().all()
     assert len(jobs) == 1
     assert jobs[0].title == "Python Engineer"
@@ -139,6 +137,52 @@ async def test_sync_profile_no_slugs_short_circuits(db_session):
 
     assert result["new_jobs"] == 0
     mock_source.search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_profile_no_slugs_returns_warning(db_session):
+    """Empty greenhouse slug list yields a structured warning so the UI can surface it."""
+    from app.models.user import User
+    from app.services.profile_service import get_or_create_profile
+
+    user = User(id=uuid.uuid4(), email="warn@test.com")
+    db_session.add(user)
+    await db_session.commit()
+
+    profile = await get_or_create_profile(user.id, db_session)
+    profile.target_company_slugs = {}
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+
+    result = await job_sync_service.sync_profile(profile, db_session)
+
+    assert result.get("warnings") == ["no_target_slugs"]
+
+
+@pytest.mark.asyncio
+async def test_sync_profile_with_slugs_has_no_warnings(db_session):
+    """When the profile has slugs configured, no no_target_slugs warning is surfaced."""
+    from app.models.user import User
+    from app.services.profile_service import get_or_create_profile
+
+    user = User(id=uuid.uuid4(), email="hasslugs@test.com")
+    db_session.add(user)
+    await db_session.commit()
+
+    profile = await get_or_create_profile(user.id, db_session)
+    profile.target_company_slugs = {"greenhouse": ["acme"]}
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+
+    mock_source = MagicMock()
+    mock_source.source_name = "greenhouse_board"
+    mock_source.search = AsyncMock(return_value=([make_job_data()], None))
+
+    result = await job_sync_service.sync_profile(profile, db_session, sources=[mock_source])
+
+    assert "no_target_slugs" not in result.get("warnings", [])
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_onboarding_agent.py
+++ b/tests/integration/test_onboarding_agent.py
@@ -3,11 +3,13 @@ Integration test for the onboarding LangGraph agent with a real PostgreSQL check
 """
 
 import uuid
+from unittest.mock import patch
 
 import pytest
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 
 from app.agents.onboarding import build_graph
+from app.agents.test_llm import ToolCapableFakeLLM
 from tests.conftest import patch_llm
 
 
@@ -69,6 +71,68 @@ async def test_session_resumes_across_invocations(checkpointer):
         )
 
     assert len(result["messages"]) >= 4
+
+
+class _SpyLLM(ToolCapableFakeLLM):
+    """Records the system message sent to it on each call."""
+
+    captured_system: list[str] = []  # noqa: RUF012  (class-level capture is intentional in tests)
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        for m in messages:
+            if m.__class__.__name__ == "SystemMessage":
+                self.__class__.captured_system.append(str(m.content))
+        return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_agent_node_injects_current_profile_snapshot(checkpointer, db_session, asyncpg_url):
+    """The system message sent to the LLM must include a snapshot of the current
+    profile state (so the LLM can tell what's actually saved vs. what it imagined
+    saving — issue #40)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.models.user import User
+    from app.models.user_profile import UserProfile
+
+    user_id = uuid.uuid4()
+    user = User(id=user_id, email=f"snap-{user_id}@local")
+    db_session.add(user)
+    profile = UserProfile(
+        user_id=user_id,
+        target_roles=["Backend Engineer"],
+        target_company_slugs={"greenhouse": ["stripe", "openai"]},
+    )
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+    profile_id = str(profile.id)
+
+    # Build a fresh session factory bound to the same test database so the
+    # agent_node DB lookup uses our seeded data.
+    engine = create_async_engine(asyncpg_url, echo=False)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    spy = _SpyLLM(responses=["What else should we add?"])
+    _SpyLLM.captured_system = []
+    with patch("app.agents.onboarding.get_llm", return_value=spy):
+        graph = build_graph(checkpointer)
+        await graph.ainvoke(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "profile_id": profile_id,
+                "profile_updates": {},
+            },
+            {"configurable": {"thread_id": profile_id, "db_factory": factory}},
+        )
+    await engine.dispose()
+
+    assert _SpyLLM.captured_system, "Spy LLM never received a system message"
+    system_blob = "\n".join(_SpyLLM.captured_system)
+    assert "Current Profile" in system_blob
+    assert "Backend Engineer" in system_blob
+    assert "stripe" in system_blob
+    assert "openai" in system_blob
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_generation_agent.py
+++ b/tests/unit/test_generation_agent.py
@@ -54,3 +54,15 @@ async def test_document_has_required_fields():
     assert doc["doc_type"] == "cover_letter"
     assert len(doc["content_md"]) > 30
     assert doc["generation_model"]
+
+
+def test_cover_letter_prompt_targets_concise_length():
+    """Prompt instructs the LLM to write a concise letter (≤140 words),
+    not the previous 250–350 word default that produced unreadable output."""
+    from app.agents.generation_agent import COVER_LETTER_PROMPT
+
+    # Stale 250-350 word target must be gone
+    assert "250" not in COVER_LETTER_PROMPT
+    assert "350" not in COVER_LETTER_PROMPT
+    # New concise target present
+    assert "140" in COVER_LETTER_PROMPT

--- a/tests/unit/test_jobs_api_quota.py
+++ b/tests/unit/test_jobs_api_quota.py
@@ -1,0 +1,22 @@
+"""Unit test for the manual job-sync daily quota constant.
+
+The previous limit of 1/day made the in-app "Sync jobs" button effectively
+unusable after the first click of the day (429 every subsequent click).
+This test enforces a usable lower bound and prevents future regressions.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("GOOGLE_API_KEY", "fake-test-key")
+os.environ.setdefault("ENVIRONMENT", "test")
+
+
+def test_manual_sync_daily_limit_is_usable():
+    """Ceiling must allow more than one click per day; 1/day was the prior bug."""
+    from app.api.jobs import MANUAL_SYNC_DAILY_LIMIT
+
+    assert MANUAL_SYNC_DAILY_LIMIT >= 10, (
+        f"Daily quota for manual sync is too low: {MANUAL_SYNC_DAILY_LIMIT}. "
+        "1/day made the UI button effectively unusable. Use ≥ 10."
+    )

--- a/tests/unit/test_onboarding_prompt.py
+++ b/tests/unit/test_onboarding_prompt.py
@@ -1,0 +1,137 @@
+"""Unit tests for onboarding agent system prompt and tool-call discipline.
+
+Covers issues:
+  #40 — silent profile-update claims (no tool call but agent says "I've updated")
+  #43 — empty target_company_slugs.greenhouse → 0 jobs forever
+
+These tests assert the prompt contract; tool-call behavior is covered separately
+by the integration suite that runs the graph end-to-end.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("GOOGLE_API_KEY", "fake-test-key")
+os.environ.setdefault("ENVIRONMENT", "test")
+
+
+def test_prompt_makes_slugs_part_of_search_ready_gate():
+    """Search-ready check must require at least one greenhouse slug, not just location.
+
+    The original prompt gated only on location/remote — empty target_company_slugs.greenhouse
+    silently produced 0-job syncs forever. The gate must include slugs too.
+    """
+    from app.agents.onboarding import SYSTEM_PROMPT
+
+    # Look for a single sentence/clause that ties "search-ready" (or equivalent) to
+    # both the location AND slug requirement. Crude but effective: split on
+    # "search-ready" / "ready" / "complete" and check the surrounding window mentions slugs.
+    lower = SYSTEM_PROMPT.lower()
+    assert "target_company_slugs" in SYSTEM_PROMPT or "greenhouse slug" in lower
+
+    # Find a clause that defines the search-ready gate (the operational sentence,
+    # not just a heading). It must mention slugs/companies in the same paragraph.
+    candidates = [
+        m for m in ("search-ready until", "do not consider", "search-ready when") if m in lower
+    ]
+    assert candidates, (
+        "Prompt must contain an operational search-ready gate clause "
+        "(e.g. 'search-ready until ...' or 'do not consider ...')."
+    )
+    found_slug_clause = False
+    for needle in candidates:
+        idx = lower.index(needle)
+        paragraph_end = lower.find("\n\n", idx)
+        if paragraph_end == -1:
+            paragraph_end = len(lower)
+        clause = lower[idx:paragraph_end]
+        if "slug" in clause or "target_company" in clause or "company" in clause:
+            found_slug_clause = True
+            break
+    assert found_slug_clause, "At least one search-ready clause must require slugs/companies."
+
+
+def test_prompt_proactively_asks_for_target_companies():
+    """Prompt instructs the agent to PROACTIVELY ask for slugs, not just IF the user
+    volunteers them. The old conditional ('if the user names...') let the agent skip
+    the step entirely."""
+    from app.agents.onboarding import SYSTEM_PROMPT
+
+    # Old conditional language should be gone or rewritten
+    # New language must indicate an active ask
+    lower = SYSTEM_PROMPT.lower()
+    assert "ask" in lower
+    # A curated list of suggestions makes the ask actionable
+    suggestions = ["stripe", "openai", "anthropic", "datadog"]
+    assert any(s in lower for s in suggestions), (
+        "Prompt should include at least one curated Greenhouse slug suggestion "
+        "so the agent can offer concrete examples to the user."
+    )
+
+
+def test_prompt_mandates_tool_call_before_claiming_save():
+    """Prompt forbids the agent from saying 'I've updated/saved/adjusted' without
+    actually invoking save_profile_updates in the same turn (the #40 bug)."""
+    from app.agents.onboarding import SYSTEM_PROMPT
+
+    lower = SYSTEM_PROMPT.lower()
+    # Must contain a mandatory directive about tool usage (MUST / always / never).
+    assert "must call" in lower or "must invoke" in lower or "always call" in lower
+    # Must explicitly forbid fabricated save claims
+    assert (
+        "never claim" in lower
+        or "do not claim" in lower
+        or "do not say" in lower
+        or "never say" in lower
+    )
+
+
+def test_format_current_profile_includes_relevant_fields():
+    """The helper that injects the current profile snapshot must surface the
+    fields the LLM needs as ground truth: roles, seniority, location, remote_ok,
+    search keywords, target company slugs."""
+    from app.agents.onboarding import _format_current_profile
+
+    snapshot = _format_current_profile(
+        {
+            "target_roles": ["Backend Engineer", "Software Architect"],
+            "seniority": "senior",
+            "target_locations": ["San Diego, CA"],
+            "remote_ok": True,
+            "search_keywords": ["Python", "distributed systems"],
+            "target_company_slugs": {"greenhouse": ["stripe", "openai"]},
+            "full_name": "Maksym P.",
+        }
+    )
+
+    # Each ground-truth field must be visible to the LLM.
+    assert "Backend Engineer" in snapshot
+    assert "Software Architect" in snapshot
+    assert "senior" in snapshot.lower()
+    assert "San Diego" in snapshot
+    assert "remote_ok" in snapshot.lower() or "remote" in snapshot.lower()
+    assert "Python" in snapshot
+    assert "stripe" in snapshot
+    assert "openai" in snapshot
+
+
+def test_format_current_profile_handles_missing_fields():
+    """Empty/None values must not crash and must not invent values."""
+    from app.agents.onboarding import _format_current_profile
+
+    snapshot = _format_current_profile(
+        {
+            "target_roles": [],
+            "seniority": None,
+            "target_locations": [],
+            "remote_ok": False,
+            "search_keywords": [],
+            "target_company_slugs": {},
+            "full_name": None,
+        }
+    )
+    # Should produce a non-empty snapshot that signals the empty state.
+    assert snapshot.strip()
+    # Should NOT contain fabricated values
+    assert "Backend Engineer" not in snapshot
+    assert "stripe" not in snapshot


### PR DESCRIPTION
## Summary

Fixes four bugs found during manual testing, filed as #40, #41, #42, #43. Three commits, one per logical concern.

- **#41** Cover letters were 250-350 words (output ~270). Tightened the prompt to 100-140 words with a "no filler" directive.
- **#42** The dashboard "Sync jobs" button 429'd after one click/day because `manual_sync` daily quota was 1. Bumped to 25, extracted as a constant, and surfaced FastAPI's error `detail` in the UI toast (it was being swallowed before).
- **#43** Profiles silently synced 0 jobs forever when `target_company_slugs.greenhouse` was empty (prod logs confirmed this on both live profiles). Onboarding agent now treats company-slug collection as a required step with curated suggestions, and the search-ready gate requires at least one slug. Sync responses now carry `warnings: ["no_target_slugs"]` so the UI can surface the gap; cron aggregates this into `profiles_without_slugs`.
- **#40** The onboarding agent claimed to save profile changes without invoking `save_profile_updates` (the "I've updated your profile" hallucination from the manual-test transcript). Added a mandatory tool-call rule to the system prompt and — more importantly — `agent_node` now injects a live `## Current Profile` snapshot from the DB on every turn, so the LLM has ground truth and can't hallucinate prior saves.

## Test plan

- [x] `uv run pytest tests/unit tests/integration` — 148 passed
- [x] `cd frontend && npm test` — 29 passed
- [x] `uv run ruff check app/ tests/` — clean
- [x] All 11 modified Python files pass `ruff format --check`
- [x] New tests added per fix (RED → GREEN verified):
  - `test_cover_letter_prompt_targets_concise_length`
  - `test_manual_sync_daily_limit_is_usable`
  - `Matches.test.tsx` — 429 toast surfacing
  - `test_sync_profile_no_slugs_returns_warning`, `test_sync_profile_with_slugs_has_no_warnings`
  - cron summary now asserts `profiles_without_slugs`
  - `test_prompt_makes_slugs_part_of_search_ready_gate`
  - `test_prompt_proactively_asks_for_target_companies`
  - `test_prompt_mandates_tool_call_before_claiming_save`
  - `test_format_current_profile_*` (×2)
  - `test_agent_node_injects_current_profile_snapshot` (integration)

## Manual follow-ups for the user (not in this PR)

The two prod profiles still have empty `target_company_slugs.greenhouse`. After this merges and deploys, re-run onboarding (or PATCH the profile directly) to add slugs — the new onboarding flow will guide the user through it. The 0-jobs symptom won't resolve until those slugs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)