### PR TITLE
feat(config): match-queue caps configurable via Settings (re #77)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,12 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     matching_max_concurrency: int = 8
     matching_jobs_per_batch: int = 20
+    # Per-tick match-queue caps. `max_per_profile` bounds how many jobs a
+    # single profile can own in one score_and_match call (slower ticks risk
+    # Cloud Run's 300s wall when one profile dominates the batch — see #71).
+    # `tick_deadline_seconds` bounds total wall time per tick.
+    matching_max_per_profile_per_tick: int = 30
+    matching_tick_deadline_seconds: int = 240
 
     cors_allowed_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]
     # Absolute base URL Google sees as redirect_uri host. Cloud Run forwards HTTP to

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -267,12 +267,17 @@ async def run_sync_queue(*, max_slugs: int = 64, deadline_seconds: int = 240) ->
 async def run_match_queue(
     *,
     batch_size: int = 100,
-    deadline_seconds: int = 240,
-    max_per_profile: int = 30,
+    deadline_seconds: int | None = None,
+    max_per_profile: int | None = None,
 ) -> dict:
     """Drain pending_match applications. One LangGraph batch per profile per tick
     (the agent fans out internally). Per-tick deadline keeps us under Cloud Run's
     300s wall.
+
+    `deadline_seconds` and `max_per_profile` default to
+    `Settings.matching_tick_deadline_seconds` and
+    `Settings.matching_max_per_profile_per_tick` respectively (see #77 — env-var
+    tunable without a redeploy). Tests can still pass explicit overrides.
 
     `max_per_profile` caps how many jobs a single profile can own in one
     score_and_match call. Without it, batch_size=100 concentrated on one
@@ -284,6 +289,13 @@ async def run_match_queue(
     import time
 
     from app.agents.llm_safe import BudgetExhausted
+    from app.config import get_settings
+
+    settings = get_settings()
+    if deadline_seconds is None:
+        deadline_seconds = settings.matching_tick_deadline_seconds
+    if max_per_profile is None:
+        max_per_profile = settings.matching_max_per_profile_per_tick
     from app.database import get_session_factory
     from app.models.application import Application
     from app.models.job import Job

--- a/tests/integration/test_match_queue_cron.py
+++ b/tests/integration/test_match_queue_cron.py
@@ -147,6 +147,79 @@ async def test_run_match_queue_releases_leases_without_failing_attempts_on_budge
 
 
 @pytest.mark.asyncio
+async def test_run_match_queue_uses_settings_for_default_caps(db_session, monkeypatch):
+    """Defaults for max_per_profile and deadline_seconds come from Settings
+    (#77) — env vars `MATCHING_MAX_PER_PROFILE_PER_TICK` and
+    `MATCHING_TICK_DEADLINE_SECONDS` tune behaviour without a redeploy."""
+    import app.config as cfg
+
+    # Reset the settings singleton so the monkeypatched env vars take effect
+    monkeypatch.setattr(cfg, "_settings", None)
+    monkeypatch.setenv("MATCHING_MAX_PER_PROFILE_PER_TICK", "2")
+
+    profile = await _seed_profile(db_session, "airbnb")
+    profile_id = profile.id
+
+    jobs = []
+    for i in range(5):
+        job = Job(
+            source="greenhouse_board",
+            external_id=f"settings-{i}",
+            title=f"Engineer {i}",
+            company_name=slug_to_company_name("airbnb"),
+            apply_url=f"https://x/{i}",
+            is_active=True,
+        )
+        db_session.add(job)
+        jobs.append(job)
+    await db_session.commit()
+    for j in jobs:
+        await db_session.refresh(j)
+        await match_queue_service.enqueue_for_interested_profiles(j, db_session)
+
+    fake_graph = MagicMock()
+
+    async def fake_invoke(state, config=None):
+        from app.agents.matching_agent import ScoreResult
+
+        return {
+            "scores": [
+                ScoreResult(
+                    application_id=jc["application_id"],
+                    score=0.9,
+                    summary="ok",
+                    rationale="ok",
+                    strengths=[],
+                    gaps=[],
+                )
+                for jc in state["jobs"]
+            ]
+        }
+
+    fake_graph.ainvoke = fake_invoke
+
+    with patch("app.agents.matching_agent.build_graph", return_value=fake_graph):
+        # No explicit max_per_profile: should pull `2` from MATCHING_MAX_PER_PROFILE_PER_TICK
+        result = await run_match_queue()
+
+    db_session.expire_all()
+    matched = (
+        (
+            await db_session.execute(
+                sa.select(Application).where(
+                    Application.profile_id == profile_id,
+                    Application.match_status == "matched",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(matched) == 2, f"settings-driven cap=2 should mean 2 scored, got {len(matched)}"
+    assert result["deferred"] == 3, f"expected 3 deferred, got {result}"
+
+
+@pytest.mark.asyncio
 async def test_run_match_queue_caps_jobs_per_profile_per_tick(db_session):
     """A single profile must not own more than `max_per_profile` jobs in one
     score_and_match call. With batch_size=100 concentrated on one profile and


### PR DESCRIPTION
## Summary

Adds two env-var-driven knobs so per-tick match-queue limits can be tuned without a redeploy:

\`\`\`
MATCHING_MAX_PER_PROFILE_PER_TICK   default 30  (was hardcoded by PR #71)
MATCHING_TICK_DEADLINE_SECONDS      default 240
\`\`\`

\`run_match_queue\`'s \`max_per_profile\` and \`deadline_seconds\` parameters now default to \`None\` and resolve from \`get_settings()\` when not set. Tests can still pass explicit overrides.

## Test plan

- [x] New: \`test_run_match_queue_uses_settings_for_default_caps\` sets \`MATCHING_MAX_PER_PROFILE_PER_TICK=2\` via \`monkeypatch.setenv\`, asserts the cron honours it (2 scored, 3 deferred for a 5-app fixture).
- [x] Existing match-queue tests pass unchanged (they pass explicit \`max_per_profile=\`).
- [x] Full suite: 260/260.

Re #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)