### PR TITLE
perf(match): concurrency 2→8, batch 30→100 (within-run drain ~13×)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     langsmith_project: str = "job-application-agent"
     job_stale_after_days: int = 21
     log_level: str = "INFO"
-    matching_max_concurrency: int = 2
+    matching_max_concurrency: int = 8
     matching_jobs_per_batch: int = 20
 
     cors_allowed_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -230,7 +230,7 @@ async def run_sync_queue(*, max_slugs: int = 64, deadline_seconds: int = 240) ->
     return {**counts, "remaining": remaining}
 
 
-async def run_match_queue(*, batch_size: int = 30, deadline_seconds: int = 240) -> dict:
+async def run_match_queue(*, batch_size: int = 100, deadline_seconds: int = 240) -> dict:
     """Drain pending_match applications. One LangGraph batch per profile per tick
     (the agent fans out internally). Per-tick deadline keeps us under Cloud Run's
     300s wall."""


### PR DESCRIPTION
## Summary
PR #61 (\`*/5\` cron + 0.5s throttle) moved the needle but the queue still drains too slowly because LLM latency dominates per-job time and we were only running 2 in parallel.

## Phase-1 evidence
From prod cron logs (\`api-00056\`+):
- \`cron.process_match_queue.completed\` shows \`duration_ms ≈ 187,000\` for 30 jobs.
- Per-job effective time ≈ **12.5s** (the LLM call is dominant; the 0.5s throttle is ~4%).
- \`matching_max_concurrency = 2\` → only 2 \`safe_ainvoke\` calls in flight per run.
- GH cron actually delivered ~1 process-match-queue run/hour (3 in last 2.5 h vs 30 expected from \`*/5\`). GH-side; not fixable from our code.

## Lever
Bump within-run knobs:
- \`matching_max_concurrency\`: 2 → 8
- \`run_match_queue.batch_size\` default: 30 → 100

\`100 jobs × 12.5s / 8 slots = ~156s\` — comfortably inside the 240s \`deadline_seconds\` and Cloud Run's 300s timeout.

## Effect
| | before | after |
|---|---|---|
| jobs/run | 30 | 100 |
| within-run throughput | 2 slots × 12.5s | 8 slots × 12.5s |
| effective drain (1 run/hr) | ~30/hr | ~100/hr |
| time to clear 303 | ~10 hr | ~3 hr |

## Quota check (Gemini 2.5 Flash)
8 slots × (60s / 12.5s/job) = 38 effective RPM. Free tier = 60 RPM, so we stay under. Existing \`10s, 30s\` exponential backoff on 429 catches any burst overrun.

## Test plan
- [x] \`uv run ruff check\` clean
- [x] \`uv run pytest tests/integration/test_match_queue.py tests/integration/test_match_queue_cron.py tests/integration/test_match_scoring.py tests/unit/test_config.py\` — 19 passed
- [ ] After deploy: \`cron.process_match_queue.completed\` events show \`attempted=100, succeeded≈100, duration_ms\` < 240,000
- [ ] \`matches_pending\` in \`/api/sync/status\` drops visibly within minutes after a sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)