### PR TITLE
feat(frontend): dev-only "Skip OAuth" button on the Landing page

### DIFF
--- a/frontend/src/pages/Landing.test.tsx
+++ b/frontend/src/pages/Landing.test.tsx
@@ -62,4 +62,59 @@ describe('Landing', () => {
     })
     expect(window.location.href).toBe('')
   })
+
+  // Dev-only "skip OAuth" button — gated on `import.meta.env.DEV` so production
+  // builds tree-shake it away. Defense in depth: even if the button somehow
+  // reached prod, /api/test/login is only mounted when ENVIRONMENT is
+  // development or test (app/main.py), so it would 404. Vitest runs in DEV
+  // mode by default, so the button is rendered for these tests.
+
+  it('renders a dev-only "Skip OAuth" button in development builds', () => {
+    render(<Landing />)
+    expect(
+      screen.getByRole('button', { name: /Dev login \(skip OAuth\)/i })
+    ).toBeInTheDocument()
+  })
+
+  it('dev login posts to /api/test/login, stores token, then navigates to /matches', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ access_token: 'dev-jwt-xyz', user_id: 'u-1', email: 'e2e@local' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    sessionStorage.clear()
+
+    render(<Landing />)
+    await userEvent.click(screen.getByRole('button', { name: /Dev login \(skip OAuth\)/i }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/test/login', { method: 'POST' })
+    })
+    await waitFor(() => {
+      expect(sessionStorage.getItem('access_token')).toBe('dev-jwt-xyz')
+    })
+    await waitFor(() => {
+      expect(window.location.href).toBe('/matches')
+    })
+    sessionStorage.clear()
+  })
+
+  it('shows a user-facing error if dev login fails (e.g. backend not in dev mode)', async () => {
+    // Production-style backend: /api/test/login isn't mounted → 404.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) })
+    )
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<Landing />)
+    await userEvent.click(screen.getByRole('button', { name: /Dev login \(skip OAuth\)/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Dev login failed/i)
+    })
+    expect(sessionStorage.getItem('access_token')).toBeNull()
+    expect(window.location.href).toBe('')
+  })
 })

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -25,6 +25,27 @@ export default function Landing() {
     }
   }
 
+  // Dev-only escape hatch. Calls the deterministic test-user login endpoint
+  // (mounted only when ENVIRONMENT is development or test — see app/main.py),
+  // stores the JWT in sessionStorage, and full-page-navigates to /matches so
+  // AuthProvider re-mounts and reads the freshly-set token.
+  async function startDevLogin() {
+    setError(null)
+    setPending(true)
+    try {
+      const res = await fetch('/api/test/login', { method: 'POST' })
+      if (!res.ok) throw new Error(`test login returned ${res.status}`)
+      const data = await res.json()
+      if (!data?.access_token) throw new Error('missing access_token')
+      sessionStorage.setItem('access_token', data.access_token)
+      window.location.href = '/matches'
+    } catch (err) {
+      setPending(false)
+      setError('Dev login failed. Is the backend running with ENVIRONMENT=development?')
+      console.error('Dev login failed', err)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center gap-8 px-4">
       <div className="text-center max-w-lg">
@@ -50,6 +71,20 @@ export default function Landing() {
       </button>
       {error && (
         <p role="alert" className="text-sm text-red-600 -mt-4">{error}</p>
+      )}
+      {/* `import.meta.env.DEV` is a Vite compile-time constant: in production
+          builds it folds to `false` and the entire block is dead-code-eliminated.
+          The /api/test/login endpoint is also gated server-side, so this is
+          defense in depth, not the primary safety boundary. */}
+      {import.meta.env.DEV && (
+        <button
+          type="button"
+          onClick={startDevLogin}
+          disabled={pending}
+          className="text-xs text-gray-400 hover:text-gray-600 underline disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          Dev login (skip OAuth)
+        </button>
       )}
       <a href="https://github.com/maksym-panibrat/job-application-agent" className="text-sm text-gray-400 hover:text-gray-600">
         View on GitHub

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary

Restores a local-dev affordance you can use to skip the Google OAuth round-trip when poking at the SPA. Adds a small "Dev login (skip OAuth)" button under the existing Google sign-in CTA on the Landing page.

Click flow: `POST /api/test/login` → grab the deterministic e2e-test-user JWT → `sessionStorage.access_token = …` → `window.location.href = '/matches'` (full-page nav so `AuthProvider` remounts and reads the freshly-set token).

## Two layers of safety

- **Frontend:** gated on `import.meta.env.DEV`. Vite folds this to a literal `false` in production builds and tree-shakes the entire block. Verified: after `npm run build`, neither the button label `Dev login` nor the URL `test/login` appear in the production bundle (0 hits each); the `Sign in with Google` CTA is still there (1 hit).
- **Backend:** `/api/test/*` routes only mount when `ENVIRONMENT in ("development","test")` — see `app/main.py:218`. In prod the endpoint 404s, so even a hypothetically-leaked button would be inert.

So the affordance is dev-only by build-time stripping *and* by server-side route gating.

Tsconfig change: adds `"vite/client"` to `compilerOptions.types` so `import.meta.env.DEV` typechecks under `tsc`. Without this `npm run build` fails with `TS2339: Property 'env' does not exist on type 'ImportMeta'`.

## Test plan

- [x] `cd frontend && npm run test` (37/37 pass — 3 new Landing tests cover render, click-success, click-error)
- [x] `cd frontend && npm run build` (clean — TS check passes, bundle builds)
- [x] Bundle audit: prod build contains 0 references to `Dev login` and 0 references to `test/login`
- [ ] Manual local: `uv run uvicorn app.main:app --reload` + `cd frontend && npm run dev` → click "Dev login (skip OAuth)" on `localhost:5173` → land on `/matches` as the e2e-test user
- [ ] Manual prod: confirm the button is absent on `https://job-search.panibrat.com` after this PR ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)