### PR TITLE
feat(scripts): rematch_account.py helper for /api/profile/rematch

### DIFF
--- a/scripts/check_rematch_drained.py
+++ b/scripts/check_rematch_drained.py
@@ -1,0 +1,118 @@
+"""
+Verify a profile's rematch has fully drained.
+
+Reports:
+1. Count of applications still in pending_match (should be ~0).
+2. Count of applications scored in the last 60 minutes (should match the rematch size).
+3. 3 sample match_summary values to spot-check the new prompt's output.
+
+Usage:
+    PYTHONPATH=. uv run python scripts/check_rematch_drained.py [--email maksym@panibrat.com]
+"""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import text
+
+from app.database import get_session_factory
+
+DEFAULT_EMAIL = "maksym@panibrat.com"
+
+
+async def main(email: str) -> None:
+    factory = get_session_factory()
+    async with factory() as s:
+        row = (
+            await s.execute(
+                text("""
+                    SELECT p.id::text AS profile_id
+                    FROM user_profiles p
+                    JOIN users u ON u.id = p.user_id
+                    WHERE u.email = :email
+                """),
+                {"email": email},
+            )
+        ).fetchone()
+        if not row:
+            raise SystemExit(f"No profile for {email!r}")
+        pid = row.profile_id
+        print(f"Profile: {pid}  ({email})")
+        print()
+
+        pending = (
+            await s.execute(
+                text("""
+                    SELECT count(*) FROM applications
+                    WHERE profile_id = :pid AND match_status = 'pending_match'
+                """),
+                {"pid": pid},
+            )
+        ).scalar()
+        scored_recent = (
+            await s.execute(
+                text("""
+                    SELECT count(*) FROM applications
+                    WHERE profile_id = :pid
+                      AND match_score IS NOT NULL
+                      AND updated_at > now() - interval '60 minutes'
+                """),
+                {"pid": pid},
+            )
+        ).scalar()
+        scored_total = (
+            await s.execute(
+                text("""
+                    SELECT count(*) FROM applications
+                    WHERE profile_id = :pid AND match_score IS NOT NULL
+                """),
+                {"pid": pid},
+            )
+        ).scalar()
+        errored = (
+            await s.execute(
+                text("""
+                    SELECT count(*) FROM applications
+                    WHERE profile_id = :pid AND match_status = 'error'
+                """),
+                {"pid": pid},
+            )
+        ).scalar()
+
+        print("Queue state:")
+        print(f"  pending_match    : {pending}  (target: 0)")
+        print(f"  match_status=error : {errored}")
+        print(f"  scored in last hour: {scored_recent}")
+        print(f"  scored total       : {scored_total}")
+        print()
+
+        samples = (
+            await s.execute(
+                text("""
+                    SELECT match_score, match_summary, match_rationale, length(match_summary) AS len
+                    FROM applications
+                    WHERE profile_id = :pid
+                      AND match_summary IS NOT NULL
+                      AND updated_at > now() - interval '60 minutes'
+                    ORDER BY updated_at DESC
+                    LIMIT 3
+                """),
+                {"pid": pid},
+            )
+        ).fetchall()
+        print("Recent summaries (spot-check terseness — target ≤12 words):")
+        for sc, summ, rat, n in samples:
+            words = len(summ.split()) if summ else 0
+            print(f"  [{sc:.2f}] ({words}w/{n}c) {summ!r}")
+            print(f"        rationale: {rat!r}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--email", default=DEFAULT_EMAIL)
+    args = parser.parse_args()
+    asyncio.run(main(args.email))

--- a/scripts/rematch_account.py
+++ b/scripts/rematch_account.py
@@ -1,0 +1,89 @@
+"""
+One-shot helper to call POST /api/profile/rematch for a given account.
+
+Looks up the user by email, signs a short-lived JWT (90s) using JWT_SECRET
+from the same DATABASE_URL/.env the app uses, and posts to {host}/api/profile/rematch.
+Prints the response JSON (e.g. {"reset": 47}).
+
+Usage:
+    uv run python scripts/rematch_account.py \\
+        --host https://job-application-agent-XXX-uc.a.run.app \\
+        [--email maksym@panibrat.com]
+
+Defaults to the configured user's email; --host is required (varies per Cloud Run deploy).
+"""
+
+import argparse
+import asyncio
+import datetime
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import httpx
+import jwt
+from sqlmodel import select
+
+from app.config import get_settings
+from app.database import get_session_factory
+from app.models.user import User
+
+DEFAULT_EMAIL = "maksym@panibrat.com"
+
+
+async def lookup_user_id(email: str) -> str:
+    factory = get_session_factory()
+    async with factory() as s:
+        u = (await s.execute(select(User).where(User.email == email))).scalar_one_or_none()
+    if not u:
+        raise SystemExit(f"No user with email {email!r}")
+    return str(u.id)
+
+
+def sign_token(user_id: str, secret: str, ttl_seconds: int = 90) -> str:
+    now = datetime.datetime.now(datetime.UTC)
+    return jwt.encode(
+        {
+            "sub": user_id,
+            "aud": ["fastapi-users:auth"],
+            "iat": int(now.timestamp()),
+            "exp": int((now + datetime.timedelta(seconds=ttl_seconds)).timestamp()),
+        },
+        secret,
+        algorithm="HS256",
+    )
+
+
+async def main(host: str, email: str) -> None:
+    settings = get_settings()
+    secret = settings.jwt_secret.get_secret_value()
+    if secret == "dev-secret":
+        print(
+            "WARNING: jwt_secret is dev-secret — this will not authenticate against prod.",
+            file=sys.stderr,
+        )
+
+    user_id = await lookup_user_id(email)
+    token = sign_token(user_id, secret)
+
+    url = f"{host.rstrip('/')}/api/profile/rematch"
+    print(f"POST {url}  (user={email})")
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(url, headers={"Authorization": f"Bearer {token}"})
+    print(f"HTTP {resp.status_code}")
+    print(resp.text)
+    if resp.status_code >= 400:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", required=True, help="Base URL, e.g. https://...run.app")
+    parser.add_argument(
+        "--email",
+        default=DEFAULT_EMAIL,
+        help=f"Account email (default {DEFAULT_EMAIL})",
+    )
+    args = parser.parse_args()
+    asyncio.run(main(args.host, args.email))

--- a/scripts/rematch_account.py
+++ b/scripts/rematch_account.py
@@ -1,14 +1,19 @@
 """
 One-shot helper to call POST /api/profile/rematch for a given account.
 
-Looks up the user by email, signs a short-lived JWT (90s) using JWT_SECRET
-from the same DATABASE_URL/.env the app uses, and posts to {host}/api/profile/rematch.
-Prints the response JSON (e.g. {"reset": 47}).
+Looks up the user by email, signs a short-lived JWT (90s), and posts to
+{host}/api/profile/rematch. Prints the response JSON (e.g. {"reset": 47}).
 
-Usage:
-    uv run python scripts/rematch_account.py \\
-        --host https://job-application-agent-XXX-uc.a.run.app \\
-        [--email maksym@panibrat.com]
+CRITICAL — JWT_SECRET must match the deployed environment's secret, or
+prod returns 401 "Invalid token". Local .env typically holds a dev secret
+that prod will reject. Pass the prod secret explicitly:
+
+    JWT_SECRET=$(gcloud secrets versions access latest --secret=jwt-secret) \\
+        uv run python scripts/rematch_account.py \\
+            --host https://job-application-agent-XXX-uc.a.run.app \\
+            [--email maksym@panibrat.com]
+
+pydantic-settings prefers env vars over .env, so the inline JWT_SECRET wins.
 
 Defaults to the configured user's email; --host is required (varies per Cloud Run deploy).
 """
@@ -35,7 +40,11 @@ DEFAULT_EMAIL = "maksym@panibrat.com"
 async def lookup_user_id(email: str) -> str:
     factory = get_session_factory()
     async with factory() as s:
-        u = (await s.execute(select(User).where(User.email == email))).scalar_one_or_none()
+        # User has `oauth_accounts: list[...] = Relationship(lazy="joined")` in the
+        # model — the LEFT JOIN can yield multiple rows per user (one per oauth
+        # account), so .unique() must be called before scalar_one_or_none().
+        result = await s.execute(select(User).where(User.email == email))
+        u = result.unique().scalar_one_or_none()
     if not u:
         raise SystemExit(f"No user with email {email!r}")
     return str(u.id)
@@ -60,9 +69,13 @@ async def main(host: str, email: str) -> None:
     secret = settings.jwt_secret.get_secret_value()
     if secret == "dev-secret":
         print(
-            "WARNING: jwt_secret is dev-secret — this will not authenticate against prod.",
+            "ERROR: jwt_secret is the dev default — prod will reject the token.",
+            "Re-run with: JWT_SECRET=$(gcloud secrets versions access latest "
+            "--secret=jwt-secret) uv run python scripts/rematch_account.py ...",
+            sep="\n",
             file=sys.stderr,
         )
+        raise SystemExit(2)
 
     user_id = await lookup_user_id(email)
     token = sign_token(user_id, secret)


### PR DESCRIPTION
## Summary

Operational helper to invoke the rematch endpoint added in #67 without copying tokens out of the browser or hand-rolling SQL.

\`\`\`bash
uv run python scripts/rematch_account.py --host https://<prod-host>
# defaults --email to maksym@panibrat.com; override for other accounts
\`\`\`

What it does:
1. Looks up user by email via the configured DB
2. Signs a 90-second JWT using local \`JWT_SECRET\` (must match prod's)
3. POSTs to \`{host}/api/profile/rematch\`
4. Prints \`HTTP 200\` + \`{"reset": N}\`

Pattern mirrors \`scripts/make_smoke_token.py\` — same JWT shape (\`HS256\`, \`aud=fastapi-users:auth\`, \`sub=user_id\`) read via \`app.config\` settings.

## Why a script

After every prompt iteration we'll want to re-score the test account. Doing it via \`POST /api/profile/rematch\` means the cron handles the actual work, but signing/posting needs *some* glue. Browser-token-copy works once; a checked-in script is reusable.

## Test plan

- [x] \`ruff check\` clean
- [ ] Run against prod after #67 deploys to confirm 200 + non-zero \`reset\` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)