### PR TITLE
fix(llm): recognize google-genai 429 RESOURCE_EXHAUSTED as BudgetExhausted

### DIFF
--- a/app/agents/llm_safe.py
+++ b/app/agents/llm_safe.py
@@ -42,8 +42,17 @@ async def safe_ainvoke(
         return await model.ainvoke(messages, **kwargs)
     except Exception as exc:
         exc_str = str(exc)
-        is_budget_exhausted = isinstance(exc, GaxResourceExhausted) or (
-            "429" in exc_str and "quota" in exc_str.lower()
+        # langchain-google-genai (new google-genai SDK) raises
+        # ChatGoogleGenerativeAIError(... 429 RESOURCE_EXHAUSTED ... credits
+        # are depleted ...) — the literal word "quota" is absent. Match on
+        # the canonical RESOURCE_EXHAUSTED status string so prepayment-credit
+        # depletion falls through the same graceful BudgetExhausted path as
+        # the legacy google-api-core ResourceExhausted.
+        exc_lower = exc_str.lower()
+        is_budget_exhausted = (
+            isinstance(exc, GaxResourceExhausted)
+            or "resource_exhausted" in exc_lower
+            or ("429" in exc_str and "quota" in exc_lower)
         )
         if is_budget_exhausted:
             resumes_at = _next_month_utc()

--- a/tests/unit/test_safe_ainvoke.py
+++ b/tests/unit/test_safe_ainvoke.py
@@ -41,6 +41,28 @@ async def test_safe_ainvoke_raises_budget_exhausted_on_429_quota_string():
 
 
 @pytest.mark.asyncio
+async def test_safe_ainvoke_raises_budget_exhausted_on_genai_resource_exhausted():
+    """google-genai SDK / langchain-google-genai wrapped 429 RESOURCE_EXHAUSTED
+    must also map to BudgetExhausted. Real prod message lacks the literal word
+    "quota" — it says "Your prepayment credits are depleted" — so the older
+    "429 + quota" predicate misses it. Caught in prod via Cloud Error Reporting
+    when chat endpoint returned generic "Stream error" instead of a graceful
+    budget-exhausted UX (smoke step 7, 2026-05-04)."""
+    msg = (
+        "Error calling model 'gemini-2.5-pro' (RESOURCE_EXHAUSTED): "
+        "429 RESOURCE_EXHAUSTED. {'error': {'code': 429, 'message': "
+        "'Your prepayment credits are depleted. Please go to AI Studio "
+        "at https://ai.studio/projects to manage your project and billing.', "
+        "'status': 'RESOURCE_EXHAUSTED'}}"
+    )
+    model = MagicMock()
+    model.ainvoke = AsyncMock(side_effect=Exception(msg))
+
+    with pytest.raises(BudgetExhausted):
+        await safe_ainvoke(model, ["msg"])
+
+
+@pytest.mark.asyncio
 async def test_safe_ainvoke_propagates_non_quota_exceptions():
     """Non-quota exceptions propagate unchanged."""
     model = MagicMock()


### PR DESCRIPTION
## Summary

Surfaced via Cloud Error Reporting on 2026-05-04 after prod Gemini prepayment credits depleted. Chat returned generic SSE `Stream error` instead of the graceful budget-exhausted UX, and `run_match_queue` silently marked all pending matches as failed (3 attempts → `match_status="error"`).

**Root cause:** `safe_ainvoke`'s predicate matched only the legacy `google.api_core.exceptions.ResourceExhausted` class or the substring pair `429 + quota`. The new google-genai SDK / langchain-google-genai wrapper raises `ChatGoogleGenerativeAIError(... 429 RESOURCE_EXHAUSTED ... credits are depleted ...)` — neither isinstance nor `quota` matches (the message says "credits are depleted", not "quota").

**Fix:** also match `"resource_exhausted" in exc_str.lower()` — the canonical Google API status string, present in every shape of this error across both SDKs. Now `BudgetExhausted` is raised consistently → UI banner + match-queue graceful skip both work.

## Important: this does NOT unblock smoke step 7

Smoke step 7 (`POST /api/chat/messages`) is currently failing in prod because **Gemini prepayment credits are depleted**. The smoke test asserts a successful `content` chunk; only a billing top-up at https://ai.studio/projects can produce that. After top-up, smoke will pass on the next CI run.

This PR's value: the *next* time credits hit zero, users see a meaningful "budget exhausted" banner instead of a generic stream error, and the match queue degrades gracefully instead of marking everything failed.

## Test plan

- [x] `uv run pytest tests/unit/test_safe_ainvoke.py` — 6/6 pass (5 existing + 1 new with real prod exception string)
- [x] `uv run pytest tests/unit/ tests/integration/` — 245/245 pass
- [x] Lint + format clean on touched files
- [ ] After billing top-up: re-run smoke job to confirm step 7 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)