### PR TITLE
refactor(resolver): promote _normalize to public normalize (#110)

### DIFF
--- a/app/services/company_catalog.py
+++ b/app/services/company_catalog.py
@@ -25,7 +25,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.company import Company
-from app.services.company_resolver import _normalize
+from app.services.company_resolver import normalize
 
 log = structlog.get_logger()
 
@@ -47,7 +47,7 @@ class CatalogRow(BaseModel):
 
     @property
     def normalized_key(self) -> str:
-        return _normalize(self.canonical_name)
+        return normalize(self.canonical_name)
 
     @property
     def provider_slugs_dict(self) -> dict[str, str]:

--- a/app/services/company_resolver.py
+++ b/app/services/company_resolver.py
@@ -38,8 +38,13 @@ class FanoutTimeoutError(Exception):
     """
 
 
-def _normalize(text: str) -> str:
-    """Trim, lowercase, collapse internal whitespace runs to single hyphens."""
+def normalize(text: str) -> str:
+    """Trim, lowercase, collapse internal whitespace runs to single hyphens.
+
+    Public because `app.services.company_catalog` imports it: both modules
+    must agree on the rule (it produces `Company.normalized_key`, the
+    unique key used by the catalog seeder's ON CONFLICT clause).
+    """
     s = text.strip().lower()
     s = re.sub(r"\s+", "-", s)
     return s
@@ -71,7 +76,7 @@ async def resolve(input_text: str, session: AsyncSession) -> Company | None:
 
     Returns None on no-match. Raises FanoutTimeoutError on fan-out timeout.
     """
-    normalized = _normalize(input_text)
+    normalized = normalize(input_text)
     if not normalized:
         return None
 

--- a/tests/integration/test_company_resolver.py
+++ b/tests/integration/test_company_resolver.py
@@ -2,7 +2,7 @@
 
 These tests rely on real Postgres semantics (INSERT ... ON CONFLICT) and the
 testcontainer-backed `db_session` fixture from tests/integration/conftest.py.
-The pure-function `_normalize` test lives under tests/unit/.
+The pure-function `normalize` test lives under tests/unit/.
 """
 
 from datetime import UTC, datetime

--- a/tests/unit/test_company_resolver.py
+++ b/tests/unit/test_company_resolver.py
@@ -8,7 +8,7 @@ from app.services import company_resolver
 
 
 def test_normalize_strips_case_and_whitespace_and_hyphenates():
-    assert company_resolver._normalize("  Linear  ") == "linear"
-    assert company_resolver._normalize("Meta Platforms") == "meta-platforms"
-    assert company_resolver._normalize("ByteDance") == "bytedance"
-    assert company_resolver._normalize("Acme   Corp") == "acme-corp"
+    assert company_resolver.normalize("  Linear  ") == "linear"
+    assert company_resolver.normalize("Meta Platforms") == "meta-platforms"
+    assert company_resolver.normalize("ByteDance") == "bytedance"
+    assert company_resolver.normalize("Acme   Corp") == "acme-corp"


### PR DESCRIPTION
## Primary changes
- Rename `app.services.company_resolver._normalize` → `normalize` and update the cross-module import in `company_catalog.py`.
- Add a docstring on `normalize` noting why it's public: both modules must agree on the rule because it produces `Company.normalized_key`, the unique key behind the catalog seeder's ON CONFLICT.
- Update unit/integration test references.

Per #110 this is Option 1 (rename in place). No shared `_text_utils` module exists yet, and there are no other normalization helpers about to land — Option 2 was unnecessary churn.

## Reviewer walkthrough
1. Review `app/services/company_resolver.py` for the `_normalize` → `normalize` rename and the new docstring documenting the shared normalization contract.
2. Review `app/services/company_catalog.py` for the import rename and continued use of `normalize()` in `CatalogRow.normalized_key`.
3. Review `tests/unit/test_company_resolver.py` and `tests/integration/test_company_resolver.py` for the updated symbol references.

## Correctness and invariants
- `normalize()` remains the single normalization rule shared by the resolver and catalog code, so `Company.normalized_key` stays aligned with the catalog seeder's `ON CONFLICT` key.
- This patch changes visibility and references, not behavior: the normalization logic itself is unchanged, and no new shared utility module is introduced in this diff.

## Testing and QA
- [x] `uv run ruff check app/ tests/` — all checks passed
- [x] `uv run pytest tests/unit/test_company_resolver.py tests/unit/test_company_catalog_parse.py` — 11/11 passed
- [x] `rg _normalize app/ tests/ frontend/` — no hits for the private symbol (only `normalized_key` / `test_normalize_*`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves #110
