### PR TITLE
fix: 8 sync-flow gaps (#45-#52)

### DIFF
--- a/app/agents/matching_agent.py
+++ b/app/agents/matching_agent.py
@@ -35,7 +35,7 @@ def truncate_description(desc: str, max_chars: int = MAX_JOB_DESC_CHARS) -> str:
 
 class ScoreResult(BaseModel):
     application_id: str
-    score: float  # 0.0 – 1.0
+    score: float | None  # 0.0 – 1.0; None signals scoring was skipped (retry next sync)
     rationale: str
     strengths: list[str]
     gaps: list[str]
@@ -154,11 +154,13 @@ def build_graph() -> StateGraph:
                     break
                 except BudgetExhausted:
                     log.warning("match.budget_exhausted_skip", title=job["title"])
+                    # score=None so the Application is re-eligible next sync
+                    # instead of being permanently auto_rejected at 0.0.
                     return {
                         "scores": [
                             ScoreResult(
                                 application_id=job["application_id"],
-                                score=0.0,
+                                score=None,
                                 rationale="Skipped: LLM quota exhausted",
                                 strengths=[],
                                 gaps=[],
@@ -179,7 +181,7 @@ def build_graph() -> StateGraph:
                             "scores": [
                                 ScoreResult(
                                     application_id=job["application_id"],
-                                    score=0.0,
+                                    score=None,
                                     rationale="Skipped: API rate limit exceeded after retries",
                                     strengths=[],
                                     gaps=[],

--- a/app/models/application.py
+++ b/app/models/application.py
@@ -12,7 +12,12 @@ class Application(SQLModel, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     job_id: uuid.UUID = Field(foreign_key="jobs.id")
     profile_id: uuid.UUID = Field(foreign_key="user_profiles.id")
-    status: str = "pending_review"  # pending_review, dismissed, applied
+    # status values:
+    #   pending_review — scored above threshold, awaiting user review (default)
+    #   auto_rejected  — scored below match_score_threshold (set by match_service)
+    #   dismissed      — user dismissed via PATCH
+    #   applied        — user marked applied via PATCH
+    status: str = "pending_review"
     # Values: none, pending, generating, awaiting_review, ready, failed
     generation_status: str = "none"
     generation_attempts: int = 0

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -29,10 +29,10 @@ async def run_job_sync() -> dict:
         profiles = result.scalars().all()
 
     profiles_synced = 0
-    profiles_without_slugs = 0
     total_new = 0
     total_updated = 0
     total_stale = 0
+    total_warnings: dict[str, int] = {}
 
     for profile in profiles:
         try:
@@ -42,15 +42,19 @@ async def run_job_sync() -> dict:
                 total_new += sync_result.get("new_jobs", 0)
                 total_updated += sync_result.get("updated_jobs", 0)
                 total_stale += sync_result.get("stale_jobs", 0)
-                if "no_target_slugs" in sync_result.get("warnings", []):
-                    profiles_without_slugs += 1
+                # Generic aggregation — counts every warning code emitted by
+                # sync_profile, so new codes surface automatically (#48).
+                for w in sync_result.get("warnings", []):
+                    total_warnings[w] = total_warnings.get(w, 0) + 1
                 await match_service.score_and_match(profile, session)
         except Exception as exc:
             await log.aexception("scheduler.sync_error", profile_id=str(profile.id), error=str(exc))
 
     return {
         "profiles_synced": profiles_synced,
-        "profiles_without_slugs": profiles_without_slugs,
+        # Back-compat field; total_warnings["no_target_slugs"] is the canonical source.
+        "profiles_without_slugs": total_warnings.get("no_target_slugs", 0),
+        "total_warnings": total_warnings,
         "total_new_jobs": total_new,
         "total_updated_jobs": total_updated,
         "total_stale_jobs": total_stale,

--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -15,7 +15,11 @@ from app.config import get_settings
 from app.models.user_profile import UserProfile
 from app.services import job_service
 from app.sources.base import JobData, JobSource
-from app.sources.greenhouse_board import GreenhouseBoardSource
+from app.sources.greenhouse_board import (
+    GreenhouseBoardSource,
+    InvalidSlugError,
+    TransientFetchError,
+)
 
 log = structlog.get_logger()
 
@@ -55,14 +59,27 @@ async def sync_profile(
     source = sources[0] if sources else GreenhouseBoardSource()
     source_name = source.source_name
     raw: list[JobData] = []
-    errors = 0
+    failed_slugs: list[dict] = []
 
     for slug in slugs:
         try:
             jobs, _ = await source.search(query="", location=None, slug=slug)
             raw.extend(jobs)
+        except InvalidSlugError as exc:
+            failed_slugs.append({"slug": slug, "kind": "invalid", "error": str(exc)})
+            await log.awarning(
+                "job_sync.invalid_slug", source=source_name, slug=slug, error=str(exc)
+            )
+        except TransientFetchError as exc:
+            failed_slugs.append({"slug": slug, "kind": "transient", "error": str(exc)})
+            await log.awarning(
+                "job_sync.transient_fetch_error",
+                source=source_name,
+                slug=slug,
+                error=str(exc),
+            )
         except Exception as exc:
-            errors += 1
+            failed_slugs.append({"slug": slug, "kind": "error", "error": str(exc)})
             await log.awarning(
                 "job_sync.source_error",
                 source=source_name,
@@ -83,17 +100,23 @@ async def sync_profile(
 
     stale = await job_service.mark_stale_jobs(settings.job_stale_after_days, session)
 
+    warnings: list[str] = []
+    if failed_slugs:
+        warnings.append("slug_fetch_errors")
+
     result = {
         "new_jobs": new_count,
         "updated_jobs": updated_count,
         "stale_jobs": stale,
         "sources": [source_name],
+        "warnings": warnings,
+        "failed_slugs": failed_slugs,
     }
     await log.ainfo(
         "job_sync.complete",
         profile_id=str(profile.id),
         duration_ms=int((time.perf_counter() - t0) * 1000),
-        errors=errors,
-        **result,
+        failed_slug_count=len(failed_slugs),
+        **{k: v for k, v in result.items() if k not in ("failed_slugs", "warnings")},
     )
     return result

--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -2,7 +2,7 @@
 
 1. From profile.target_company_slugs.greenhouse, fetch jobs via GreenhouseBoardSource.
 2. Per-source dedup by (title, company).
-3. Upsert + mark stale.
+3. Upsert. Staleness is owned by run_daily_maintenance, not this path.
 """
 
 import re
@@ -11,7 +11,6 @@ import time
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import get_settings
 from app.models.user_profile import UserProfile
 from app.services import job_service
 from app.sources.base import JobData, JobSource
@@ -42,7 +41,6 @@ async def sync_profile(
     sources: list[JobSource] | None = None,
 ) -> dict:
     """Run a Greenhouse sync for one profile. Returns a summary dict."""
-    settings = get_settings()
     t0 = time.perf_counter()
 
     slugs = (profile.target_company_slugs or {}).get("greenhouse", [])
@@ -98,7 +96,9 @@ async def sync_profile(
         else:
             updated_count += 1
 
-    stale = await job_service.mark_stale_jobs(settings.job_stale_after_days, session)
+    # Staleness is a global, time-based property handled by run_daily_maintenance;
+    # running it here once per per-profile sync caused jobs from one profile to
+    # flap inactive when another profile synced (issue #49).
 
     warnings: list[str] = []
     if failed_slugs:
@@ -107,7 +107,7 @@ async def sync_profile(
     result = {
         "new_jobs": new_count,
         "updated_jobs": updated_count,
-        "stale_jobs": stale,
+        "stale_jobs": 0,
         "sources": [source_name],
         "warnings": warnings,
         "failed_slugs": failed_slugs,

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -179,6 +179,17 @@ async def score_and_match(
         if not app:
             continue
 
+        # score=None means scoring was skipped (rate limit / quota / transient).
+        # Leave match_score NULL so the Application is re-eligible on the next
+        # sync instead of being permanently auto_rejected at 0.0 (issue #46).
+        if score_result.score is None:
+            await log.awarning(
+                "match.scoring_skipped",
+                application_id=score_result.application_id,
+                rationale=score_result.rationale[:200],
+            )
+            continue
+
         # Always persist scores for auditability
         app.match_score = score_result.score
         app.match_rationale = score_result.rationale

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -108,10 +108,20 @@ async def score_and_match(
         )
         matched_ids = {row[0] for row in matched_result.all()}
 
-        all_jobs_result = await session.execute(
-            select(Job).where(Job.is_active.is_(True)).limit(settings.matching_jobs_per_batch)
+        # Push the not-in-matched_ids filter into SQL so the LIMIT counts only
+        # fresh candidates. Order newest-first so users see recently posted
+        # jobs before backlogged ones (issue #45).
+        candidates_q = (
+            select(Job)
+            .where(Job.is_active.is_(True))
+            .order_by(Job.posted_at.desc().nullslast(), Job.fetched_at.desc())
         )
-        jobs = [j for j in all_jobs_result.scalars().all() if j.id not in matched_ids]
+        if matched_ids:
+            candidates_q = candidates_q.where(Job.id.notin_(matched_ids))
+        candidates_q = candidates_q.limit(settings.matching_jobs_per_batch)
+
+        all_jobs_result = await session.execute(candidates_q)
+        jobs = list(all_jobs_result.scalars().all())
 
     if not jobs:
         return []

--- a/app/sources/greenhouse_board.py
+++ b/app/sources/greenhouse_board.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Any
 
 import httpx
+import markdownify
 import structlog
 
 from app.sources.base import JobData, JobSource
@@ -16,6 +17,14 @@ from app.sources.base import JobData, JobSource
 GREENHOUSE_BOARDS_BASE = "https://boards-api.greenhouse.io/v1/boards"
 
 log = structlog.get_logger()
+
+
+def _html_to_markdown(content: str | None) -> str | None:
+    """Convert Greenhouse HTML `content` to Markdown so the field name matches
+    reality and the matching LLM doesn't burn tokens on tags (issue #51)."""
+    if not content:
+        return content
+    return markdownify.markdownify(content, strip=["script", "style"]).strip() or None
 
 
 class GreenhouseFetchError(Exception):
@@ -76,7 +85,7 @@ class GreenhouseBoardSource(JobSource):
             company_name=company_name,
             location=location,
             workplace_type=workplace_type,
-            description_md=item.get("content"),
+            description_md=_html_to_markdown(item.get("content")),
             salary=None,
             contract_type=None,
             apply_url=apply_url,

--- a/app/sources/greenhouse_board.py
+++ b/app/sources/greenhouse_board.py
@@ -18,6 +18,22 @@ GREENHOUSE_BOARDS_BASE = "https://boards-api.greenhouse.io/v1/boards"
 log = structlog.get_logger()
 
 
+class GreenhouseFetchError(Exception):
+    """Base for slug-fetch failures the caller should surface."""
+
+    def __init__(self, slug: str, message: str = ""):
+        self.slug = slug
+        super().__init__(message or slug)
+
+
+class InvalidSlugError(GreenhouseFetchError):
+    """Greenhouse returned 404 — the slug does not exist on their platform."""
+
+
+class TransientFetchError(GreenhouseFetchError):
+    """5xx or network error — retry on the next sync."""
+
+
 class GreenhouseBoardSource(JobSource):
     @property
     def source_name(self) -> str:
@@ -74,11 +90,28 @@ class GreenhouseBoardSource(JobSource):
                     f"{GREENHOUSE_BOARDS_BASE}/{slug}/jobs",
                     params={"content": "true"},
                 )
-                if response.status_code == 404:
-                    await log.awarning("greenhouse_board.invalid_slug", slug=slug)
-                    return []
-                response.raise_for_status()
-                data = response.json()
+        except httpx.HTTPError as exc:
+            await log.awarning(
+                "greenhouse_board.network_error",
+                slug=slug,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            raise TransientFetchError(slug, str(exc)) from exc
+
+        if response.status_code == 404:
+            await log.awarning("greenhouse_board.invalid_slug", slug=slug)
+            raise InvalidSlugError(slug, "board not found")
+        if response.status_code >= 500:
+            await log.awarning(
+                "greenhouse_board.upstream_5xx",
+                slug=slug,
+                status=response.status_code,
+            )
+            raise TransientFetchError(slug, f"upstream {response.status_code}")
+        try:
+            response.raise_for_status()
+            data = response.json()
         except Exception as exc:
             await log.aerror(
                 "greenhouse_board.fetch_failed",
@@ -88,7 +121,7 @@ class GreenhouseBoardSource(JobSource):
                 error_type=type(exc).__name__,
                 exc_info=True,
             )
-            return []
+            raise TransientFetchError(slug, str(exc)) from exc
 
         return [j for item in data.get("jobs", []) if (j := self._parse_job(item, slug))]
 

--- a/frontend/src/pages/Matches.tsx
+++ b/frontend/src/pages/Matches.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '../api/client'
 import { MatchCard } from '../components/MatchCard'
+import { computeRefetchInterval, POST_SYNC_WINDOW_MS } from './refetchInterval'
 
 function SkeletonCard() {
   return (
@@ -15,16 +17,20 @@ function SkeletonCard() {
 
 export default function Matches() {
   const qc = useQueryClient()
+  const [postSyncUntilMs, setPostSyncUntilMs] = useState<number | null>(null)
 
   const { data: apps, isLoading } = useQuery({
     queryKey: ['applications'],
     queryFn: () => api.listApplications({ status: 'pending_review' }),
-    refetchInterval: 10000,
+    refetchInterval: () => computeRefetchInterval(postSyncUntilMs),
   })
 
   const sync = useMutation({
     mutationFn: api.triggerSync,
     onSuccess: () => {
+      // Background scoring runs ~30s for a 20-job batch — poll aggressively
+      // for a minute so freshly scored matches surface without a manual reload.
+      setPostSyncUntilMs(Date.now() + POST_SYNC_WINDOW_MS)
       setTimeout(() => qc.invalidateQueries({ queryKey: ['applications'] }), 3000)
     },
   })

--- a/frontend/src/pages/refetchInterval.test.ts
+++ b/frontend/src/pages/refetchInterval.test.ts
@@ -1,0 +1,28 @@
+import {
+  computeRefetchInterval,
+  IDLE_INTERVAL_MS,
+  POST_SYNC_INTERVAL_MS,
+  POST_SYNC_WINDOW_MS,
+} from './refetchInterval'
+
+describe('computeRefetchInterval', () => {
+  it('returns idle interval when no recent sync', () => {
+    expect(computeRefetchInterval(null, 1_000_000)).toBe(IDLE_INTERVAL_MS)
+  })
+
+  it('returns aggressive interval inside the post-sync window', () => {
+    const now = 1_000_000
+    const until = now + POST_SYNC_WINDOW_MS - 1
+    expect(computeRefetchInterval(until, now)).toBe(POST_SYNC_INTERVAL_MS)
+  })
+
+  it('returns idle interval after the post-sync window expires', () => {
+    const now = 1_000_000
+    const until = now - 1 // window already over
+    expect(computeRefetchInterval(until, now)).toBe(IDLE_INTERVAL_MS)
+  })
+
+  it('idle and post-sync intervals differ', () => {
+    expect(POST_SYNC_INTERVAL_MS).toBeLessThan(IDLE_INTERVAL_MS)
+  })
+})

--- a/frontend/src/pages/refetchInterval.ts
+++ b/frontend/src/pages/refetchInterval.ts
@@ -1,0 +1,25 @@
+/**
+ * Dynamic refetch interval for the matches dashboard.
+ *
+ * Background scoring after a sync click runs ~30s for a 20-job batch
+ * (1.5s throttle + LLM latency per job). The default 10s refetch + 3s
+ * post-sync invalidation lost to that race — the user saw "Sync complete:
+ * N new jobs" but matches stayed empty until they reloaded.
+ *
+ * Returns 5s during the "post-sync window" so freshly scored applications
+ * surface promptly; returns 10s otherwise to keep the polling rate sane
+ * during idle dashboard sessions. (Issue #52)
+ */
+export const POST_SYNC_INTERVAL_MS = 5000
+export const IDLE_INTERVAL_MS = 10000
+export const POST_SYNC_WINDOW_MS = 60_000
+
+export function computeRefetchInterval(
+  postSyncUntilMs: number | null,
+  now: number = Date.now(),
+): number {
+  if (postSyncUntilMs !== null && now < postSyncUntilMs) {
+    return POST_SYNC_INTERVAL_MS
+  }
+  return IDLE_INTERVAL_MS
+}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -75,6 +75,8 @@ async def test_app(asyncpg_url, psycopg_url, monkeypatch):
     monkeypatch.setenv("REMOTEOK_ENABLED", "false")
     monkeypatch.setenv("ARBEITNOW_ENABLED", "false")
     monkeypatch.setenv("GREENHOUSE_BOARD_ENABLED", "false")
+    # Deterministic cron secret so /internal/cron/* tests don't pick up a local .env value.
+    monkeypatch.setenv("CRON_SHARED_SECRET", "dev-cron-secret")
 
     # Reset settings singleton so the env vars above take effect
     import app.config as cfg

--- a/tests/e2e/test_job_sync_e2e.py
+++ b/tests/e2e/test_job_sync_e2e.py
@@ -62,9 +62,7 @@ async def test_sync_creates_jobs_in_db(test_app, monkeypatch):
     jobs = [_make_job_data(i) for i in range(3)]
     mock_source = _mock_greenhouse_source(jobs)
 
-    monkeypatch.setattr(
-        "app.services.job_sync_service.GreenhouseBoardSource", lambda: mock_source
-    )
+    monkeypatch.setattr("app.services.job_sync_service.GreenhouseBoardSource", lambda: mock_source)
     monkeypatch.setattr("app.api.jobs._score_after_sync", AsyncMock())
 
     resp = await test_app.post("/api/jobs/sync")
@@ -100,9 +98,7 @@ async def test_resync_is_idempotent(test_app, monkeypatch):
     jobs = [_make_job_data(i) for i in range(3)]
     mock_source = _mock_greenhouse_source(jobs)
 
-    monkeypatch.setattr(
-        "app.services.job_sync_service.GreenhouseBoardSource", lambda: mock_source
-    )
+    monkeypatch.setattr("app.services.job_sync_service.GreenhouseBoardSource", lambda: mock_source)
     monkeypatch.setattr("app.api.jobs._score_after_sync", AsyncMock())
 
     # First sync
@@ -122,9 +118,7 @@ async def test_resync_is_idempotent(test_app, monkeypatch):
 
     factory = get_session_factory()
     async with factory() as session:
-        result = await session.execute(
-            select(Job).where(Job.source == "greenhouse_board")
-        )
+        result = await session.execute(select(Job).where(Job.source == "greenhouse_board"))
         db_jobs = list(result.scalars().all())
 
     assert len(db_jobs) == 3
@@ -148,9 +142,7 @@ async def test_posted_at_timezone_roundtrip(test_app, monkeypatch):
     jobs = [_make_job_data(0, posted_at=aware_posted_at)]
     mock_source = _mock_greenhouse_source(jobs)
 
-    monkeypatch.setattr(
-        "app.services.job_sync_service.GreenhouseBoardSource", lambda: mock_source
-    )
+    monkeypatch.setattr("app.services.job_sync_service.GreenhouseBoardSource", lambda: mock_source)
     monkeypatch.setattr("app.api.jobs._score_after_sync", AsyncMock())
 
     resp = await test_app.post("/api/jobs/sync")
@@ -163,9 +155,7 @@ async def test_posted_at_timezone_roundtrip(test_app, monkeypatch):
 
     factory = get_session_factory()
     async with factory() as session:
-        result = await session.execute(
-            select(Job).where(Job.source == "greenhouse_board")
-        )
+        result = await session.execute(select(Job).where(Job.source == "greenhouse_board"))
         job = result.scalar_one()
 
     assert job.posted_at is not None
@@ -176,8 +166,10 @@ async def test_posted_at_timezone_roundtrip(test_app, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_stale_job_marking(test_app, monkeypatch):
-    """
-    Jobs not refreshed within stale_after_days are marked is_active=False on next sync.
+    """Backdated jobs are marked is_active=False by daily maintenance.
+
+    Per #49, staleness is owned by run_daily_maintenance — not sync_profile —
+    to avoid one profile's sync flapping another profile's jobs inactive.
     """
     await test_app.patch(
         "/api/profile",
@@ -185,8 +177,6 @@ async def test_stale_job_marking(test_app, monkeypatch):
     )
 
     all_jobs = [_make_job_data(0), _make_job_data(1)]
-
-    # First sync: both jobs appear
     monkeypatch.setattr(
         "app.services.job_sync_service.GreenhouseBoardSource",
         lambda: _mock_greenhouse_source(all_jobs),
@@ -196,7 +186,7 @@ async def test_stale_job_marking(test_app, monkeypatch):
     resp = await test_app.post("/api/jobs/sync")
     assert resp.json()["new_jobs"] == 2
 
-    # Backdate job #0's fetched_at so it looks stale
+    # Backdate job #0's fetched_at past the staleness window
     from app.database import get_session_factory
     from app.models.job import Job
 
@@ -215,13 +205,12 @@ async def test_stale_job_marking(test_app, monkeypatch):
         await session.commit()
         stale_job_id = stale_job.id
 
-    # Second sync: only job #1 returned — job #0 is NOT refreshed, so mark_stale picks it up
-    monkeypatch.setattr(
-        "app.services.job_sync_service.GreenhouseBoardSource",
-        lambda: _mock_greenhouse_source([all_jobs[1]]),
+    # Trigger the daily-maintenance cron — the new owner of staleness (#49).
+    # Default cron secret in dev/test env is "dev-cron-secret" (app/config.py).
+    resp2 = await test_app.post(
+        "/internal/cron/maintenance",
+        headers={"X-Cron-Secret": "dev-cron-secret"},
     )
-
-    resp2 = await test_app.post("/api/jobs/sync")
     assert resp2.status_code == 200
     assert resp2.json()["stale_jobs"] >= 1
 

--- a/tests/integration/test_cron_endpoints.py
+++ b/tests/integration/test_cron_endpoints.py
@@ -63,6 +63,10 @@ async def test_cron_sync_returns_structured_summary(client):
     # how many active searches are misconfigured (empty target_company_slugs.greenhouse).
     assert "profiles_without_slugs" in data
     assert isinstance(data["profiles_without_slugs"], int)
+    # total_warnings is a generic dict aggregator — survives addition of new
+    # warning codes from sync_profile (#48).
+    assert "total_warnings" in data
+    assert isinstance(data["total_warnings"], dict)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -255,6 +255,57 @@ async def test_sync_profile_surfaces_transient_fetch_errors(db_session):
 
 
 @pytest.mark.asyncio
+async def test_sync_profile_does_not_mark_jobs_stale(db_session):
+    """Issue #49: mark_stale_jobs runs in daily maintenance — sync_profile must
+    not duplicate that work (it caused jobs from one profile to flap inactive
+    when another profile synced)."""
+    from datetime import timedelta
+
+    from app.models.user import User
+    from app.services.profile_service import get_or_create_profile
+
+    user = User(id=uuid.uuid4(), email="staleness@test.com")
+    db_session.add(user)
+    await db_session.commit()
+
+    profile = await get_or_create_profile(user.id, db_session)
+    profile.target_company_slugs = {"greenhouse": ["acme"]}
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+
+    # Pre-seed an active job whose fetched_at is older than the staleness window.
+    # If sync_profile ran mark_stale_jobs it would flip is_active=False; with #49
+    # fixed, this job should remain active until run_daily_maintenance runs.
+    stale_eligible = Job(
+        source="greenhouse_board",
+        external_id="stale-eligible-1",
+        title="Old Job",
+        company_name="Other Co",
+        apply_url="https://x/y",
+        description_md="x",
+        is_active=True,
+        fetched_at=datetime.now(UTC) - timedelta(days=20),
+    )
+    db_session.add(stale_eligible)
+    await db_session.commit()
+
+    mock_source = MagicMock()
+    mock_source.source_name = "greenhouse_board"
+    mock_source.search = AsyncMock(return_value=([make_job_data(external_id="acme-1")], None))
+
+    result = await job_sync_service.sync_profile(profile, db_session, sources=[mock_source])
+
+    # The new acme job should be inserted; the unrelated stale-eligible job
+    # must remain active (sync no longer touches staleness).
+    assert result["new_jobs"] == 1
+    assert result["stale_jobs"] == 0
+
+    refreshed = await db_session.execute(select(Job).where(Job.external_id == "stale-eligible-1"))
+    assert refreshed.scalar_one().is_active is True
+
+
+@pytest.mark.asyncio
 async def test_sync_profile_dedups_within_slug(db_session):
     """Same (title, company) returned twice from one slug is upserted once."""
     from app.models.user import User

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -186,6 +186,75 @@ async def test_sync_profile_with_slugs_has_no_warnings(db_session):
 
 
 @pytest.mark.asyncio
+async def test_sync_profile_surfaces_invalid_slug_errors(db_session):
+    """Issue #47: a typo'd or removed slug must show up as a structured warning
+    + a `failed_slugs` list, not silently produce 0 jobs."""
+    from app.models.user import User
+    from app.services.profile_service import get_or_create_profile
+    from app.sources.greenhouse_board import InvalidSlugError
+
+    user = User(id=uuid.uuid4(), email="badslug@test.com")
+    db_session.add(user)
+    await db_session.commit()
+
+    profile = await get_or_create_profile(user.id, db_session)
+    profile.target_company_slugs = {"greenhouse": ["good", "bad"]}
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+
+    async def fake_search(query, location, slug=None, **kwargs):
+        if slug == "bad":
+            raise InvalidSlugError(slug, "not found")
+        return [make_job_data(external_id=f"job-{slug}")], None
+
+    mock_source = MagicMock()
+    mock_source.source_name = "greenhouse_board"
+    mock_source.search = AsyncMock(side_effect=fake_search)
+
+    result = await job_sync_service.sync_profile(profile, db_session, sources=[mock_source])
+
+    assert result["new_jobs"] == 1, "the good slug should have been upserted"
+    assert "slug_fetch_errors" in result.get("warnings", [])
+    failed = result.get("failed_slugs", [])
+    assert any(f.get("slug") == "bad" and f.get("kind") == "invalid" for f in failed), (
+        f"Expected failed_slugs to include the invalid 'bad' slug; got {failed}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_profile_surfaces_transient_fetch_errors(db_session):
+    """5xx / network errors are reported as transient (retry next sync), distinguished
+    from permanent invalid slugs (#47)."""
+    from app.models.user import User
+    from app.services.profile_service import get_or_create_profile
+    from app.sources.greenhouse_board import TransientFetchError
+
+    user = User(id=uuid.uuid4(), email="transient@test.com")
+    db_session.add(user)
+    await db_session.commit()
+
+    profile = await get_or_create_profile(user.id, db_session)
+    profile.target_company_slugs = {"greenhouse": ["flaky"]}
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+
+    async def fake_search(query, location, slug=None, **kwargs):
+        raise TransientFetchError(slug, "503 upstream")
+
+    mock_source = MagicMock()
+    mock_source.source_name = "greenhouse_board"
+    mock_source.search = AsyncMock(side_effect=fake_search)
+
+    result = await job_sync_service.sync_profile(profile, db_session, sources=[mock_source])
+
+    failed = result.get("failed_slugs", [])
+    assert any(f.get("slug") == "flaky" and f.get("kind") == "transient" for f in failed)
+    assert "slug_fetch_errors" in result.get("warnings", [])
+
+
+@pytest.mark.asyncio
 async def test_sync_profile_dedups_within_slug(db_session):
     """Same (title, company) returned twice from one slug is upserted once."""
     from app.models.user import User

--- a/tests/integration/test_match_scoring.py
+++ b/tests/integration/test_match_scoring.py
@@ -152,6 +152,52 @@ async def test_list_applications_ordering(db_session):
 
 
 @pytest.mark.asyncio
+async def test_score_and_match_does_not_persist_none_scores(db_session):
+    """Issue #46: scoring failures (rate limits, quota) should NOT poison the
+    pool. When matching_agent returns score=None, score_and_match must leave
+    match_score NULL so the Application is re-eligible on the next sync."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.agents.matching_agent import ScoreResult
+
+    profile = await _seed_profile(db_session)
+    job = await _seed_job(db_session, title="Will fail to score")
+
+    # Patch the matching graph to return a "scoring skipped" ScoreResult
+    # (score=None) instead of a real LLM-derived score.
+    fake_graph = AsyncMock()
+
+    async def fake_ainvoke(state, config=None):
+        app_id = state["jobs"][0]["application_id"]
+        return {
+            "scores": [
+                ScoreResult(
+                    application_id=app_id,
+                    score=None,
+                    rationale="Skipped: API rate limit exceeded after retries",
+                    strengths=[],
+                    gaps=[],
+                )
+            ]
+        }
+
+    fake_graph.ainvoke = fake_ainvoke
+
+    with patch("app.agents.matching_agent.build_graph", return_value=fake_graph):
+        await score_and_match(profile, db_session, jobs=[job])
+
+    result = await db_session.execute(
+        select(Application).where(Application.profile_id == profile.id)
+    )
+    apps = result.scalars().all()
+    assert len(apps) == 1
+    # Failed-scoring rows must not be marked auto_rejected; match_score stays None
+    # so the next sync's matched_ids filter does NOT exclude this Application.
+    assert apps[0].match_score is None
+    assert apps[0].status != "auto_rejected"
+
+
+@pytest.mark.asyncio
 async def test_score_and_match_picks_unscored_jobs_when_pool_is_largely_scored(db_session):
     """
     Issue #45: matching used to LIMIT before filtering out already-scored jobs,

--- a/tests/integration/test_match_scoring.py
+++ b/tests/integration/test_match_scoring.py
@@ -152,6 +152,62 @@ async def test_list_applications_ordering(db_session):
 
 
 @pytest.mark.asyncio
+async def test_score_and_match_picks_unscored_jobs_when_pool_is_largely_scored(db_session):
+    """
+    Issue #45: matching used to LIMIT before filtering out already-scored jobs,
+    so once 20 jobs were scored every subsequent run yielded 0 fresh candidates.
+
+    Seed more jobs than the batch limit, pre-score the first batch, and assert
+    that score_and_match still finds the unscored ones.
+    """
+    from app.config import get_settings
+
+    settings = get_settings()
+    batch = settings.matching_jobs_per_batch  # default 20
+    extra = 5
+
+    profile = await _seed_profile(db_session)
+
+    # First `batch` jobs: pre-create scored Applications so they appear in matched_ids.
+    pre_scored_jobs = [await _seed_job(db_session, title=f"Pre-scored {i}") for i in range(batch)]
+    for j in pre_scored_jobs:
+        db_session.add(
+            Application(
+                job_id=j.id,
+                profile_id=profile.id,
+                match_score=0.8,
+                match_rationale="seeded",
+            )
+        )
+    await db_session.commit()
+
+    # Next `extra` jobs: unscored, must be picked up.
+    fresh_jobs = [await _seed_job(db_session, title=f"Fresh {i}") for i in range(extra)]
+    fresh_ids = {j.id for j in fresh_jobs}
+
+    responses = [
+        '{"score": 0.85, "rationale": "Good", "strengths": ["Python"], "gaps": []}'
+    ] * extra
+    with patch_llm("app.agents.matching_agent", responses):
+        await score_and_match(profile, db_session)
+
+    result = await db_session.execute(
+        select(Application).where(
+            Application.profile_id == profile.id,
+            Application.match_rationale != "seeded",
+        )
+    )
+    new_apps = result.scalars().all()
+    new_job_ids = {a.job_id for a in new_apps}
+
+    assert new_job_ids == fresh_ids, (
+        f"Expected the {extra} fresh jobs to be scored, "
+        f"but got {len(new_job_ids)} new applications. "
+        "The LIMIT is being applied before the matched_ids filter."
+    )
+
+
+@pytest.mark.asyncio
 async def test_list_applications_returns_job_data(db_session):
     """list_applications returns (Application, Job) tuples — no N+1 queries needed."""
     profile = await _seed_profile(db_session)

--- a/tests/unit/test_greenhouse_board_source.py
+++ b/tests/unit/test_greenhouse_board_source.py
@@ -139,6 +139,47 @@ async def test_greenhouse_board_connection_error_raises_transient():
 
 
 @pytest.mark.asyncio
+async def test_greenhouse_board_converts_html_content_to_markdown():
+    """Issue #51: Greenhouse `content` is HTML; we should store Markdown so the
+    field name matches reality and the matching LLM doesn't waste tokens on tags."""
+    source = GreenhouseBoardSource()
+
+    fixture = {
+        "jobs": [
+            {
+                "id": 4000010,
+                "title": "Backend Engineer",
+                "location": {"name": "Remote"},
+                "content": (
+                    "<h1>About the role</h1>"
+                    "<p>You will <strong>scale</strong> our systems.</p>"
+                    "<ul><li>Python</li><li>Postgres</li></ul>"
+                ),
+                "absolute_url": "https://boards.greenhouse.io/stripe/jobs/4000010",
+                "updated_at": "2026-04-01T10:00:00Z",
+            }
+        ]
+    }
+
+    with respx.mock:
+        respx.get(f"{GREENHOUSE_BOARDS_BASE}/stripe/jobs").mock(
+            return_value=httpx.Response(200, json=fixture)
+        )
+        jobs, _ = await source.search("", None, slug="stripe")
+
+    assert len(jobs) == 1
+    desc = jobs[0].description_md or ""
+    assert "<p>" not in desc
+    assert "<h1>" not in desc
+    assert "<li>" not in desc
+    assert "<strong>" not in desc
+    # Plain content should still be present
+    assert "About the role" in desc
+    assert "Python" in desc
+    assert "Postgres" in desc
+
+
+@pytest.mark.asyncio
 async def test_greenhouse_board_5xx_raises_transient():
     """5xx from Greenhouse is transient — distinguish from 404 (#47)."""
     from app.sources.greenhouse_board import TransientFetchError

--- a/tests/unit/test_greenhouse_board_source.py
+++ b/tests/unit/test_greenhouse_board_source.py
@@ -72,15 +72,17 @@ async def test_greenhouse_board_two_slugs_called_independently():
 
 
 @pytest.mark.asyncio
-async def test_greenhouse_board_404_returns_empty():
+async def test_greenhouse_board_404_raises_invalid_slug():
+    """404 from Greenhouse means the slug doesn't exist — surface this so the
+    caller can warn the user (issue #47). Previously silently returned []."""
+    from app.sources.greenhouse_board import InvalidSlugError
+
     source = GreenhouseBoardSource()
 
     with respx.mock:
         respx.get(f"{GREENHOUSE_BOARDS_BASE}/bad-slug/jobs").mock(return_value=httpx.Response(404))
-        jobs, cursor = await source.search("", None, slug="bad-slug")
-
-    assert jobs == []
-    assert cursor is None
+        with pytest.raises(InvalidSlugError):
+            await source.search("", None, slug="bad-slug")
 
 
 @pytest.mark.asyncio
@@ -122,14 +124,30 @@ async def test_greenhouse_board_remote_location():
 
 
 @pytest.mark.asyncio
-async def test_greenhouse_board_connection_error_returns_empty():
+async def test_greenhouse_board_connection_error_raises_transient():
+    """Network errors are transient — surface so the caller can retry next sync (#47)."""
+    from app.sources.greenhouse_board import TransientFetchError
+
     source = GreenhouseBoardSource()
 
     with respx.mock:
         respx.get(f"{GREENHOUSE_BOARDS_BASE}/bad-slug/jobs").mock(
             side_effect=httpx.ConnectError("connection refused")
         )
-        jobs, cursor = await source.search("", None, slug="bad-slug")
+        with pytest.raises(TransientFetchError):
+            await source.search("", None, slug="bad-slug")
 
-    assert jobs == []
-    assert cursor is None
+
+@pytest.mark.asyncio
+async def test_greenhouse_board_5xx_raises_transient():
+    """5xx from Greenhouse is transient — distinguish from 404 (#47)."""
+    from app.sources.greenhouse_board import TransientFetchError
+
+    source = GreenhouseBoardSource()
+
+    with respx.mock:
+        respx.get(f"{GREENHOUSE_BOARDS_BASE}/stripe/jobs").mock(
+            return_value=httpx.Response(503, text="service unavailable")
+        )
+        with pytest.raises(TransientFetchError):
+            await source.search("", None, slug="stripe")


### PR DESCRIPTION
## Summary

After PR #44 unstuck onboarding/slugs, a deeper review of the sync code surfaced 8 logical gaps. This PR closes all of them. One commit per issue so they can be reviewed/cherry-picked independently.

| # | Severity | What changed |
|---|---|---|
| #45 | 🔴 High | `score_and_match` no longer plateaus at 20 matches — push not-in-matched_ids into SQL + add ORDER BY |
| #46 | 🟠 Med-high | rate-limited/quota-skipped scores no longer poison the pool — `score=None` retries on next sync |
| #47 | 🟠 Med | slug 404s and 5xx now raise `InvalidSlugError`/`TransientFetchError` and surface as `failed_slugs` + `warnings` |
| #48 | 🟡 Med | cron now aggregates warnings generically as `total_warnings: dict[str, int]` |
| #49 | 🟡 Med | drop redundant `mark_stale_jobs` call from `sync_profile` (lived in `run_daily_maintenance` already) — fixes multi-profile flapping |
| #50 | 🟢 Low | document `auto_rejected` status in the model |
| #51 | 🟢 Low | convert Greenhouse HTML descriptions to Markdown at parse time using `markdownify` (already a dep) |
| #52 | 🟡 Med | post-sync refetch window: poll matches every 5s for 60s after a sync click so freshly scored jobs surface without manual reload |

## Test plan

- [x] `uv run pytest tests/unit tests/integration` — 155 passed
- [x] `cd frontend && npm test` — 33 passed
- [x] `uv run ruff check app/ tests/` — clean
- [x] All 13 modified Python files pass `ruff format --check`
- [x] New tests added per fix:
  - `test_score_and_match_picks_unscored_jobs_when_pool_is_largely_scored` (#45)
  - `test_score_and_match_does_not_persist_none_scores` (#46)
  - `test_greenhouse_board_404_raises_invalid_slug`, `test_greenhouse_board_5xx_raises_transient`, `test_sync_profile_surfaces_invalid_slug_errors`, `test_sync_profile_surfaces_transient_fetch_errors` (#47)
  - cron summary now asserts `total_warnings: dict` shape (#48)
  - `test_sync_profile_does_not_mark_jobs_stale` (#49)
  - `test_greenhouse_board_converts_html_content_to_markdown` (#51)
  - `refetchInterval.test.ts` (#52)
- [x] No production schema changes; safe to deploy without a migration window.

## Notable design choices

- **`ScoreResult.score: float | None`** instead of a separate `match_status` column (issue #46 option A). Avoids a migration and keeps the contract minimal. If we later want per-row failure analytics, a column upgrade is cheap.
- **#49 leaves `stale_jobs` in the result dict** as a hard 0 instead of removing the field — keeps the API shape stable for any downstream consumer.
- **#52 uses a function `refetchInterval`** so React Query re-evaluates per tick. Setting it once at mount would have ignored the post-sync state change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)