### PR TITLE
fix(profile): bump PATCH rate limit 5/hr → 30/hr

### DIFF
--- a/app/api/profile.py
+++ b/app/api/profile.py
@@ -77,9 +77,12 @@ async def update_profile(
     settings: Settings = Depends(get_settings),
 ):
     if settings.environment == "production":
+        # 30/hr — abuse cap, not a usability cap. The previous 5/hr was hostile to
+        # real users (typo edits hit it) and reliably broke smoke-prod whenever
+        # >2 deploys landed within an hour (smoke makes 2 PATCHes per run).
         await check_rate_limit(
             key=f"profile_edit:{profile.user_id}",
-            limit=5,
+            limit=30,
             window_seconds=3600,
             session=session,
         )


### PR DESCRIPTION
## Summary
PR #62 soft-passed step 10 (cleanup) on 429 but kept step 4 (the actual round-trip assertion) strict. The very next CI run on main hit 429 at **step 4** because four deploys in one hour × 2 PATCHes per run = 8 attempts vs the 5/hr cap. We can't soft-pass step 4 without losing the assertion. The right fix is to widen the cap.

## Why 5/hr was wrong
- Hostile to real users: editing a profile to fix typos a few times in a session would hit the wall.
- Hostile to operator activity: smoke-prod is expected to PATCH every deploy.
- Doesn't actually deter abuse: a bot doesn't care whether the wall is at 5, 30, or 60.

## Why 30/hr is right
- Abuse cap, not usability cap. A human user literally cannot type into a form fast enough to exhaust 30 in an hour.
- Smoke makes 2 PATCHes/run → 15 deploys/hr would be needed to exhaust the new cap; CI peaks at ~3-4.
- A real bot at 30/hr is still throttled enough to be useless and obvious in logs.

## Test plan
- [x] \`uv run ruff check\`
- [x] \`uv run pytest tests/integration/test_rate_limit_service.py\` — 7 passed
- [ ] After merge: smoke-prod on the next deploy returns 200 at both step 4 and step 10
- [ ] No accidental escape (still gated on \`environment == "production"\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)