### PR TITLE
fix(cron): generation-queue deadline + drop stale checkpointer kwarg (re #76)

### DIFF
--- a/app/api/internal_cron.py
+++ b/app/api/internal_cron.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Awaitable, Callable
 
 import structlog
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException
 
 from app.agents.llm_safe import BudgetExhausted
 from app.config import Settings, get_settings
@@ -77,17 +77,8 @@ async def cron_sync():
 
 
 @router.post("/generation-queue", dependencies=[Depends(verify_secret)])
-async def cron_generation_queue(request: Request):
-    # generate_materials requires a LangGraph checkpointer; resolve it from the
-    # app state (initialized in the FastAPI lifespan) and 503 loudly if missing.
-    checkpointer = getattr(request.app.state, "checkpointer", None)
-    if checkpointer is None:
-        raise HTTPException(status_code=503, detail="checkpointer not initialized")
-
-    async def task() -> dict:
-        return await run_generation_queue(checkpointer)
-
-    return await _run_cron("generation_queue", task)
+async def cron_generation_queue():
+    return await _run_cron("generation_queue", run_generation_queue)
 
 
 @router.post("/process-sync-queue", dependencies=[Depends(verify_secret)])

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -49,18 +49,29 @@ async def run_job_sync() -> dict:
     }
 
 
-async def run_generation_queue(checkpointer) -> dict:
-    """Generate materials for applications stuck in pending status. Returns a summary dict.
+async def run_generation_queue(*, deadline_seconds: int = 240) -> dict:
+    """Generate materials for applications stuck in pending status.
 
-    ``checkpointer`` must be a LangGraph checkpointer (typically
-    ``request.app.state.checkpointer`` initialized in the FastAPI lifespan).
-    ``generate_materials`` raises ``RuntimeError`` if it is None.
+    Bounded by `deadline_seconds` per Cloud Run's 300s wall: 10 pending apps ×
+    ~10-30s per generate_materials call easily exceeds 300s if Gemini is slow.
+    Iterations after the deadline trips are deferred to the next tick — they
+    stay in generation_status='pending' and become eligible immediately
+    (no lease in this lifecycle, contrast with run_match_queue's 300s lease).
+
+    Note: `generate_materials` is a synchronous-LLM call (no checkpointer).
+    The contract was changed in commit 4d47205-era; passing `checkpointer=`
+    was a stale kwarg from the LangGraph-interrupt era and TypeError'd at
+    every call (silently caught by the generic except, returning failed=N).
     """
+    import time
+
     from app.database import get_session_factory
     from app.models.application import Application
     from app.services.application_service import generate_materials
 
     factory = get_session_factory()
+    deadline = time.monotonic() + deadline_seconds
+
     async with factory() as session:
         result = await session.execute(
             select(Application)
@@ -76,17 +87,31 @@ async def run_generation_queue(checkpointer) -> dict:
     attempted = len(app_ids)
     succeeded = 0
     failed = 0
+    deferred = 0
 
-    for app_id in app_ids:
+    for i, app_id in enumerate(app_ids):
+        if time.monotonic() > deadline:
+            deferred = len(app_ids) - i
+            await log.awarning(
+                "scheduler.generation_queue_deferred",
+                deferred=deferred,
+                processed=i,
+            )
+            break
         try:
             async with factory() as session:
-                await generate_materials(app_id, session, checkpointer=checkpointer)
+                await generate_materials(app_id, session)
                 succeeded += 1
         except Exception as exc:
             failed += 1
             await log.aexception("scheduler.generation_error", app_id=str(app_id), error=str(exc))
 
-    return {"attempted": attempted, "succeeded": succeeded, "failed": failed}
+    return {
+        "attempted": attempted,
+        "succeeded": succeeded,
+        "failed": failed,
+        "deferred": deferred,
+    }
 
 
 async def run_daily_maintenance() -> dict:

--- a/tests/integration/test_generation_queue_cron.py
+++ b/tests/integration/test_generation_queue_cron.py
@@ -1,0 +1,116 @@
+"""Integration tests for run_generation_queue cron worker."""
+
+import asyncio
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.models.application import Application
+from app.models.job import Job
+from app.models.user import User
+from app.models.user_profile import UserProfile
+from app.scheduler.tasks import run_generation_queue
+
+
+async def _seed_pending_app(db_session) -> Application:
+    """User → Profile → Job → Application(generation_status='pending')."""
+    user = User(id=uuid.uuid4(), email=f"genq-{uuid.uuid4()}@test.com")
+    db_session.add(user)
+    await db_session.commit()
+
+    profile = UserProfile(user_id=user.id, email=user.email)
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+
+    job = Job(
+        source="greenhouse_board",
+        external_id=str(uuid.uuid4()),
+        title="Engineer",
+        company_name="Acme",
+        apply_url="https://x",
+        description_md="role",
+    )
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)
+
+    app_row = Application(
+        job_id=job.id,
+        profile_id=profile.id,
+        generation_status="pending",
+    )
+    db_session.add(app_row)
+    await db_session.commit()
+    await db_session.refresh(app_row)
+    return app_row
+
+
+@pytest.mark.asyncio
+async def test_run_generation_queue_calls_generate_materials_with_correct_signature(db_session):
+    """Latent bug discovered while working #76: run_generation_queue passes
+    `checkpointer=...` to generate_materials, but the function's signature
+    is just (application_id, session). The TypeError is silently caught by
+    the generic `except Exception` and counted as `failed`, so the cron
+    looks healthy in CI but every pending app fails to generate in prod.
+
+    This test exercises the actual call path (not a mock of run_generation_queue
+    itself) to catch the TypeError."""
+    await _seed_pending_app(db_session)
+    received_kwargs: dict = {}
+
+    async def fake_generate(application_id, session):
+        # Capture what kwargs we got — none should be passed beyond positional args.
+        received_kwargs["application_id"] = application_id
+        received_kwargs["called"] = True
+        return None
+
+    with patch(
+        "app.services.application_service.generate_materials",
+        side_effect=fake_generate,
+    ):
+        result = await run_generation_queue()
+
+    assert received_kwargs.get("called"), (
+        "generate_materials was never invoked successfully — likely TypeError "
+        "from an unexpected keyword argument. result={result}"
+    )
+    assert result["attempted"] == 1
+    assert result["succeeded"] == 1
+    assert result["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_generation_queue_respects_deadline_and_surfaces_deferred(db_session):
+    """Per-tick deadline must short-circuit further iterations. Without it,
+    10 pending apps × ~10-30s per generate_materials call ≈ 100-300s, right at
+    Cloud Run's 300s wall (#76)."""
+    # Seed 3 pending apps
+    for _ in range(3):
+        await _seed_pending_app(db_session)
+
+    call_times: list[float] = []
+
+    async def slow_generate(application_id, session):
+        call_times.append(time.monotonic())
+        await asyncio.sleep(0.4)  # each call exceeds the 0.3s deadline alone
+        return None
+
+    with patch(
+        "app.services.application_service.generate_materials",
+        side_effect=slow_generate,
+    ):
+        result = await run_generation_queue(deadline_seconds=0.3)
+
+    # First call always fires (deadline check is at top of loop, deadline still
+    # ahead). After it, 0.4s elapsed > 0.3s deadline → break, defer the rest.
+    assert len(call_times) == 1, (
+        f"expected exactly 1 call before the deadline trips, got {len(call_times)}"
+    )
+    assert result["attempted"] == 3
+    assert result["succeeded"] == 1
+    assert result["deferred"] == 2, (
+        f"deferred count must surface so callers know there's queued work left; got {result}"
+    )

--- a/tests/unit/test_internal_cron.py
+++ b/tests/unit/test_internal_cron.py
@@ -24,9 +24,10 @@ def make_app(
         google_api_key="fake",
     )
     test_app.dependency_overrides[get_cron_settings] = lambda: override_settings
-    # Emulate lifespan: the /generation-queue endpoint resolves the checkpointer
-    # from app.state.checkpointer and 503s if absent. Tests pass a sentinel
-    # object by default; pass checkpointer=None to exercise the guard.
+    # The `checkpointer` parameter is a vestigial parameter kept so existing
+    # tests don't break — generate_materials no longer uses a checkpointer
+    # (#76 stripped the stale kwarg from the cron path). Set on app.state
+    # for any future test that wants to assert state is or isn't present.
     if checkpointer is not None:
         test_app.state.checkpointer = checkpointer
     return TestClient(test_app, raise_server_exceptions=raise_server_exceptions)
@@ -125,22 +126,28 @@ def test_generation_queue_budget_exhausted_returns_structured_response():
     assert body["resumes_at"] == resumes_at.isoformat()
 
 
-def test_generation_queue_missing_checkpointer_returns_503():
-    # If the FastAPI lifespan never set app.state.checkpointer, the cron endpoint
-    # 503s loudly instead of calling run_generation_queue (which would hit the
-    # RuntimeError in generate_materials).
+def test_generation_queue_does_not_require_checkpointer():
+    """generate_materials switched to a synchronous (no-checkpointer) contract
+    in the cover-letter-graph rewrite. The cron endpoint no longer threads a
+    checkpointer; passing one was a stale kwarg that TypeError'd at every call
+    and was silently caught by the generic except, masking the bug (#76)."""
     client = make_app(secret="real-secret", checkpointer=None)
     with patch(
         "app.api.internal_cron.run_generation_queue",
-        new=AsyncMock(return_value={"attempted": 0, "succeeded": 0, "failed": 0}),
+        new=AsyncMock(return_value={"attempted": 0, "succeeded": 0, "failed": 0, "deferred": 0}),
     ) as mock:
         resp = client.post(
             "/internal/cron/generation-queue",
             headers={"X-Cron-Secret": "real-secret"},
         )
-    assert resp.status_code == 503
-    assert resp.json()["detail"] == "checkpointer not initialized"
-    mock.assert_not_called()
+    assert resp.status_code == 200, resp.text
+    mock.assert_called_once()
+    # No checkpointer arg passed — call should be plain `run_generation_queue()`.
+    call = mock.call_args
+    assert call.args == () and call.kwargs == {}, (
+        f"run_generation_queue must be called with no args, "
+        f"got args={call.args} kwargs={call.kwargs}"
+    )
 
 
 def test_sync_unexpected_exception_returns_500():


### PR DESCRIPTION
## Summary

Two distinct fixes for the same code path:

### 1. Latent TypeError on every prod tick (discovered while fixing #76)

\`run_generation_queue\` was calling \`generate_materials(app_id, session, checkpointer=checkpointer)\` but \`generate_materials\`'s signature is \`(application_id, session)\` — the contract was changed to synchronous (no checkpointer) in the cover-letter-graph rewrite (commit \`4d47205\`-era), but the cron call site wasn't updated.

Every pending app TypeError'd at the call. The exception was silently caught by the generic \`except Exception\` in the loop, and the cron returned 200 with \`failed=N\` — so it looked healthy in CI while **every pending application failed to generate in prod**.

**Fix:** drop the stale kwarg. Drop \`checkpointer\` from \`run_generation_queue\`'s signature and from \`cron_generation_queue\`'s handler (no \`app.state\` lookup needed anymore).

### 2. 5-min Cloud Run wall risk (the originally-tracked #76 concern)

10 pending apps × ~10-30s per \`generate_materials\` ≈ 100-300s/tick, right at the 300s wall. One slow Gemini response stacks the next.

**Fix:** add \`deadline_seconds: int = 240\` parameter; per-iteration deadline check; surface \`deferred\` count in the result dict (matches \`run_match_queue\` shape from PR #71). Apps deferred this tick stay in \`generation_status='pending'\` and are eligible immediately on the next tick (no lease in this lifecycle).

## Test plan

- [x] New: \`test_run_generation_queue_calls_generate_materials_with_correct_signature\` — fails on prior code with TypeError
- [x] New: \`test_run_generation_queue_respects_deadline_and_surfaces_deferred\` — exercises deadline with stubbed slow generate
- [x] Updated: \`test_generation_queue_missing_checkpointer_returns_503\` → \`test_generation_queue_does_not_require_checkpointer\`
- [x] Full suite: 259 passing

Re #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)