### PR TITLE
fix(sync): bulk cron uses sync_profile so it actually prunes invalid slugs

### DIFF
--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -16,27 +16,32 @@ log = structlog.get_logger()
 
 
 async def run_job_sync() -> dict:
-    """Bulk-enqueue stale slugs for every active profile. The actual fetch
-    happens in run_sync_queue; this is just the scheduled "wake up and sweep" pass."""
+    """Bulk-sync every active profile via sync_profile (same path the user
+    triggers from the UI). The actual fetch happens in run_sync_queue; this
+    is the scheduled "wake up, prune dead slugs, enqueue stale ones, score
+    cached jobs" sweep."""
     from app.database import get_session_factory
     from app.models.user_profile import UserProfile
-    from app.services import slug_registry_service
+    from app.services.job_sync_service import sync_profile
 
     factory = get_session_factory()
     profiles_enqueued = 0
     slugs_enqueued = 0
+    slugs_pruned = 0
     async with factory() as session:
         result = await session.execute(
             select(UserProfile).where(UserProfile.search_active.is_(True))
         )
         for profile in result.scalars().all():
-            queued = await slug_registry_service.enqueue_stale(profile, session, ttl_hours=6)
-            if queued:
+            summary = await sync_profile(profile, session)
+            if summary["queued_slugs"]:
                 profiles_enqueued += 1
-                slugs_enqueued += len(queued)
+                slugs_enqueued += len(summary["queued_slugs"])
+            slugs_pruned += len(summary.get("pruned_slugs", []))
     return {
         "profiles_enqueued": profiles_enqueued,
         "slugs_enqueued": slugs_enqueued,
+        "slugs_pruned": slugs_pruned,
     }
 
 

--- a/tests/integration/test_sync_queue_cron.py
+++ b/tests/integration/test_sync_queue_cron.py
@@ -90,6 +90,26 @@ async def test_run_job_sync_bulk_enqueues_for_active_profiles(db_session):
 
 
 @pytest.mark.asyncio
+async def test_run_job_sync_prunes_invalid_slugs_for_active_profiles(db_session):
+    """The 6h /internal/cron/sync now also prunes is_invalid=True slugs from
+    each active profile (closes the gap where prune only ran on user-initiated
+    sync, never on the cron sweep)."""
+    from app.models.slug_fetch import SlugFetch
+    from app.scheduler.tasks import run_job_sync
+
+    profile = await _seed_profile(db_session, "airbnb", "deadcorp", "stripe")
+    db_session.add(SlugFetch(source="greenhouse_board", slug="deadcorp", is_invalid=True))
+    await db_session.commit()
+
+    summary = await run_job_sync()
+
+    assert summary["slugs_pruned"] == 1
+    db_session.expire_all()
+    await db_session.refresh(profile)
+    assert profile.target_company_slugs["greenhouse"] == ["airbnb", "stripe"]
+
+
+@pytest.mark.asyncio
 async def test_run_sync_queue_marks_invalid_after_2_404s(db_session):
     profile = await _seed_profile(db_session, "openai")
     await slug_registry_service.enqueue_stale(profile, db_session, ttl_hours=6)


### PR DESCRIPTION
## Summary
PR #60 added invalid-slug auto-prune to \`sync_profile\`. The \`0 */6 * * *\` bulk cron (\`run_job_sync\` in \`app/scheduler/tasks.py\`) called \`slug_registry_service.enqueue_stale\` directly and never went through \`sync_profile\` — so the prune step never ran from the cron path. Users only got their invalid slugs cleaned up if they manually clicked "Sync jobs" in the UI.

This PR closes that gap: \`run_job_sync\` now calls \`sync_profile\` per active profile and aggregates the summaries. Same end-to-end behaviour the user-triggered sync produces, but for every active profile every 6 hours.

The returned summary now also includes \`slugs_pruned\` so the cron logs make the cleanup observable.

## Test plan
- [x] \`uv run ruff check\` clean
- [x] New test \`test_run_job_sync_prunes_invalid_slugs_for_active_profiles\` pins the behaviour (red → green)
- [x] Existing \`test_run_job_sync_bulk_enqueues_for_active_profiles\` still passes (the enqueue path is unchanged in shape)
- [x] \`uv run pytest tests/integration/ tests/unit/\` — 217 passed
- [ ] After deploy: next \`0 */6 * * *\` cron run logs \`cron.sync.completed\` with \`slugs_pruned\` > 0 for affected profiles, and stale banners self-clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)