### PR TITLE
perf(match): triple drain rate via */5 cron + 0.5s throttle

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 */6 * * *'      # bulk-enqueue stale slugs
     - cron: '*/10 * * * *'     # generation queue (existing)
     - cron: '0 3 * * *'        # daily maintenance (existing)
-    - cron: '*/15 * * * *'     # process sync + match queues (new)
+    - cron: '*/5 * * * *'      # process sync + match queues
   workflow_dispatch:
 
 jobs:
@@ -64,7 +64,7 @@ jobs:
           [ "$code" -lt 400 ] || exit 1
 
   process-sync-queue:
-    if: github.event.schedule == '*/15 * * * *' || github.event_name == 'workflow_dispatch'
+    if: github.event.schedule == '*/5 * * * *' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger sync queue drain
@@ -82,7 +82,7 @@ jobs:
           [ "$code" -lt 400 ] || exit 1
 
   process-match-queue:
-    if: github.event.schedule == '*/15 * * * *' || github.event_name == 'workflow_dispatch'
+    if: github.event.schedule == '*/5 * * * *' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger match queue drain

--- a/app/agents/matching_agent.py
+++ b/app/agents/matching_agent.py
@@ -146,7 +146,7 @@ def build_graph() -> StateGraph:
             if backoff:
                 await asyncio.sleep(backoff)
             async with semaphore:
-                await asyncio.sleep(1.5)  # throttle: ~2 req/s per slot
+                await asyncio.sleep(0.5)  # throttle: ~6 req/s per slot
                 try:
                     result = await safe_ainvoke(
                         llm, [HumanMessage(content=prompt)], config=run_config


### PR DESCRIPTION
## Summary
The match queue was draining at ~30-60 jobs/hour while syncs add ~300 at a time, leading to "Scoring 303 jobs" sitting visibly stuck for hours. This bumps the drain rate to ~120-180 jobs/hour.

## Two-knob change
- \`.github/workflows/cron.yml\`: \`*/15\` → \`*/5\` for the \`process-{sync,match}-queue\` jobs.
- \`app/agents/matching_agent.py\`: per-job throttle \`1.5s\` → \`0.5s\`.

## Capacity math
Per-job time after change: \`0.5s throttle + ~5s LLM + DB ops ≈ 5.5s\`.

Batch size stays at 30 → run takes \`~165s\`, comfortably inside the existing \`deadline_seconds=240\` and Cloud Run's 300s request timeout. Cannot bump \`batch_size\` higher without crossing 300s.

Theoretical \`*/5\` = 12 firings/hour × 30 = 360 jobs/hour; realistic with GH cron drops/lag ≈ 120-180/hour. A 303-job backlog now drains in <2 hours instead of 5-10.

## Concurrency
\`run_match_queue\` uses \`FOR UPDATE SKIP LOCKED\` in \`match_queue_service.next_batch\`, so overlapping invocations (possible at \`*/5\` if a prior run is still going) safely partition rows.

## Quota safety
Gemini free-tier RPM = 60. Our semaphore is single-slot by default and the dominant per-job latency is the LLM call itself (~5s), so steady-state RPM stays well under quota. The existing 10s/30s exponential-backoff retry on 429 is the safety net.

## Test plan
- [x] \`uv run ruff check app/agents/matching_agent.py\`
- [x] \`uv run pytest tests/integration/test_match_scoring.py tests/integration/test_match_queue.py tests/integration/test_match_queue_cron.py\` — 17 passed
- [ ] After merge: confirm \`cron.process_match_queue.completed\` events appear ~every 5-10 min in Cloud Run logs
- [ ] Confirm \`matches_pending\` count in \`/api/sync/status\` decreases visibly during a backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)