### PR TITLE
fix(cron): persistent incident-issue tracking across PR closes (re #78)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -122,14 +122,29 @@ jobs:
         run: |
           set -euo pipefail
           title="[cron] scheduled job failing"
-          # gh issue list --search respects the exact title via "in:title"
-          existing=$(gh issue list --repo "$REPO" --state open --search "$title in:title" --json number --jq '.[0].number' || echo "")
+          # Search across BOTH open and closed issues so the persistent
+          # tracking-issue identity survives a `closes #N` keyword on a
+          # fix PR (#78). Without --state all, every cron-fix PR that
+          # closes the tracker would orphan it and force a new issue
+          # number on the next failure (#70 → #72 churn observed
+          # 2026-05-04). Prefer OPEN; fall back to most-recently-closed.
+          # If found-but-closed, reopen and comment.
+          existing=$(gh issue list --repo "$REPO" --state all --search "$title in:title" \
+            --json number,state,closedAt --limit 20 \
+            --jq '([.[] | select(.state == "OPEN")] + ([.[] | select(.state == "CLOSED")] | sort_by(.closedAt) | reverse))[0] // empty' \
+            || echo "")
           body="Cron run failed: $RUN_URL
           Job results: $FAILED_JOBS
 
           First step in triage: check prod logs for 5xx from /internal/cron/* endpoints and reconcile prod schema vs deployed code (see commit 28e5ce5 for the canonical drift case)."
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "$REPO" --body "$body"
+            num=$(echo "$existing" | jq -r '.number')
+            state=$(echo "$existing" | jq -r '.state')
+            if [ "$state" = "CLOSED" ]; then
+              gh issue reopen "$num" --repo "$REPO" \
+                --comment "Reopened by alert-on-failure: a new cron run failed after this issue was closed."
+            fi
+            gh issue comment "$num" --repo "$REPO" --body "$body"
           else
             gh issue create --repo "$REPO" --title "$title" \
               --label "incident,cron" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ Matching agent uses `asyncio.Semaphore` + 1.5s sleep + 10s/30s exponential backo
 
 No in-process scheduler. `app/scheduler/tasks.py` is invoked via `POST /internal/cron/{sync,generation-queue,maintenance}` with `X-Cron-Secret`, triggered by `.github/workflows/cron.yml`.
 
+**Cron-incident PR convention**: when a PR fixes a cron failure, reference the persistent tracking issue with `re #N` / `relates to #N` — **never** `closes #N` / `fixes #N`. The alert-on-failure workflow now reopens-and-comments on the most recent matching issue regardless of state (after #78), so closing it is harmless — but the explicit form keeps history clean and matches the long-lived-tracker intent. The original churn (#70 → #72 on 2026-05-04 from a `closes #70`) is what motivates this.
+
 ### Generation contract
 
 `generate_materials()` (`app/services/application_service.py`) runs the cover-letter graph synchronously and returns the saved `GeneratedDocument`. The HTTP entrypoint is `POST /api/applications/{id}/cover-letter` — the request blocks for the duration of the LLM call (≈10–30s) and there is no background task, no checkpointer, no interrupt, and no `/resume` endpoint. Valid `generation_status` values: `none · generating · ready · failed`. Single-writer rule: `generate_materials` owns the status writes (`generating` → `ready`/`failed`); the API route does nothing but await it.


### PR DESCRIPTION
## Summary

Two complementary fixes so the cron incident tracker preserves identity across PR closes:

1. **Workflow** (defense in depth): \`alert-on-failure\` now searches \`--state all\`, prefers \`OPEN\`, falls back to most-recently-closed by \`closedAt desc\`. Reopens automatically if found-but-closed before commenting. So even if a future PR uses \`closes #N\`, we recover.

2. **Convention** (CLAUDE.md): document that cron-fix PRs should use \`re #N\` / \`relates to #N\`, not \`closes #N\`. Defense (1) makes forgetting harmless; the convention keeps history clean.

## Why

PR #71 said \`closes #70\`, GitHub auto-closed #70 on merge, \`alert-on-failure\` couldn't find an open matching issue, so it created #72. The persistent tracker's identity leaks every time someone uses \`closes\` on a cron-fix PR (#70 → #72 churn observed 2026-05-04).

## Test plan

The workflow change can't be exercised in PR CI (it only runs on \`schedule\`). Validated:
- [x] YAML parses cleanly
- [x] jq selection logic verified locally with three fixtures (open+closed mix → OPEN; closed-only → most recent closed; empty → empty)
- [ ] Will manually verify on the next genuine cron failure (or trigger one via \`workflow_dispatch\` if desired)

Re #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)