### PR TITLE
feat(ops): scripts/recover_error_matches.py + service helpers (re #75)

### DIFF
--- a/app/services/match_queue_service.py
+++ b/app/services/match_queue_service.py
@@ -118,6 +118,88 @@ async def mark_attempt_failed(application_id: uuid.UUID, session: AsyncSession) 
     await session.commit()
 
 
+async def audit_error_apps(
+    session: AsyncSession,
+    *,
+    since: datetime | None = None,
+    profile_id: uuid.UUID | None = None,
+) -> list[dict]:
+    """Count Application rows in match_status='error', grouped by profile_id.
+
+    Used for one-off recovery after incidents that wrongly drove apps to
+    'error' (e.g. the 2026-05-04 Gemini credit depletion: while the new
+    BudgetExhausted graceful path wasn't yet deployed, every match_queue tick
+    incremented attempts on every claimed app; after 3 attempts → error).
+
+    `since` filters by Application.created_at; passing None counts all.
+    """
+    from sqlalchemy import func
+
+    q = select(
+        Application.profile_id,
+        func.count(Application.id).label("count"),
+        func.min(Application.created_at).label("oldest"),
+        func.max(Application.created_at).label("newest"),
+    ).where(Application.match_status == "error")
+    if since is not None:
+        q = q.where(Application.created_at >= since)
+    if profile_id is not None:
+        q = q.where(Application.profile_id == profile_id)
+    q = q.group_by(Application.profile_id)
+
+    result = await session.execute(q)
+    return [
+        {
+            "profile_id": row.profile_id,
+            "count": row.count,
+            "oldest": row.oldest,
+            "newest": row.newest,
+        }
+        for row in result.all()
+    ]
+
+
+async def recover_error_apps(
+    session: AsyncSession,
+    *,
+    since: datetime | None = None,
+    profile_id: uuid.UUID | None = None,
+) -> int:
+    """Re-queue Application rows in match_status='error' back to pending_match.
+
+    Resets the lifecycle so run_match_queue picks them up on the next tick:
+      match_status='error' → 'pending_match'
+      match_attempts → 0
+      match_queued_at → now()
+      match_claimed_at → None
+      match_score / match_summary / match_rationale: untouched (already null
+      on error rows by construction — they never scored successfully).
+
+    Returns the rowcount.
+    """
+    now = datetime.now(UTC)
+    from sqlalchemy import update
+
+    stmt = (
+        update(Application)
+        .where(Application.match_status == "error")
+        .values(
+            match_status="pending_match",
+            match_attempts=0,
+            match_queued_at=now,
+            match_claimed_at=None,
+            updated_at=now,
+        )
+    )
+    if since is not None:
+        stmt = stmt.where(Application.created_at >= since)
+    if profile_id is not None:
+        stmt = stmt.where(Application.profile_id == profile_id)
+    result = await session.execute(stmt)
+    await session.commit()
+    return result.rowcount or 0
+
+
 async def release_claim(application_id: uuid.UUID, session: AsyncSession) -> None:
     """Clear the lease without incrementing attempts.
 

--- a/scripts/recover_error_matches.py
+++ b/scripts/recover_error_matches.py
@@ -1,0 +1,109 @@
+"""
+Audit + optionally recover Application rows stuck in match_status='error'.
+
+Used after incidents that wrongly drove apps to 'error' — the canonical case
+is the 2026-05-04 Gemini credit-depletion window (#75): while the
+BudgetExhausted graceful path wasn't yet deployed (#73, #74), every
+match_queue tick called mark_attempt_failed on every claimed app; after 3
+attempts the app flipped to status='error' and stopped retrying.
+
+Usage:
+
+    # Default: audit only (read-only). Counts error apps grouped by profile.
+    DATABASE_URL=postgresql+asyncpg://... uv run python scripts/recover_error_matches.py
+
+    # Audit since a given date (created_at-based; updated_at has no onupdate).
+    DATABASE_URL=... uv run python scripts/recover_error_matches.py \
+        --since 2026-05-04T06:00:00Z
+
+    # Apply the recovery — re-queue all error apps to pending_match.
+    DATABASE_URL=... uv run python scripts/recover_error_matches.py --apply
+
+    # Restrict to a single profile.
+    DATABASE_URL=... uv run python scripts/recover_error_matches.py \
+        --profile-id 7fda7e3b-...
+
+Recovery is idempotent: matched / pending_match / dismissed apps are
+untouched. Only `match_status='error'` rows are flipped.
+
+CRITICAL — DATABASE_URL must point at the right environment. Like
+`make migrate`, this script intentionally has no automatic prod-guard;
+double-check the URL host before passing --apply.
+"""
+
+import argparse
+import asyncio
+import sys
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.database import get_session_factory  # noqa: E402
+from app.services import match_queue_service  # noqa: E402
+
+
+async def run(since: datetime | None, profile_id: uuid.UUID | None, apply: bool) -> int:
+    factory = get_session_factory()
+    async with factory() as session:
+        rows = await match_queue_service.audit_error_apps(
+            session, since=since, profile_id=profile_id
+        )
+
+    if not rows:
+        print("No applications in match_status='error' match the filters.")
+        return 0
+
+    print(f"Audit: {len(rows)} profile(s) with error-status applications")
+    print(f"  {'profile_id':<38} {'count':>5}  {'oldest':<26} {'newest':<26}")
+    total = 0
+    for row in rows:
+        total += row["count"]
+        print(
+            f"  {str(row['profile_id']):<38} {row['count']:>5}  "
+            f"{row['oldest'].isoformat() if row['oldest'] else '-':<26} "
+            f"{row['newest'].isoformat() if row['newest'] else '-':<26}"
+        )
+    print(f"  total: {total} application(s)")
+
+    if not apply:
+        print("\nDry run (audit only). Re-run with --apply to recover.")
+        return 0
+
+    print("\nApplying recovery: error → pending_match, attempts=0, queued_at=now()…")
+    async with factory() as session:
+        affected = await match_queue_service.recover_error_apps(
+            session, since=since, profile_id=profile_id
+        )
+    print(
+        f"Recovered {affected} application(s). "
+        "They will be re-claimed on the next match_queue tick."
+    )
+    return 0
+
+
+def _parse_iso(s: str) -> datetime:
+    # accept trailing Z (Python <3.11 doesn't, but fromisoformat in 3.12 does)
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--since",
+        type=_parse_iso,
+        help="Filter by Application.created_at >= ISO8601 (e.g. 2026-05-04T06:00:00Z).",
+    )
+    parser.add_argument(
+        "--profile-id",
+        type=uuid.UUID,
+        help="Only consider apps for this profile.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually run the recovery. Without this flag, audit only.",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(args.since, args.profile_id, args.apply)))

--- a/tests/integration/test_match_queue.py
+++ b/tests/integration/test_match_queue.py
@@ -143,3 +143,60 @@ async def test_mark_error_after_3_attempts(db_session):
     ).scalar_one()
     assert refreshed.match_status == "error"
     assert refreshed.match_attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_audit_and_recover_error_apps(db_session):
+    """audit_error_apps + recover_error_apps round-trip:
+    seed mixed apps (some error, some pending_match, some matched), audit,
+    then recover and assert the error apps flip back to pending_match while
+    others are untouched. Mirrors the 2026-05-04 prod recovery scenario (#75)."""
+    from datetime import UTC, datetime, timedelta
+
+    p1 = await _seed_profile(db_session, "airbnb")
+    p2 = await _seed_profile(db_session, "stripe")
+
+    # Seed jobs for each profile + create their pending applications
+    for slug, profile in (("airbnb", p1), ("stripe", p2)):
+        for ext in ("a", "b"):
+            db_session.add(_job(slug, ext))
+    await db_session.commit()
+    jobs = (await db_session.execute(sa.select(Job))).scalars().all()
+    for job in jobs:
+        await match_queue_service.enqueue_for_interested_profiles(job, db_session)
+
+    # Get all the just-created applications
+    apps = (await db_session.execute(sa.select(Application))).scalars().all()
+    assert len(apps) == 4  # 2 jobs per profile × 2 profiles, each scoped to one profile
+
+    # Force two of them into match_status='error' (simulating depletion outcome)
+    for app in apps[:2]:
+        for _ in range(3):
+            await match_queue_service.mark_attempt_failed(app.id, db_session)
+
+    db_session.expire_all()
+
+    # Audit — all profiles, no time bound
+    rows = await match_queue_service.audit_error_apps(db_session)
+    total = sum(r["count"] for r in rows)
+    assert total == 2, f"expected 2 error apps, got {total} ({rows})"
+
+    # Audit with `since` in the future → should match nothing
+    future = datetime.now(UTC) + timedelta(days=1)
+    rows_future = await match_queue_service.audit_error_apps(db_session, since=future)
+    assert rows_future == []
+
+    # Recover — re-queue all error apps
+    recovered = await match_queue_service.recover_error_apps(db_session)
+    assert recovered == 2
+
+    db_session.expire_all()
+    statuses = (await db_session.execute(sa.select(Application.match_status))).scalars().all()
+    # All 4 apps should now be pending_match
+    assert sorted(statuses) == ["pending_match"] * 4
+    attempts = (await db_session.execute(sa.select(Application.match_attempts))).scalars().all()
+    assert all(a == 0 for a in attempts), f"attempts must reset to 0, got {attempts}"
+
+    # Second audit should find nothing
+    rows_after = await match_queue_service.audit_error_apps(db_session)
+    assert rows_after == []


### PR DESCRIPTION
## Summary

Ops tooling for recovering Application rows that wrongly ended up in \`match_status='error'\` during the 2026-05-04 Gemini credit-depletion window. Without #74 deployed at the time, every match_queue tick called \`mark_attempt_failed\` on every claimed app; after 3 attempts the app flipped to \`error\` and stopped. Now that #74 is live future depletions degrade gracefully — but the *historical* damage from 2026-05-04 needs a manual sweep.

## What ships

- \`match_queue_service.audit_error_apps(since, profile_id)\` — read-only count grouped by profile.
- \`match_queue_service.recover_error_apps(since, profile_id)\` — re-queue: \`error\` → \`pending_match\`, \`attempts=0\`, \`queued_at=now()\`, \`claimed_at=None\`.
- \`scripts/recover_error_matches.py\` — CLI wrapper. Audit-only by default; \`--apply\` actually performs the recovery.

## Note about the issue's `updated_at` filter

#75's original suggestion to filter by \`updated_at >= since\` doesn't work: the Application model has no \`onupdate\` on \`updated_at\`, so it reflects row creation time, not status-flip time. Script uses \`created_at\` instead. Documented inline.

## Usage

\`\`\`bash
# Audit (read-only) — count error apps grouped by profile
DATABASE_URL=postgresql+asyncpg://... uv run python scripts/recover_error_matches.py

# Limit to apps created since the depletion window
DATABASE_URL=... uv run python scripts/recover_error_matches.py \\
    --since 2026-05-04T06:00:00Z

# Recover them
DATABASE_URL=... uv run python scripts/recover_error_matches.py --apply
\`\`\`

## Test plan

- [x] \`uv run pytest tests/integration/test_match_queue.py::test_audit_and_recover_error_apps\` — covers the round-trip
- [x] Full suite: 257 passing
- [ ] Post-merge: I'll run the audit against prod (or guide @maksym-panibrat to) and report counts back on #75 before it gets closed
- [ ] If non-zero, run with \`--apply\` and confirm subsequent match_queue ticks drain the recovered apps cleanly

Re #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)