### PR TITLE
fix(checkpointer): use AsyncConnectionPool with check so dead Neon conns get replaced

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -89,8 +89,9 @@ async def lifespan(app: FastAPI):
     # Init LangGraph checkpointer (psycopg v3, separate pool from SQLAlchemy asyncpg)
     psycopg_uri = str(settings.database_url).replace("+asyncpg", "")
     # setup() runs CREATE INDEX CONCURRENTLY which cannot run inside a pipeline,
-    # so we run it once on a plain connection before opening the pipeline saver.
+    # so we run it once on a plain connection before opening the runtime pool.
     from psycopg.errors import DuplicateTable
+    from psycopg_pool import AsyncConnectionPool
 
     async with AsyncPostgresSaver.from_conn_string(psycopg_uri) as setup_checkpointer:
         try:
@@ -98,8 +99,20 @@ async def lifespan(app: FastAPI):
         except DuplicateTable:
             pass  # checkpoint tables already exist from a previous deploy
         # all other exceptions propagate and fail lifespan — loud failure at startup
-    async with AsyncPostgresSaver.from_conn_string(psycopg_uri, pipeline=True) as checkpointer:
-        app.state.checkpointer = checkpointer
+
+    # Use a connection pool with check_connection so dead connections (Neon's
+    # idle timeout closes them while a Cloud Run instance is dormant) are
+    # replaced transparently. Without this, every chat request after ~5min idle
+    # fails with psycopg.OperationalError("the connection is closed") for the
+    # remaining lifetime of the instance.
+    async with AsyncConnectionPool(
+        psycopg_uri,
+        min_size=1,
+        max_size=4,
+        open=False,
+        check=AsyncConnectionPool.check_connection,
+    ) as pool:
+        app.state.checkpointer = AsyncPostgresSaver(pool)
         await log.ainfo("checkpointer.ready")
 
         yield


### PR DESCRIPTION
## Summary
Re-ships the checkpointer fix that was missed when PR #58 was squash-merged: only the SQLAlchemy `pool_pre_ping` commit landed; this LangGraph-checkpointer commit was on the same branch but never attached to the PR.

## What's broken in prod
Chat returns `200` with an empty SSE stream because `graph.astream` raises on the first checkpointer cursor:
```
psycopg.OperationalError: the connection is closed
  File "app/api/chat.py", line 71, in stream_response
    async for chunk in graph.astream(...)
  File ".../langgraph/checkpoint/postgres/aio.py", line 197, in aget_tuple
    async with self._cursor() as cur:
```
Confirmed on revision `api-00055-pc4` at 19:20:26, 19:20:57, …, 20:11:59, 20:17:18 UTC. Initial failure also surfaces as `consuming input failed: SSL connection has been closed unexpectedly` — Neon dropping a long-lived TCP conn.

## Why
The checkpointer is opened once in `lifespan` with `AsyncPostgresSaver.from_conn_string(..., pipeline=True)` — a single long-lived `psycopg.AsyncConnection`. Cloud Run instances live for hours; Neon's pooler closes idle conns after a few minutes. Once that happens, the cached connection is permanently dead and every chat from that instance fails until the instance is recycled.

## Fix
Replace the single `AsyncConnection` runtime saver with an `AsyncConnectionPool` whose `check=AsyncConnectionPool.check_connection` callback runs `SELECT 1` on every checkout (psycopg's equivalent of SQLAlchemy `pool_pre_ping`). Dead connections raise on the probe, the pool catches via `_getconn_with_check_loop`, discards, and hands out a fresh one. Pipeline mode is dropped — it's incompatible with pooled checkout (each call may get a different conn).

## Test plan
- [x] `uv run ruff check app/main.py`
- [x] `uv run pytest tests/integration/test_onboarding_agent.py tests/e2e/test_chat_flow.py -v` — 8 passed
- [ ] After deploy: `POST /api/chat/messages` returns content (not blank) on a Cloud Run instance that's been idle >5 min
- [ ] No new `psycopg.OperationalError: the connection is closed` from `chat.py:71` in Cloud Run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)