### PR TITLE
fix(sync): auto-prune invalid Greenhouse slugs from profile

### DIFF
--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -4,8 +4,10 @@ The actual fetch happens in app.scheduler.tasks.run_sync_queue.
 The actual matching happens in app.scheduler.tasks.run_match_queue.
 This function:
   1. Seeds 5 default slugs if profile has none.
-  2. Enqueues every stale (last_fetched_at NULL or > 6h old) slug for background fetch.
-  3. Scores up to `matching_jobs_per_batch` already-cached, slug-scoped, unscored jobs
+  2. Drops any slug whose SlugFetch row is is_invalid=True (the source of
+     the "We removed X" banner — backend now matches the UI promise).
+  3. Enqueues every stale (last_fetched_at NULL or > 6h old) slug for background fetch.
+  4. Scores up to `matching_jobs_per_batch` already-cached, slug-scoped, unscored jobs
      so the user sees something immediately.
 """
 
@@ -13,8 +15,10 @@ from datetime import UTC, datetime
 
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from app.config import get_settings
+from app.models.slug_fetch import SlugFetch
 from app.models.user_profile import UserProfile
 from app.services import match_service, slug_registry_service
 from app.services.profile_service import seed_defaults_if_empty
@@ -22,11 +26,46 @@ from app.services.profile_service import seed_defaults_if_empty
 log = structlog.get_logger()
 
 
+async def _prune_invalid_slugs(profile: UserProfile, session: AsyncSession) -> list[str]:
+    """Drop greenhouse slugs marked is_invalid=True from the profile. Returns
+    the list of removed slugs (sorted, possibly empty). Caller commits."""
+    user_slugs = (profile.target_company_slugs or {}).get("greenhouse") or []
+    if not user_slugs:
+        return []
+    rows = (
+        (
+            await session.execute(
+                select(SlugFetch).where(
+                    SlugFetch.source == "greenhouse_board",
+                    SlugFetch.slug.in_(user_slugs),
+                    SlugFetch.is_invalid.is_(True),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    invalid = {r.slug for r in rows}
+    if not invalid:
+        return []
+    cleaned = [s for s in user_slugs if s not in invalid]
+    profile.target_company_slugs = {
+        **(profile.target_company_slugs or {}),
+        "greenhouse": cleaned,
+    }
+    session.add(profile)
+    return sorted(invalid)
+
+
 async def sync_profile(profile: UserProfile, session: AsyncSession) -> dict:
     settings = get_settings()
     seeded = seed_defaults_if_empty(profile)
     if seeded:
         session.add(profile)
+        await session.commit()
+
+    pruned = await _prune_invalid_slugs(profile, session)
+    if pruned:
         await session.commit()
 
     queued = await slug_registry_service.enqueue_stale(profile, session, ttl_hours=6)
@@ -38,6 +77,7 @@ async def sync_profile(profile: UserProfile, session: AsyncSession) -> dict:
         "queued_slugs": queued,
         "matched_now": len(matched),
         "seeded_defaults": seeded,
+        "pruned_slugs": pruned,
     }
     profile.last_sync_requested_at = datetime.now(UTC)
     profile.last_sync_summary = summary

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -92,6 +92,33 @@ async def test_sync_profile_returns_202_shape_and_enqueues_stale_slugs(db_sessio
 
 
 @pytest.mark.asyncio
+async def test_sync_profile_prunes_invalid_slugs_from_profile(db_session):
+    """sync_profile removes slugs from profile.target_company_slugs.greenhouse
+    when their SlugFetch row is marked is_invalid=True. The banner that says
+    "we removed [slugs]" was lying — this test pins the new behaviour."""
+    from app.models.slug_fetch import SlugFetch
+    from app.models.user import User
+    from app.services.profile_service import get_or_create_profile
+
+    user = User(id=uuid.uuid4(), email="t@t.com")
+    db_session.add(user)
+    await db_session.commit()
+    profile = await get_or_create_profile(user.id, db_session)
+    profile.target_company_slugs = {"greenhouse": ["airbnb", "deadcorp", "stripe"]}
+    db_session.add(profile)
+    db_session.add(SlugFetch(source="greenhouse_board", slug="deadcorp", is_invalid=True))
+    await db_session.commit()
+    await db_session.refresh(profile)
+
+    result = await job_sync_service.sync_profile(profile, db_session)
+
+    assert result["pruned_slugs"] == ["deadcorp"]
+    assert "deadcorp" not in result["queued_slugs"]
+    await db_session.refresh(profile)
+    assert profile.target_company_slugs["greenhouse"] == ["airbnb", "stripe"]
+
+
+@pytest.mark.asyncio
 async def test_sync_profile_seeds_defaults_when_empty(db_session):
     from app.models.user import User
     from app.services.profile_service import get_or_create_profile


### PR DESCRIPTION
## Summary
The frontend banner has been promising "We removed [slugs] — Greenhouse no longer has boards for them" since [feat(ui): show notice for auto-pruned invalid slugs](../commit/644044f). The backend never actually removed them. This makes the promise true.

## What was broken
Every writer of \`profile.target_company_slugs\` (onboarding agent, \`PATCH /api/profile\`, \`seed_defaults_if_empty\`) **replaces or grows** the list — none filter against \`SlugFetch.is_invalid\`. Result:
- Invalid slugs sit in the profile forever.
- Each \`/api/sync/status\` poll re-discovers them as invalid (via \`SlugFetch.is_invalid=True\`) → banner shows.
- \`Dismiss\` is purely client-side state → re-mounts on refresh → banner reappears.

Verified by \`grep -rn "target_company_slugs\\s*=" app/\` — only two assignments, both unconditional rewrites.

## Fix
\`sync_profile\` now runs a small \`_prune_invalid_slugs\` step between \`seed_defaults_if_empty\` and \`enqueue_stale\`:
1. Reads the user's greenhouse slug list.
2. Joins against \`SlugFetch\` for any rows with \`is_invalid=True\`.
3. Filters those out of \`profile.target_company_slugs.greenhouse\`, persists.
4. Returns the removed list as \`pruned_slugs\` in the sync response.

The banner self-clears on the next \`/api/sync/status\` poll because the pruned slugs are no longer in \`user_slugs\` → \`invalid_slugs\` is empty for them.

## Why this is safe
\`slug_registry_service\` flips \`is_invalid=True\` only after **2 consecutive 404s** with transient errors deliberately not counted (\`slug_registry_service.py:163\`). So a single Greenhouse 5xx blip can't cost a user their slugs.

## Test plan
- [x] \`uv run ruff format && ruff check\`
- [x] \`uv run pytest tests/integration/ tests/unit/\` — 216 passed
- [x] New test \`test_sync_profile_prunes_invalid_slugs_from_profile\` pins the behaviour
- [ ] After deploy: hit \`POST /api/jobs/sync\` with a profile containing an invalid slug; verify it disappears from \`GET /api/profile\` and \`GET /api/sync/status::invalid_slugs\` no longer lists it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)