### PR TITLE
chore(sync): drop dead seeded_defaults from the sync wire contract (#109)

### DIFF
--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -5,7 +5,7 @@ Two contracts here, by design (#80):
   prune_and_enqueue(profile, session)
     Bulk-cron-safe and HTTP-warm-up: drop slugs marked is_invalid, enqueue
     stale slugs for background fetch, update profile.last_sync_*. Fast (no
-    LLM). Returns {queued_slugs, matched_now=0, seeded_defaults, pruned_slugs}.
+    LLM). Returns {queued_slugs, matched_now=0, pruned_slugs}.
 
   sync_profile(profile, session)
     User-triggered HTTP path (POST /api/jobs/sync). Calls prune_and_enqueue
@@ -94,7 +94,6 @@ async def prune_and_enqueue(profile: UserProfile, session: AsyncSession) -> dict
     summary = {
         "queued_slugs": queued,
         "matched_now": 0,
-        "seeded_defaults": False,
         "pruned_slugs": pruned,
     }
     profile.last_sync_requested_at = datetime.now(UTC)
@@ -127,6 +126,5 @@ async def sync_profile(profile: UserProfile, session: AsyncSession) -> dict:
         profile_id=str(profile.id),
         queued_slugs=summary["queued_slugs"],
         matched_now=summary["matched_now"],
-        seeded_defaults=summary["seeded_defaults"],
     )
     return {"status": "queued", **summary}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -194,7 +194,6 @@ export const api = {
       status: string
       queued_slugs: string[]
       matched_now: number
-      seeded_defaults: boolean
     }>('/api/jobs/sync', { method: 'POST' }),
 
   // Sync status (Task 19)

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -125,7 +125,7 @@ describe('AppShell sync (header button)', () => {
     server.use(
       http.post('/api/jobs/sync', () => {
         posted = true
-        return HttpResponse.json({ status: 'queued', queued_slugs: ['stripe'], matched_now: 2, seeded_defaults: false })
+        return HttpResponse.json({ status: 'queued', queued_slugs: ['stripe'], matched_now: 2 })
       }),
     )
     const user = userEvent.setup()
@@ -195,7 +195,7 @@ describe('AppShell sync (mobile menu)', () => {
     server.use(
       http.post('/api/jobs/sync', () => {
         posted = true
-        return HttpResponse.json({ status: 'queued', queued_slugs: [], matched_now: 0, seeded_defaults: false })
+        return HttpResponse.json({ status: 'queued', queued_slugs: [], matched_now: 0 })
       }),
     )
     const user = userEvent.setup()

--- a/frontend/src/components/chat/Chat.test.tsx
+++ b/frontend/src/components/chat/Chat.test.tsx
@@ -70,7 +70,7 @@ describe('Chat', () => {
       if (url === '/api/jobs/sync' && init?.method === 'POST') {
         syncCalled = true
         return Promise.resolve(new Response(JSON.stringify({
-          status: 'queued', queued_slugs: [], matched_now: 0, seeded_defaults: false,
+          status: 'queued', queued_slugs: [], matched_now: 0,
         }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       }
       return originalFetch(url)

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -152,10 +152,9 @@ async def test_sync_profile_prunes_invalid_provider_slugs_from_company(db_sessio
 
 @pytest.mark.asyncio
 async def test_sync_profile_no_longer_seeds_defaults(db_session):
-    """seed_defaults_if_empty is now a no-op (default-seeding moved to the
-    onboarding agent + company_resolver path). sync_profile must always report
-    seeded_defaults=False, and must not write anything to the deprecated
-    target_company_slugs JSONB column."""
+    """seed_defaults_if_empty is gone (default-seeding moved to the onboarding
+    agent + company_resolver path). sync_profile must not write anything to
+    the deprecated target_company_slugs JSONB column."""
     from app.models.company import Company
     from app.models.user import User
     from app.services.profile_service import get_or_create_profile
@@ -186,7 +185,6 @@ async def test_sync_profile_no_longer_seeds_defaults(db_session):
     await db_session.refresh(profile)
 
     result = await job_sync_service.sync_profile(profile, db_session)
-    assert result["seeded_defaults"] is False
     assert sorted(result["queued_slugs"]) == ["airbnb", "stripe"]
     await db_session.refresh(profile)
     # legacy column untouched


### PR DESCRIPTION
## Primary changes
- Remove the dead `seeded_defaults` key end-to-end now that #107 deleted the producer and the value was pinned `False`.
- Drop the field from `app/services/job_sync_service.py` in the `prune_and_enqueue` return contract, docstring, and `sync.queued` log line.
- Drop it from the frontend `triggerSync` return type, update the AppShell / Chat response mocks, and narrow the integration test assertion and docstring accordingly.

The integration test name `test_sync_profile_no_longer_seeds_defaults` is kept — its purpose is now narrower (verifies the deprecated `target_company_slugs` JSONB column isn't written), and the docstring is updated to match.

## Reviewer walkthrough
1. Review `app/services/job_sync_service.py` for the removed `seeded_defaults` response/log surface.
2. Review `frontend/src/api/client.ts`, `frontend/src/components/AppShell.test.tsx`, and `frontend/src/components/chat/Chat.test.tsx` for the matching API contract and test-mock updates.
3. Review `tests/integration/test_job_sync.py` for the narrower assertion that the deprecated `target_company_slugs` column still stays untouched.

## Correctness and invariants
- `seeded_defaults` is now dead API/log surface: #107 already removed the producer, so the sync response and `sync.queued` log should not keep advertising a field that is always `False`.
- This change does not reintroduce default seeding; `sync_profile` still only queues/prunes companies, and the deprecated `target_company_slugs` JSONB column must remain unwritten.

## Testing and QA
- [x] `rg seeded_defaults app/ tests/ frontend/` — no hits
- [x] `uv run ruff check` — passed
- [x] `uv run pytest tests/integration/test_job_sync.py` — 9/9 passed
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test -- AppShell.test.tsx Chat.test.tsx` — 16/16 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves #109
