### PR TITLE
fix(cron): two 504-timeout regressions in /internal/cron/* (closes #70)

### DIFF
--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -33,7 +33,11 @@ async def run_job_sync() -> dict:
             select(UserProfile).where(UserProfile.search_active.is_(True))
         )
         for profile in result.scalars().all():
-            summary = await sync_profile(profile, session)
+            # score_cached_jobs=False: bulk cron must not synchronously LLM-score
+            # — Cloud Run's 300s wall vs. multi-profile fan-out caused the
+            # recurring HTTP 504 in /internal/cron/sync (issue #70). Matching
+            # is owned by run_match_queue.
+            summary = await sync_profile(profile, session, score_cached_jobs=False)
             if summary["queued_slugs"]:
                 profiles_enqueued += 1
                 slugs_enqueued += len(summary["queued_slugs"])
@@ -235,10 +239,23 @@ async def run_sync_queue(*, max_slugs: int = 64, deadline_seconds: int = 240) ->
     return {**counts, "remaining": remaining}
 
 
-async def run_match_queue(*, batch_size: int = 100, deadline_seconds: int = 240) -> dict:
+async def run_match_queue(
+    *,
+    batch_size: int = 100,
+    deadline_seconds: int = 240,
+    max_per_profile: int = 30,
+) -> dict:
     """Drain pending_match applications. One LangGraph batch per profile per tick
     (the agent fans out internally). Per-tick deadline keeps us under Cloud Run's
-    300s wall."""
+    300s wall.
+
+    `max_per_profile` caps how many jobs a single profile can own in one
+    score_and_match call. Without it, batch_size=100 concentrated on one
+    profile + slow Gemini latency can exceed the 240s deadline before any
+    inter-profile loop check runs (one-off HTTP 504 in
+    /internal/cron/process-match-queue, 2026-05-02). Apps over the cap stay
+    pending_match with claimed_at set; the 300s lease in next_batch makes
+    them re-eligible the tick after."""
     import time
 
     from app.database import get_session_factory
@@ -250,12 +267,12 @@ async def run_match_queue(*, batch_size: int = 100, deadline_seconds: int = 240)
 
     factory = get_session_factory()
     deadline = time.monotonic() + deadline_seconds
-    succeeded = failed = 0
+    succeeded = failed = deferred = 0
 
     async with factory() as session:
         batch = await match_queue_service.next_batch(session, limit=batch_size)
     if not batch:
-        return {"attempted": 0, "succeeded": 0, "failed": 0}
+        return {"attempted": 0, "succeeded": 0, "failed": 0, "deferred": 0}
     attempted = len(batch)
 
     # Group by profile_id; one LangGraph invocation per profile
@@ -265,13 +282,23 @@ async def run_match_queue(*, batch_size: int = 100, deadline_seconds: int = 240)
 
     for profile_id, apps in by_profile.items():
         if time.monotonic() > deadline:
-            break
+            deferred += len(apps)
+            continue
+        # Slice per-profile to bound one score_and_match call's wall time.
+        # Apps beyond the cap remain claimed (lease set by next_batch); they
+        # become re-eligible after the 300s lease expires (~next tick).
+        apps_this_tick = apps[:max_per_profile]
+        deferred += len(apps) - len(apps_this_tick)
         async with factory() as session:
             profile = (
                 await session.execute(select(UserProfile).where(UserProfile.id == profile_id))
             ).scalar_one()
             jobs = list(
-                (await session.execute(select(Job).where(Job.id.in_([a.job_id for a in apps]))))
+                (
+                    await session.execute(
+                        select(Job).where(Job.id.in_([a.job_id for a in apps_this_tick]))
+                    )
+                )
                 .scalars()
                 .all()
             )
@@ -280,12 +307,12 @@ async def run_match_queue(*, batch_size: int = 100, deadline_seconds: int = 240)
                 await score_and_match(profile, session, jobs=jobs)
             except Exception as exc:
                 await log.aexception("match_queue.batch_error", error=str(exc))
-                for a in apps:
+                for a in apps_this_tick:
                     await match_queue_service.mark_attempt_failed(a.id, session)
-                failed += len(apps)
+                failed += len(apps_this_tick)
                 continue
 
-            for a in apps:
+            for a in apps_this_tick:
                 # If it has a score now, mark done. If still no score (rate-limited),
                 # increment attempts; will retry next tick.
                 refreshed = (
@@ -298,4 +325,9 @@ async def run_match_queue(*, batch_size: int = 100, deadline_seconds: int = 240)
                     await match_queue_service.mark_attempt_failed(refreshed.id, session)
                     failed += 1
 
-    return {"attempted": attempted, "succeeded": succeeded, "failed": failed}
+    return {
+        "attempted": attempted,
+        "succeeded": succeeded,
+        "failed": failed,
+        "deferred": deferred,
+    }

--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -57,7 +57,20 @@ async def _prune_invalid_slugs(profile: UserProfile, session: AsyncSession) -> l
     return sorted(invalid)
 
 
-async def sync_profile(profile: UserProfile, session: AsyncSession) -> dict:
+async def sync_profile(
+    profile: UserProfile,
+    session: AsyncSession,
+    *,
+    score_cached_jobs: bool = True,
+) -> dict:
+    # `score_cached_jobs=True` is the user-triggered "instant feedback" path
+    # (POST /api/jobs/sync) — score up to N already-cached jobs synchronously
+    # so the UI has something to show before run_match_queue ticks.
+    # The 6h bulk cron must pass `False`: it has no UI to feed back to and
+    # runs across N profiles inside Cloud Run's 300s wall — synchronous LLM
+    # scoring there blew that budget (HTTP 504, issue #70 / regression in
+    # commit 191df6a). Matching for cron-discovered jobs is owned by
+    # run_match_queue (every 5min, deadline-bounded).
     settings = get_settings()
     seeded = seed_defaults_if_empty(profile)
     if seeded:
@@ -69,9 +82,12 @@ async def sync_profile(profile: UserProfile, session: AsyncSession) -> dict:
         await session.commit()
 
     queued = await slug_registry_service.enqueue_stale(profile, session, ttl_hours=6)
-    matched = await match_service.score_cached(
-        profile, session, cap=settings.matching_jobs_per_batch
-    )
+    if score_cached_jobs:
+        matched = await match_service.score_cached(
+            profile, session, cap=settings.matching_jobs_per_batch
+        )
+    else:
+        matched = []
 
     summary = {
         "queued_slugs": queued,

--- a/tests/integration/test_match_queue_cron.py
+++ b/tests/integration/test_match_queue_cron.py
@@ -79,3 +79,98 @@ async def test_run_match_queue_drains_pending(db_session):
     assert len(apps) == 1
     assert apps[0].match_status == "matched"
     assert apps[0].match_score == 0.9
+
+
+@pytest.mark.asyncio
+async def test_run_match_queue_caps_jobs_per_profile_per_tick(db_session):
+    """A single profile must not own more than `max_per_profile` jobs in one
+    score_and_match call. With batch_size=100 concentrated on one profile and
+    slow Gemini latency, a single LangGraph batch can exceed Cloud Run's 300s
+    wall (one-off HTTP 504 in /internal/cron/process-match-queue, 2026-05-02).
+    Unprocessed apps stay pending_match with claimed_at set; the 300s lease
+    in match_queue_service.next_batch makes them re-eligible next tick."""
+    profile = await _seed_profile(db_session, "airbnb")
+    profile_id = profile.id
+
+    # Seed 8 jobs + 8 pending_match Applications for the same profile
+    jobs = []
+    for i in range(8):
+        job = Job(
+            source="greenhouse_board",
+            external_id=f"cap-{i}",
+            title=f"Engineer {i}",
+            company_name=slug_to_company_name("airbnb"),
+            apply_url=f"https://x/{i}",
+            is_active=True,
+        )
+        db_session.add(job)
+        jobs.append(job)
+    await db_session.commit()
+    for j in jobs:
+        await db_session.refresh(j)
+        await match_queue_service.enqueue_for_interested_profiles(j, db_session)
+
+    fake_graph = MagicMock()
+
+    async def fake_invoke(state, config=None):
+        from app.agents.matching_agent import ScoreResult
+
+        # Stub: score every job that was sent into the graph (but only those)
+        return {
+            "scores": [
+                ScoreResult(
+                    application_id=jc["application_id"],
+                    score=0.9,
+                    summary="cap-test",
+                    rationale="cap-test",
+                    strengths=[],
+                    gaps=[],
+                )
+                for jc in state["jobs"]
+            ]
+        }
+
+    fake_graph.ainvoke = fake_invoke
+
+    with patch("app.agents.matching_agent.build_graph", return_value=fake_graph):
+        result = await run_match_queue(max_per_profile=5)
+
+    # Cap: only 5 of the 8 claimed apps were sent to score_and_match this tick.
+    # The other 3 stay pending_match with claimed_at set (300s lease).
+    assert result["attempted"] == 8, "all 8 were claimed by next_batch"
+    assert result["succeeded"] == 5, "exactly max_per_profile (5) were scored"
+    assert result["deferred"] == 3, "3 deferred to a later tick by the per-profile cap"
+
+    db_session.expire_all()
+    matched = (
+        (
+            await db_session.execute(
+                sa.select(Application).where(
+                    Application.profile_id == profile_id,
+                    Application.match_status == "matched",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    pending = (
+        (
+            await db_session.execute(
+                sa.select(Application).where(
+                    Application.profile_id == profile_id,
+                    Application.match_status == "pending_match",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(matched) == 5
+    assert len(pending) == 3
+    # Deferred apps must remain claimed (claimed_at set) so the next tick's
+    # next_batch call doesn't re-claim them inside the 300s lease window.
+    for app in pending:
+        assert app.match_claimed_at is not None, (
+            "deferred apps must remain claimed for the 300s lease window"
+        )

--- a/tests/integration/test_sync_queue_cron.py
+++ b/tests/integration/test_sync_queue_cron.py
@@ -90,6 +90,51 @@ async def test_run_job_sync_bulk_enqueues_for_active_profiles(db_session):
 
 
 @pytest.mark.asyncio
+async def test_run_job_sync_does_not_synchronously_score_cached_jobs(db_session):
+    """The 6h /internal/cron/sync must NOT call score_cached. Bulk cron has no UI
+    to give "instant feedback" to and runs against N profiles inside Cloud Run's
+    300s wall — synchronous LLM scoring blew that budget (HTTP 504, issue #70).
+    score_and_match belongs in run_match_queue (every 5min, deadline-bounded)."""
+    from app.scheduler.tasks import run_job_sync
+
+    profile = await _seed_profile(db_session, "airbnb")
+    profile_id = profile.id
+    job = Job(
+        source="greenhouse_board",
+        external_id="9001",
+        title="Backend Engineer",
+        company_name=slug_to_company_name("airbnb"),
+        apply_url="https://boards.greenhouse.io/airbnb/jobs/9001",
+        description_clean="job",
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    summary = await run_job_sync()
+
+    # Cron pass should enqueue the slug but not score the cached job.
+    assert summary["slugs_enqueued"] == 1
+    # `run_job_sync` commits via a separate session; drop in-memory cache so we
+    # re-read the worker-committed state.
+    db_session.expire_all()
+    scores = (
+        (
+            await db_session.execute(
+                sa.select(Application.match_score).where(Application.profile_id == profile_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # Either zero Application rows (score_cached never ran, so never created one),
+    # or rows exist with match_score=None. Both prove no LLM scoring happened.
+    assert all(s is None for s in scores), (
+        f"run_job_sync invoked synchronous LLM scoring (match_scores={scores!r}); "
+        "this is the regression that caused the recurring 504 in /internal/cron/sync."
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_job_sync_prunes_invalid_slugs_for_active_profiles(db_session):
     """The 6h /internal/cron/sync now also prunes is_invalid=True slugs from
     each active profile (closes the gap where prune only ran on user-initiated


### PR DESCRIPTION
## Summary

Two distinct cron HTTP 504s observed since 2026-05-02 — different surfaces, same root-cause class: synchronous LLM work × Cloud Run 300s wall.

- **`/internal/cron/sync`** (recurring every 6h, 6 alerts on #70): regression from PR #64 (commit `191df6a`). `run_job_sync` was switched to `sync_profile` to enable invalid-slug pruning, but `sync_profile` also calls `match_service.score_cached` — the user-triggered "instant feedback" LLM path. With N profiles × cached unscored jobs × 429 backoffs, every 6-hour tick blew the 300s budget. Add `score_cached_jobs: bool = True` keyword-only flag; cron passes `False`, HTTP user path keeps default `True`. Pruning still runs from cron.

- **`/internal/cron/process-match-queue`** (one-off 504 on 2026-05-02 21:38): `batch_size=100` concentrated on a single profile + slow Gemini latency can make one `score_and_match` call exceed the 240s deadline before any inter-profile check runs (deadline is between profiles, not within one). Add `max_per_profile: int = 30` to `run_match_queue` — slice per profile, defer the rest. Apps over the cap stay `pending_match` with `claimed_at` set; the 300s lease in `next_batch` re-eligibles them the tick after. Result dict gains `deferred` so `attempted == succeeded + failed + deferred`.

Both fixes follow TDD: failing tests written first, both demonstrably fail on prior code with clear evidence (`match_scores=[0.75]` for sync; `TypeError: unexpected keyword argument 'max_per_profile'` for the cap).

## Test plan

- [x] `uv run pytest tests/integration/test_sync_queue_cron.py tests/integration/test_match_queue_cron.py` — 7/7 pass (5 existing + 2 new)
- [x] `uv run pytest tests/integration/` — 112/112 pass
- [x] `uv run pytest tests/unit/` — 132/132 pass
- [x] `uv run ruff check` + `ruff format --check` on touched files clean
- [ ] After merge: watch the next `0 */6 * * *` Cron run on main (00:00 UTC) — should succeed in <30s like the fast-path runs prior to PR #64
- [ ] After merge: confirm issue #70 stops getting alert-on-failure comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)