### PR TITLE
fix(db): repair two stale-connection bugs against Neon (cron 500s + chat empty stream)

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -31,6 +31,12 @@ def get_engine():
             echo=settings.environment == "development",
             pool_size=5,
             max_overflow=2,
+            # Cloud Run idles between requests; Neon's pooler closes idle
+            # connections from its side. Without pre_ping the next checkout
+            # hands out a dead conn → InterfaceError("connection is closed").
+            # pool_recycle is a backstop in case pre_ping ever races.
+            pool_pre_ping=True,
+            pool_recycle=1800,
             connect_args=connect_args,
         )
     return engine


### PR DESCRIPTION
## Summary
- Adds `pool_pre_ping=True` and `pool_recycle=1800` to the SQLAlchemy async engine.
- Fixes intermittent 500s in cron endpoints (`/internal/cron/process-match-queue`, `/internal/cron/process-sync-queue`, `/internal/cron/generation-queue`) caused by `asyncpg.exceptions._base.InterfaceError: connection is closed`.
- Same root cause behind the `/api/status` 500s visible in Cloud Run logs.

## Why
Cloud Run instances idle between requests; Neon's pooler kills idle TCP connections from its side. Without `pool_pre_ping`, SQLAlchemy hands the dead connection out on the next request, which 500s on the first query. `pre_ping` issues a cheap probe (`SELECT 1`) before checkout and transparently replaces dead connections. `pool_recycle=1800` is a belt-and-suspenders backstop.

Evidence in cron run [25099056126](https://github.com/maksym-panibrat/job-application-agent/actions/runs/25099056126) (`process-match-queue` HTTP 500) — Cloud Run stderr shows:
```
asyncpg.exceptions._base.InterfaceError: connection is closed
```
…raised inside `match_queue_service.next_batch` while opening a transaction on a checked-out-but-dead pool connection.

## Test plan
- [x] `uv run ruff check app/database.py`
- [x] `uv run pytest tests/integration/` — 100 passed
- [ ] After deploy: confirm next several `process-match-queue` / `process-sync-queue` / `generation-queue` cron runs return 200
- [ ] No new InterfaceError("connection is closed") entries in Cloud Run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)