### PR TITLE
feat(matching): POST /api/profile/rematch endpoint

### DIFF
--- a/app/api/profile.py
+++ b/app/api/profile.py
@@ -11,7 +11,7 @@ from app.api.deps import get_current_profile
 from app.config import Settings, get_settings
 from app.database import get_db
 from app.models.user_profile import UserProfile
-from app.services import profile_service
+from app.services import match_service, profile_service
 from app.services.rate_limit_service import check_daily_quota, check_rate_limit
 
 log = structlog.get_logger()
@@ -155,6 +155,32 @@ async def upload_resume(
         "extraction_status": extraction_status,
         "message": "Resume uploaded successfully.",
     }
+
+
+@router.post("/rematch")
+async def rematch_profile(
+    profile: UserProfile = Depends(get_current_profile),
+    session: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    """Re-queue all eligible scored applications for re-scoring with the current
+    matching prompt. Eligible = status IN (pending_review, auto_rejected) AND
+    match_score IS NOT NULL. Dismissed/applied rows are user decisions and stay.
+
+    Use after a prompt iteration or scoring-rubric change. The match-queue cron
+    drains pending_match rows on its next tick (~5 min)."""
+    if settings.environment == "production":
+        # 6/hr — re-scoring N applications consumes N LLM calls and is the
+        # most expensive profile-scoped action. Lower than profile_edit (30/hr).
+        await check_rate_limit(
+            key=f"profile_rematch:{profile.user_id}",
+            limit=6,
+            window_seconds=3600,
+            session=session,
+        )
+    reset = await match_service.mark_for_rescore(profile.id, session)
+    await log.ainfo("profile.rematch", profile_id=str(profile.id), reset=reset)
+    return {"reset": reset}
 
 
 @router.patch("/search")

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import structlog
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -17,6 +18,39 @@ from app.models.user_profile import Skill, UserProfile, WorkExperience
 from app.services import profile_service
 
 log = structlog.get_logger()
+
+
+async def mark_for_rescore(profile_id: uuid.UUID, session: AsyncSession) -> int:
+    """Flip eligible scored applications back to pending_match so the cron re-scores
+    them with the current matching prompt. Returns the number of rows affected.
+
+    Eligibility: status IN ('pending_review', 'auto_rejected') AND match_score IS NOT NULL.
+    Leaves dismissed/applied (user decisions) and already-pending_match rows untouched.
+    """
+    now = datetime.now(UTC)
+    result = await session.execute(
+        update(Application)
+        .where(
+            Application.profile_id == profile_id,
+            Application.status.in_(("pending_review", "auto_rejected")),
+            Application.match_score.isnot(None),
+        )
+        .values(
+            match_status="pending_match",
+            match_queued_at=now,
+            match_claimed_at=None,
+            match_attempts=0,
+            match_score=None,
+            match_summary=None,
+            match_rationale=None,
+            match_strengths=[],
+            match_gaps=[],
+            status="pending_review",
+            updated_at=now,
+        )
+    )
+    await session.commit()
+    return result.rowcount or 0
 
 
 def format_profile_text(

--- a/tests/integration/test_profile_rematch.py
+++ b/tests/integration/test_profile_rematch.py
@@ -1,0 +1,173 @@
+"""POST /api/profile/rematch flips eligible apps back to pending_match for re-scoring."""
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from app.models.application import Application
+from app.models.job import Job
+from app.models.user import User
+from app.models.user_profile import UserProfile
+
+
+async def _make_job(db_session, external_id: str = None) -> Job:
+    job = Job(
+        source="greenhouse_board",
+        external_id=external_id or str(uuid.uuid4()),
+        title="Engineer",
+        company_name="Co",
+        apply_url="https://example.com/apply",
+        description_md="A role.",
+    )
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)
+    return job
+
+
+def _scored_app(job_id, profile_id, *, status: str) -> Application:
+    return Application(
+        job_id=job_id,
+        profile_id=profile_id,
+        status=status,
+        match_status="matched",
+        match_score=0.8,
+        match_summary="Old summary",
+        match_rationale="Old rationale",
+        match_strengths=["A"],
+        match_gaps=["B"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_rematch_resets_eligible_apps_only(db_session, auth_headers, seeded_user):
+    """Resets pending_review+scored and auto_rejected+scored.
+
+    Leaves dismissed/applied/queued untouched.
+    """
+    from app.main import app as fastapi_app
+
+    _user, profile = seeded_user
+
+    # Eligible: pending_review with a score
+    j1 = await _make_job(db_session, "rm-1")
+    a_pending = _scored_app(j1.id, profile.id, status="pending_review")
+    # Eligible: auto_rejected with a score
+    j2 = await _make_job(db_session, "rm-2")
+    a_rejected = _scored_app(j2.id, profile.id, status="auto_rejected")
+    # NOT eligible: dismissed (user decision)
+    j3 = await _make_job(db_session, "rm-3")
+    a_dismissed = _scored_app(j3.id, profile.id, status="dismissed")
+    # NOT eligible: applied (user decision)
+    j4 = await _make_job(db_session, "rm-4")
+    a_applied = _scored_app(j4.id, profile.id, status="applied")
+    # NOT eligible: still queued (no match_score)
+    j5 = await _make_job(db_session, "rm-5")
+    a_queued = Application(
+        job_id=j5.id,
+        profile_id=profile.id,
+        status="pending_review",
+        match_status="pending_match",
+        match_score=None,
+    )
+
+    db_session.add_all([a_pending, a_rejected, a_dismissed, a_applied, a_queued])
+    await db_session.commit()
+    for a in (a_pending, a_rejected, a_dismissed, a_applied, a_queued):
+        await db_session.refresh(a)
+    pending_id = a_pending.id
+    rejected_id = a_rejected.id
+    dismissed_id = a_dismissed.id
+    applied_id = a_applied.id
+    queued_id = a_queued.id
+
+    transport = ASGITransport(app=fastapi_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/profile/rematch", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["reset"] == 2  # only the two scored+pending/auto_rejected apps
+
+    # Verify state per app
+    for app_id, label in [(pending_id, "pending"), (rejected_id, "rejected")]:
+        app = (
+            await db_session.execute(select(Application).where(Application.id == app_id))
+        ).scalar_one()
+        await db_session.refresh(app)
+        assert app.match_status == "pending_match", f"{label}: match_status not reset"
+        assert app.match_score is None, f"{label}: match_score not cleared"
+        assert app.match_summary is None, f"{label}: summary not cleared"
+        assert app.match_rationale is None, f"{label}: rationale not cleared"
+        assert app.match_strengths == [], f"{label}: strengths not cleared"
+        assert app.match_gaps == [], f"{label}: gaps not cleared"
+        assert app.status == "pending_review", f"{label}: status not lifted to pending_review"
+        assert app.match_queued_at is not None, f"{label}: match_queued_at not set"
+
+    # Untouched apps
+    for app_id, expected_status in [
+        (dismissed_id, "dismissed"),
+        (applied_id, "applied"),
+    ]:
+        app = (
+            await db_session.execute(select(Application).where(Application.id == app_id))
+        ).scalar_one()
+        await db_session.refresh(app)
+        assert app.status == expected_status
+        assert app.match_status == "matched"  # unchanged
+        assert app.match_score == 0.8
+
+    # Already-queued unchanged
+    queued = (
+        await db_session.execute(select(Application).where(Application.id == queued_id))
+    ).scalar_one()
+    await db_session.refresh(queued)
+    assert queued.match_status == "pending_match"
+    assert queued.match_score is None  # was already None
+
+
+@pytest.mark.asyncio
+async def test_rematch_isolates_other_profiles(db_session, auth_headers, seeded_user):
+    """Caller's apps are reset; another user's apps are untouched."""
+    from app.main import app as fastapi_app
+
+    _user, profile = seeded_user
+
+    # Other user with their own scored app
+    other_user = User(id=uuid.uuid4(), email=f"other-{uuid.uuid4()}@test.com")
+    db_session.add(other_user)
+    await db_session.commit()
+    other_profile = UserProfile(user_id=other_user.id, email=other_user.email)
+    db_session.add(other_profile)
+    await db_session.commit()
+    await db_session.refresh(other_profile)
+
+    j_mine = await _make_job(db_session, "iso-mine")
+    j_theirs = await _make_job(db_session, "iso-theirs")
+    mine = _scored_app(j_mine.id, profile.id, status="pending_review")
+    theirs = _scored_app(j_theirs.id, other_profile.id, status="pending_review")
+    db_session.add_all([mine, theirs])
+    await db_session.commit()
+    await db_session.refresh(mine)
+    await db_session.refresh(theirs)
+    mine_id = mine.id
+    theirs_id = theirs.id
+
+    transport = ASGITransport(app=fastapi_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/profile/rematch", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["reset"] == 1  # only mine
+
+    mine_after = (
+        await db_session.execute(select(Application).where(Application.id == mine_id))
+    ).scalar_one()
+    theirs_after = (
+        await db_session.execute(select(Application).where(Application.id == theirs_id))
+    ).scalar_one()
+    await db_session.refresh(mine_after)
+    await db_session.refresh(theirs_after)
+    assert mine_after.match_status == "pending_match"
+    assert theirs_after.match_status == "matched"  # untouched
+    assert theirs_after.match_score == 0.8


### PR DESCRIPTION
## Summary

Adds a profile-scoped rematch trigger so a user (or the dev/test loop) can re-score their already-matched applications after a prompt iteration without manual SQL.

- New service: \`match_service.mark_for_rescore(profile_id, session) -> int\` — single \`UPDATE\` over eligible rows.
- New endpoint: \`POST /api/profile/rematch\` (auth-gated, profile-scoped, rate-limited 6/hr in prod).
- Eligibility: \`status IN ('pending_review', 'auto_rejected') AND match_score IS NOT NULL\`. Lifts \`auto_rejected\` back to \`pending_review\` so the new prompt gets a fair chance.
- Untouched: \`dismissed\` / \`applied\` (user decisions) and already-\`pending_match\` (in flight).
- All match_* fields reset to NULL/empty so the audit trail clearly shows a fresh row.

## Why now

After PR #66 (matching-prompt redesign) merged, prod has ~3,800 jobs with new \`description_clean\` data and a new prompt structure — but already-matched applications still carry the OLD scores/summaries. Without this endpoint, re-scoring requires raw SQL against prod. After this lands, you POST once and the */5min match-queue cron picks them up.

## Test plan

- [x] \`tests/integration/test_profile_rematch.py\` — 2 tests pass:
  - \`test_rematch_resets_eligible_apps_only\` — verifies the eligibility filter (pending_review+scored ✅, auto_rejected+scored ✅, dismissed ❌, applied ❌, already-queued ❌)
  - \`test_rematch_isolates_other_profiles\` — caller's apps reset, other user's apps untouched
- [x] Full suite: 242 passed
- [x] ruff check + format clean

## Followup-after-merge

POST \`/api/profile/rematch\` from the test account; watch \`profile.rematch\` and \`match.scored\` log events as the cron drains the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)