### PR TITLE
fix(budget): graceful BudgetExhausted UX in chat + match-queue (re #74)

### DIFF
--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -65,6 +65,8 @@ async def send_message(
     }
 
     async def stream_response():
+        from app.agents.llm_safe import BudgetExhausted
+
         try:
             from langchain_core.messages import AIMessageChunk
 
@@ -89,6 +91,13 @@ async def send_message(
                             text += block.get("text", "")
                 if text:
                     yield f"data: {json.dumps({'content': text})}\n\n"
+        except BudgetExhausted as exc:
+            # Gemini quota / prepayment credits depleted. Surface a structured
+            # event with the resumption timestamp so the UI can render a
+            # meaningful banner instead of an opaque "Stream error" (#74).
+            await log.awarning("chat.budget_exhausted", resumes_at=exc.resumes_at.isoformat())
+            payload = {"error": "budget_exhausted", "resumes_at": exc.resumes_at.isoformat()}
+            yield f"data: {json.dumps(payload)}\n\n"
         except Exception as e:
             await log.aexception("chat.stream_error", error=str(e))
             yield f"data: {json.dumps({'error': 'Stream error'})}\n\n"

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -258,6 +258,7 @@ async def run_match_queue(
     them re-eligible the tick after."""
     import time
 
+    from app.agents.llm_safe import BudgetExhausted
     from app.database import get_session_factory
     from app.models.application import Application
     from app.models.job import Job
@@ -268,11 +269,18 @@ async def run_match_queue(
     factory = get_session_factory()
     deadline = time.monotonic() + deadline_seconds
     succeeded = failed = deferred = 0
+    budget_exhausted = False
 
     async with factory() as session:
         batch = await match_queue_service.next_batch(session, limit=batch_size)
     if not batch:
-        return {"attempted": 0, "succeeded": 0, "failed": 0, "deferred": 0}
+        return {
+            "attempted": 0,
+            "succeeded": 0,
+            "failed": 0,
+            "deferred": 0,
+            "budget_exhausted": False,
+        }
     attempted = len(batch)
 
     # Group by profile_id; one LangGraph invocation per profile
@@ -305,6 +313,23 @@ async def run_match_queue(
 
             try:
                 await score_and_match(profile, session, jobs=jobs)
+            except BudgetExhausted as exc:
+                # Gemini quota gone — not the app's fault. Release leases so
+                # the next tick re-claims naturally once budget restores.
+                # DO NOT increment attempts (that's for real failures and
+                # accumulates toward match_status='error', which silently
+                # discards perfectly good pending matches during a brief
+                # credit outage — see #74).
+                await log.awarning(
+                    "match_queue.budget_exhausted",
+                    resumes_at=exc.resumes_at.isoformat(),
+                    apps_released=len(apps_this_tick),
+                )
+                budget_exhausted = True
+                for a in apps_this_tick:
+                    await match_queue_service.release_claim(a.id, session)
+                # No point trying remaining profiles — same Gemini, same outcome.
+                break
             except Exception as exc:
                 await log.aexception("match_queue.batch_error", error=str(exc))
                 for a in apps_this_tick:
@@ -330,4 +355,5 @@ async def run_match_queue(
         "succeeded": succeeded,
         "failed": failed,
         "deferred": deferred,
+        "budget_exhausted": budget_exhausted,
     }

--- a/app/services/match_queue_service.py
+++ b/app/services/match_queue_service.py
@@ -118,6 +118,20 @@ async def mark_attempt_failed(application_id: uuid.UUID, session: AsyncSession) 
     await session.commit()
 
 
+async def release_claim(application_id: uuid.UUID, session: AsyncSession) -> None:
+    """Clear the lease without incrementing attempts.
+
+    Used when scoring failed for a reason that's not the app's fault — e.g.
+    BudgetExhausted (Gemini quota gone). The app stays pending_match and
+    becomes eligible for the next tick to re-claim once the underlying issue
+    resolves. Contrast with `mark_attempt_failed` which increments attempts
+    and after MAX_ATTEMPTS flips the app to status='error'."""
+    result = await session.execute(select(Application).where(Application.id == application_id))
+    app = result.scalar_one()
+    app.match_claimed_at = None
+    await session.commit()
+
+
 async def pending_count(session: AsyncSession, profile_id: uuid.UUID | None = None) -> int:
     from sqlalchemy import func
 

--- a/tests/e2e/test_chat_flow.py
+++ b/tests/e2e/test_chat_flow.py
@@ -61,6 +61,66 @@ async def test_chat_empty_message_rejected(test_app):
 
 
 @pytest.mark.asyncio
+async def test_chat_emits_structured_budget_exhausted_event(test_app):
+    """When the onboarding graph hits BudgetExhausted (Gemini quota / prepayment
+    credits depleted), chat must emit a structured SSE event with the resumption
+    timestamp — not the generic 'Stream error' that hides the cause from users.
+
+    Regression: see #74. Before the fix, chat.py:92 caught BudgetExhausted in
+    its `except Exception` catch-all and yielded {'error': 'Stream error'},
+    which the UI showed as an opaque failure (smoke step 7 trace, 2026-05-04)."""
+    from datetime import UTC, datetime
+    from unittest.mock import MagicMock, patch
+
+    from app.agents.llm_safe import BudgetExhausted
+
+    await test_app.get("/api/profile")
+
+    resumes_at = datetime(2026, 6, 1, tzinfo=UTC)
+
+    async def boom(*args, **kwargs):
+        raise BudgetExhausted(resumes_at)
+        # Make the function an async generator so `async for chunk in graph.astream(...)`
+        # is valid syntax against this mock.
+        yield  # pragma: no cover
+
+    fake_graph = MagicMock()
+    fake_graph.astream = boom
+
+    from app.main import app as fastapi_app
+
+    # Fixture doesn't run lifespan, so checkpointer is unset. Inject a non-None
+    # placeholder for the duration of this test so chat.py takes the real graph
+    # path, then restore (avoid leaking into other tests).
+    prev_checkpointer = getattr(fastapi_app.state, "checkpointer", None)
+    fastapi_app.state.checkpointer = MagicMock()
+    try:
+        with patch("app.agents.onboarding.build_graph", return_value=fake_graph):
+            async with test_app.stream(
+                "POST",
+                "/api/chat/messages",
+                json={"message": "anything"},
+            ) as resp:
+                assert resp.status_code == 200
+                events = []
+                async for line in resp.aiter_lines():
+                    if line.startswith("data: "):
+                        data = line[6:]
+                        if data == "[DONE]":
+                            break
+                        events.append(json.loads(data))
+    finally:
+        fastapi_app.state.checkpointer = prev_checkpointer
+
+    error_events = [e for e in events if "error" in e]
+    assert error_events, f"expected at least one error event, got {events}"
+    assert error_events[0]["error"] == "budget_exhausted", (
+        f"expected structured budget_exhausted event, got {error_events[0]}"
+    )
+    assert error_events[0]["resumes_at"] == resumes_at.isoformat()
+
+
+@pytest.mark.asyncio
 async def test_chat_session_persists_across_messages(test_app):
     """
     Two messages to the same profile thread accumulate in the checkpointed state.

--- a/tests/integration/test_match_queue_cron.py
+++ b/tests/integration/test_match_queue_cron.py
@@ -82,6 +82,71 @@ async def test_run_match_queue_drains_pending(db_session):
 
 
 @pytest.mark.asyncio
+async def test_run_match_queue_releases_leases_without_failing_attempts_on_budget(db_session):
+    """When score_and_match raises BudgetExhausted (Gemini quota gone), the
+    match queue must NOT mark every claimed app as failed. That's how a brief
+    credit outage silently moves perfectly good pending_match apps to
+    match_status='error' (#74). Instead: clear claimed_at to release the lease,
+    leave attempts unchanged. Next tick re-claims naturally once budget restores."""
+    from datetime import UTC, datetime
+
+    from app.agents.llm_safe import BudgetExhausted
+
+    profile = await _seed_profile(db_session, "airbnb")
+    profile_id = profile.id
+
+    jobs = []
+    for i in range(3):
+        job = Job(
+            source="greenhouse_board",
+            external_id=f"budget-{i}",
+            title=f"Engineer {i}",
+            company_name=slug_to_company_name("airbnb"),
+            apply_url=f"https://x/{i}",
+            is_active=True,
+        )
+        db_session.add(job)
+        jobs.append(job)
+    await db_session.commit()
+    for j in jobs:
+        await db_session.refresh(j)
+        await match_queue_service.enqueue_for_interested_profiles(j, db_session)
+
+    resumes_at = datetime(2026, 6, 1, tzinfo=UTC)
+
+    async def _raise_budget(*args, **kwargs):
+        raise BudgetExhausted(resumes_at)
+
+    with patch("app.services.match_service.score_and_match", side_effect=_raise_budget):
+        result = await run_match_queue()
+
+    db_session.expire_all()
+    apps = (
+        (
+            await db_session.execute(
+                sa.select(Application).where(Application.profile_id == profile_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(apps) == 3
+    for app in apps:
+        assert app.match_status == "pending_match", (
+            f"budget-exhausted apps must NOT flip to error: status={app.match_status}"
+        )
+        assert app.match_attempts == 0, (
+            f"budget exhausted is not the app's fault — attempts must not increment: "
+            f"attempts={app.match_attempts}"
+        )
+        assert app.match_claimed_at is None, "lease must be released so next tick re-claims"
+
+    assert result.get("budget_exhausted") is True, (
+        f"result must surface budget_exhausted flag, got {result}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_match_queue_caps_jobs_per_profile_per_tick(db_session):
     """A single profile must not own more than `max_per_profile` jobs in one
     score_and_match call. With batch_size=100 concentrated on one profile and


### PR DESCRIPTION
## Summary

Closes the half-shipped BudgetExhausted UX from PR #73. Two consumers were still ignoring the signal:

1. **`app/api/chat.py:92`** — `except Exception` swallowed `BudgetExhausted` and yielded a generic `{'error': 'Stream error'}` SSE event. Now catches it separately and emits `{'error': 'budget_exhausted', 'resumes_at': ISO8601}` so the UI can render a meaningful banner.

2. **`run_match_queue`** — the per-app post-processing loop treated \`score=None\` identically regardless of cause. A brief credit outage thus silently moved every claimed \`pending_match\` app to \`match_status='error'\` after 3 attempts (every tick = +1 attempt while budget gone). Now: catches \`BudgetExhausted\`, calls new \`release_claim\` (clears \`match_claimed_at\` without touching attempts), breaks out of the per-profile loop, surfaces \`budget_exhausted: bool\` in the result dict.

## Why bother now (we're not budget-exhausted)

Without this, the next credit outage repeats the data damage from 2026-05-04: legitimate pending matches silently disappear into \`match_status='error'\` and won't auto-recover. The chat UX bug is also user-visible.

## Test plan

- [x] \`uv run pytest\` — 256/256 pass (5 new lines of behaviour covered by 2 new tests, written before implementation per TDD)
- [x] Lint + format clean
- [ ] Post-merge: deploy job runs; smoke-prod step 6 (cron sync) and step 7 (chat) should both PASS
- [ ] No new alert-on-failure comments on the persistent cron tracking issue

## Note: 'Re #74' not 'Closes #74'

This PR is the code part of #74 but I'm intentionally NOT auto-closing — keeping the convention discussion in #78 alive (\`closes\` keyword on cron-related PRs auto-closes the persistent tracking issue, which then gets re-created with a new number on the next cron failure → churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)