### PR TITLE
test(catalog): smoke check that lifespan actually runs seed_catalog (#111)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "ruff>=0.6",
     "mypy>=1.11",
     "pre-commit>=4.5.1",
+    "asgi-lifespan>=2.1.0",
 ]
 
 [tool.ruff]

--- a/tests/integration/test_lifespan_seed.py
+++ b/tests/integration/test_lifespan_seed.py
@@ -19,8 +19,36 @@ async def test_lifespan_runs_seed_catalog(db_session):
     # lifespan we want to exercise.
     from app.main import app
 
-    async with LifespanManager(app):
-        rows = (await db_session.execute(select(Company).where(Company.is_curated))).scalars().all()
+    # `app` is a process-global FastAPI instance shared with every other test.
+    # Lifespan exit closes the AsyncConnectionPool the checkpointer wraps but
+    # leaves the AsyncPostgresSaver attached to app.state — so anything later
+    # in the same pytest process that reads app.state.checkpointer (e2e
+    # tests/e2e/test_chat_flow.py go down the chat code path that uses it)
+    # would hit a closed pool and emit "Stream error". Snapshot before, restore
+    # after. Cleanup is unconditional — if the test body raises, the next test
+    # still gets a clean app.state.
+    # `app` is a process-global FastAPI instance shared with every other test.
+    # Lifespan exit closes the AsyncConnectionPool the checkpointer wraps but
+    # leaves the AsyncPostgresSaver attached to app.state — so anything later
+    # in the same pytest process that reads app.state.checkpointer (e2e
+    # tests/e2e/test_chat_flow.py go down the chat code path that uses it)
+    # would hit a closed pool and emit "Stream error". Snapshot before, restore
+    # after. Cleanup is unconditional — if the test body raises, the next test
+    # still gets a clean app.state.
+    prior = getattr(app.state, "checkpointer", None)
+    try:
+        async with LifespanManager(app):
+            rows = (
+                (await db_session.execute(select(Company).where(Company.is_curated)))
+                .scalars()
+                .all()
+            )
+    finally:
+        if prior is None:
+            if hasattr(app.state, "checkpointer"):
+                delattr(app.state, "checkpointer")
+        else:
+            app.state.checkpointer = prior
 
     assert len(rows) >= 1, "lifespan completed but no curated rows landed"
     assert any(r.canonical_name == "Stripe" for r in rows), (

--- a/tests/integration/test_lifespan_seed.py
+++ b/tests/integration/test_lifespan_seed.py
@@ -1,0 +1,29 @@
+"""Smoke check: booting FastAPI via lifespan actually seeds the curated catalog.
+
+Every other catalog test calls `seed_catalog(db_session)` directly. This one
+goes through the real `lifespan` context manager, so a future change that
+moves the seed call after `yield`, removes it, or breaks the lazy import
+inside lifespan would fail this test.
+"""
+
+from asgi_lifespan import LifespanManager
+from sqlmodel import select
+
+from app.models.company import Company
+
+
+async def test_lifespan_runs_seed_catalog(db_session):
+    # `patch_settings` (autouse) already points DATABASE_URL at the testcontainer
+    # and resets the cached settings/engine singletons. `db_session` has already
+    # created the schema. Importing `app.main` constructs the FastAPI app whose
+    # lifespan we want to exercise.
+    from app.main import app
+
+    async with LifespanManager(app):
+        rows = (await db_session.execute(select(Company).where(Company.is_curated))).scalars().all()
+
+    assert len(rows) >= 1, "lifespan completed but no curated rows landed"
+    assert any(r.canonical_name == "Stripe" for r in rows), (
+        "Stripe is in companies.yaml; if it stops appearing, the catalog "
+        "either wasn't seeded or the YAML drifted"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -96,6 +96,18 @@ wheels = [
 ]
 
 [[package]]
+name = "asgi-lifespan"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/da/e7908b54e0f8043725a990bf625f2041ecf6bfe8eb7b19407f1c00b630f7/asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308", size = 15627, upload-time = "2023-03-28T17:35:49.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/f5/c36551e93acba41a59939ae6a0fb77ddb3f2e8e8caa716410c65f7341f72/asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f", size = 10895, upload-time = "2023-03-28T17:35:47.772Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1015,6 +1027,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "anyio" },
+    { name = "asgi-lifespan" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1057,6 +1070,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "anyio", specifier = ">=4.0" },
+    { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=8" },


### PR DESCRIPTION
## Primary changes
- Add `tests/integration/test_lifespan_seed.py`, which boots the FastAPI app via `asgi_lifespan.LifespanManager` and asserts startup materializes at least one curated company row.
- Keep the assertion anchored to a known seeded company by checking that `Stripe` appears among the curated rows.
- Add `asgi-lifespan` as a dev dependency.

## Reviewer walkthrough
1. Review `tests/integration/test_lifespan_seed.py` for the new lifespan boot path, the `is_curated=true` query, and the `Stripe` sentinel assertion.
2. Review `pyproject.toml` and `uv.lock` for the `asgi-lifespan` dev dependency addition.
3. Sanity-check the test intent against issue `#111`: this is the only catalog test that exercises startup seeding via FastAPI lifespan instead of calling `seed_catalog(db_session)` directly.

## Correctness and invariants
- Existing catalog tests seed via `seed_catalog(db_session)` directly; this test specifically exercises the FastAPI lifespan path so regressions in startup seeding are caught.
- The protected invariant is that app startup must materialize at least one curated `Company` row, and `Stripe` is used as a stable sentinel anchored in `companies.yaml`.
- Red→green verification confirmed the failure mode: if the `seed_catalog(session)` block is removed from `app/main.py`, this test fails.

## Testing and QA
- [x] `uv run pytest tests/integration/test_lifespan_seed.py` — 1/1 passed
- [x] `uv run ruff check` — passed
- [x] Red→green cycle verified by temporarily commenting out the `seed_catalog(session)` block in `app/main.py`, observing `AssertionError: lifespan completed but no curated rows landed`, then restoring it before commit
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves #111
