### PR TITLE
fix(ui): render description_clean instead of raw HTML in job details (#69)

### DIFF
--- a/app/api/applications.py
+++ b/app/api/applications.py
@@ -98,6 +98,7 @@ async def get_application(
             "salary": job.salary,
             "contract_type": job.contract_type,
             "description_md": job.description_md,
+            "description_clean": job.description_clean,
             "apply_url": job.apply_url,
             "posted_at": job.posted_at,
         }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -50,6 +50,7 @@ export interface Job {
   salary: string | null
   contract_type: string | null
   description_md: string | null
+  description_clean: string | null
   apply_url: string
   posted_at: string | null
 }

--- a/frontend/src/components/MatchCard.test.tsx
+++ b/frontend/src/components/MatchCard.test.tsx
@@ -28,6 +28,7 @@ function makeApp(overrides: Partial<Application> = {}): Application {
       salary: '$120k',
       contract_type: 'full-time',
       description_md: 'A great role.',
+      description_clean: 'A great role.',
       apply_url: 'https://example.com/apply',
       posted_at: null,
     },

--- a/frontend/src/pages/ApplicationReview.tsx
+++ b/frontend/src/pages/ApplicationReview.tsx
@@ -8,7 +8,8 @@ function JobDetails({ app }: { app: ApplicationDetail }) {
   const job = app.job
   if (!job) return null
 
-  const hasDetails = job.description_md || job.salary || job.contract_type || job.posted_at || app.match_strengths?.length || app.match_gaps?.length
+  const description = job.description_clean ?? job.description_md
+  const hasDetails = description || job.salary || job.contract_type || job.posted_at || app.match_strengths?.length || app.match_gaps?.length
 
   if (!hasDetails) return null
 
@@ -64,11 +65,11 @@ function JobDetails({ app }: { app: ApplicationDetail }) {
             </div>
           )}
 
-          {job.description_md && (
+          {description && (
             <div>
               <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Description</p>
               <pre className="whitespace-pre-wrap font-sans text-gray-700 text-sm leading-relaxed max-h-96 overflow-y-auto">
-                {job.description_md}
+                {description}
               </pre>
             </div>
           )}

--- a/tests/integration/test_applications_api_summary.py
+++ b/tests/integration/test_applications_api_summary.py
@@ -55,3 +55,43 @@ async def test_list_endpoint_includes_match_summary(db_session, auth_headers, se
     row = next(r for r in rows if r["match_score"] == 0.8)
     assert row["match_summary"] == "One-line summary text."
     assert row["match_rationale"] == "Audit text."  # still serialized for API audit
+
+
+@pytest.mark.asyncio
+async def test_detail_endpoint_exposes_description_clean(db_session, auth_headers, seeded_user):
+    """GET /api/applications/{id} surfaces description_clean (markdownified) alongside
+    the raw description_md so the SPA can render readable text instead of HTML."""
+    from app.main import app as fastapi_app
+
+    _user, profile = seeded_user
+
+    job = Job(
+        source="greenhouse_board",
+        external_id=str(uuid.uuid4()),
+        title="HTML Description Role",
+        company_name="HTMLCo",
+        apply_url="https://example.com/apply",
+        description_md="<h2>Who we are</h2><p>Cool company.</p>",
+        description_clean="## Who we are\n\nCool company.",
+    )
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)
+
+    app_obj = Application(
+        job_id=job.id,
+        profile_id=profile.id,
+        status="pending_review",
+    )
+    db_session.add(app_obj)
+    await db_session.commit()
+    await db_session.refresh(app_obj)
+
+    transport = ASGITransport(app=fastapi_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(f"/api/applications/{app_obj.id}", headers=auth_headers)
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["job"]["description_clean"] == "## Who we are\n\nCool company."
+    # description_md kept alongside for backward compat / null-fallback.
+    assert payload["job"]["description_md"] == "<h2>Who we are</h2><p>Cool company.</p>"


### PR DESCRIPTION
## Summary

Render `Job.description_clean` (markdownified text) instead of `Job.description_md` (raw HTML pulled from Greenhouse) in the application-review UI. The field name is misleading — `description_md` is HTML; `description_clean` is the post-`markdownify` text written by `upsert_job` and backfilled for legacy rows by `scripts/backfill_job_description_clean.py`.

Before: users saw literal `<h2>`, `<strong>`, `<p>` tags as visible text.
After: descriptions render as plain readable markdown via the existing `<pre whitespace-pre-wrap>`.

## Changes

- `app/api/applications.py` — `GET /api/applications/{id}` job dict now includes `description_clean` alongside `description_md` (latter kept for null-fallback + backward compat).
- `frontend/src/api/client.ts` — `Job` interface gains `description_clean: string | null`.
- `frontend/src/pages/ApplicationReview.tsx` — `JobDetails` renders `description_clean ?? description_md` so legacy rows pre-backfill still show something rather than crashing.
- `frontend/src/components/MatchCard.test.tsx` — fixture extended for the new shape.
- `tests/integration/test_applications_api_summary.py` — new test asserting the API exposes the cleaned field.

## Test plan

- [x] `uv run pytest tests/integration/test_applications_api_summary.py -v` (2/2 pass)
- [x] `uv run pytest tests/integration/test_job_sync.py -v` (9/9 pass)
- [x] `uv run pytest tests/unit/` (133/133 pass)
- [x] `uv run ruff check app/ tests/` (clean)
- [x] `cd frontend && npm run test` (34/34 pass)
- [ ] Manual: load the SPA against a populated DB, open an application, confirm description renders as readable text rather than raw HTML.

## Dry-run interpretation

`run-20260505-0007-job-application-agent-69` — see issue thread comment.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
