### PR TITLE
fix(smoke): soft-pass step 10 cleanup on 429

### DIFF
--- a/scripts/smoke/golden_path.py
+++ b/scripts/smoke/golden_path.py
@@ -847,6 +847,18 @@ async def step10_cleanup(
     if verbose:
         _verbose_log(label, "PATCH", url, r.status_code, body)
 
+    # /api/profile PATCH is rate-limited to 5/hr/user in prod
+    # (app/api/profile.py). Several deploys in <1 hr will trip this on the
+    # idempotent teardown — accept it as soft-pass rather than fail the whole
+    # smoke run. Step 4's round-trip assertion is what guards the real
+    # behaviour; this step only resets state for the next run.
+    if r.status_code == 429:
+        return True, {
+            "step": 10,
+            "teardown": "skipped — rate-limited (5/hr); next smoke run will reset",
+            "soft_pass": True,
+        }
+
     if r.status_code not in (200, 204):
         return False, {
             "step": 10,


### PR DESCRIPTION
## Summary
After this morning's three back-to-back merges (#59, #60, #61 deployed within ~10 min) the third smoke-prod failed at step 10 with HTTP 429 — masking the fact that all 7 functional steps and 5 xfails passed.

## Root cause
\`PATCH /api/profile\` is rate-limited to **5 requests/hr/user** in prod (\`app/api/profile.py:80\`). The smoke script makes 2 PATCHes per run (step 4 update + step 10 idempotent reset), so any time main gets >2 deploys within an hour the cleanup PATCH trips the limit:

\`\`\`
[step10_cleanup] PATCH /api/profile
  HTTP 429
  {"detail": "Rate limit exceeded"}
\`\`\`

The rate limit is doing its job — bumping it would weaken a real-user protection.

## Fix
Treat 429 specifically in step 10 as a **soft-pass with a note**. Step 4 (the round-trip assertion) stays strict — it has to fail loudly if PATCH is actually broken. Step 10 is best-effort teardown: a missed reset just means the next smoke run sees \`full_name="Smoke User CI"\` instead of \`"Smoke Test"\`, which step 4 immediately overwrites.

## Test plan
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] After merge: next smoke-prod with rate budget remaining should still report 200 + \`teardown: full_name reset...\`
- [ ] After merge: a smoke-prod run that follows a rapid deploy chain should now report \`soft_pass: true\` for step 10 and the overall job should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)