### PR TITLE
ci: extract upsert-tracking-issue composite action (#112)

### DIFF
--- a/.github/actions/upsert-tracking-issue/action.yml
+++ b/.github/actions/upsert-tracking-issue/action.yml
@@ -1,0 +1,77 @@
+name: 'Upsert tracking issue'
+description: >-
+  Find an existing operator-alert issue by title (preferring OPEN, falling back
+  to the most-recently-closed) and append a comment; reopen it first if it was
+  closed; create a new issue if none exists.
+
+  Hardened after the #70 -> #72 churn (2026-05-04): a `closes #N` keyword on a
+  fix PR closes the tracker, so the next failure must reopen it rather than
+  spawn a fresh issue number. Searching state:all + preferring OPEN + falling
+  back to most-recently-closed implements that.
+
+inputs:
+  title:
+    description: >-
+      Issue title; also used as the dedup key (substring match in:title).
+    required: true
+  body:
+    description: >-
+      Markdown body to post as a new comment on the existing issue, or as the
+      initial body of a freshly created issue.
+    required: true
+  labels:
+    description: >-
+      Comma-separated label names to attach when CREATING a new issue. Ignored
+      if the tracker already exists. Falls back to no-label create if any of
+      the requested labels do not yet exist in the repo.
+    required: false
+    default: ''
+  reopen-comment:
+    description: >-
+      Comment posted when reopening a closed tracker. Defaults to a generic
+      "Reopened by <workflow>" line; override for a more specific message.
+    required: false
+    default: 'Reopened by ${{ github.workflow }} after this issue was closed.'
+  github-token:
+    description: >-
+      Token used for `gh issue list / create / comment / reopen`. The calling
+      job needs `permissions: issues: write`. Defaults to the repository
+      GITHUB_TOKEN.
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Find or upsert tracking issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        TITLE: ${{ inputs.title }}
+        BODY: ${{ inputs.body }}
+        LABELS: ${{ inputs.labels }}
+        REOPEN_COMMENT: ${{ inputs.reopen-comment }}
+      run: |
+        set -euo pipefail
+        existing=$(gh issue list --repo "$REPO" --state all \
+          --search "$TITLE in:title" \
+          --json number,state,closedAt --limit 20 \
+          --jq '([.[] | select(.state == "OPEN")] + ([.[] | select(.state == "CLOSED")] | sort_by(.closedAt) | reverse))[0] // empty' \
+          || echo "")
+        if [ -n "$existing" ]; then
+          num=$(echo "$existing" | jq -r '.number')
+          state=$(echo "$existing" | jq -r '.state')
+          if [ "$state" = "CLOSED" ]; then
+            gh issue reopen "$num" --repo "$REPO" --comment "$REOPEN_COMMENT"
+          fi
+          gh issue comment "$num" --repo "$REPO" --body "$BODY"
+        else
+          if [ -n "$LABELS" ]; then
+            gh issue create --repo "$REPO" --title "$TITLE" \
+              --label "$LABELS" --body "$BODY" \
+              || gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY"
+          fi
+        fi

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -113,41 +113,15 @@ jobs:
     permissions:
       issues: write
     steps:
+      - uses: actions/checkout@v5
       - name: Open or bump "cron failing" issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          FAILED_JOBS: "sync=${{ needs.sync.result }} generation-queue=${{ needs.generation-queue.result }} maintenance=${{ needs.maintenance.result }} process-sync-queue=${{ needs.process-sync-queue.result }} process-match-queue=${{ needs.process-match-queue.result }}"
-        run: |
-          set -euo pipefail
-          title="[cron] scheduled job failing"
-          # Search across BOTH open and closed issues so the persistent
-          # tracking-issue identity survives a `closes #N` keyword on a
-          # fix PR (#78). Without --state all, every cron-fix PR that
-          # closes the tracker would orphan it and force a new issue
-          # number on the next failure (#70 → #72 churn observed
-          # 2026-05-04). Prefer OPEN; fall back to most-recently-closed.
-          # If found-but-closed, reopen and comment.
-          existing=$(gh issue list --repo "$REPO" --state all --search "$title in:title" \
-            --json number,state,closedAt --limit 20 \
-            --jq '([.[] | select(.state == "OPEN")] + ([.[] | select(.state == "CLOSED")] | sort_by(.closedAt) | reverse))[0] // empty' \
-            || echo "")
-          body="Cron run failed: $RUN_URL
-          Job results: $FAILED_JOBS
+        uses: ./.github/actions/upsert-tracking-issue
+        with:
+          title: '[cron] scheduled job failing'
+          labels: 'incident,cron'
+          reopen-comment: 'Reopened by alert-on-failure: a new cron run failed after this issue was closed.'
+          body: |
+            Cron run failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Job results: sync=${{ needs.sync.result }} generation-queue=${{ needs.generation-queue.result }} maintenance=${{ needs.maintenance.result }} process-sync-queue=${{ needs.process-sync-queue.result }} process-match-queue=${{ needs.process-match-queue.result }}
 
-          First step in triage: check prod logs for 5xx from /internal/cron/* endpoints and reconcile prod schema vs deployed code (see commit 28e5ce5 for the canonical drift case)."
-          if [ -n "$existing" ]; then
-            num=$(echo "$existing" | jq -r '.number')
-            state=$(echo "$existing" | jq -r '.state')
-            if [ "$state" = "CLOSED" ]; then
-              gh issue reopen "$num" --repo "$REPO" \
-                --comment "Reopened by alert-on-failure: a new cron run failed after this issue was closed."
-            fi
-            gh issue comment "$num" --repo "$REPO" --body "$body"
-          else
-            gh issue create --repo "$REPO" --title "$title" \
-              --label "incident,cron" \
-              --body "$body" || \
-            gh issue create --repo "$REPO" --title "$title" --body "$body"
-          fi
+            First step in triage: check prod logs for 5xx from /internal/cron/* endpoints and reconcile prod schema vs deployed code (see commit 28e5ce5 for the canonical drift case).

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -36,48 +36,31 @@ jobs:
           path: |
             catalog-results.xml
             catalog.log
+      - name: Build issue body
+        if: failure()
+        id: body
+        run: |
+          {
+            echo 'body<<TRACKING_EOF'
+            echo 'Nightly catalog validation failed.'
+            echo
+            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo 'Tail of pytest output:'
+            echo '```'
+            tail -c 3000 catalog.log
+            echo '```'
+            echo
+            echo 'First step in triage: open the failing entry in companies.yaml,'
+            echo 'curl the (provider, slug) against the upstream board manually,'
+            echo 'and either replace the slug or drop the row in a follow-up PR.'
+            echo 'TRACKING_EOF'
+          } >> "$GITHUB_OUTPUT"
       - name: Open or update tracking issue on failure
         if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          title="[catalog] live validation failing"
-          # Search BOTH open and closed so a `closes #N` on a fix PR doesn't
-          # orphan the tracker (matches cron.yml::alert-on-failure pattern,
-          # which is in turn motivated by the #70 -> #72 churn on 2026-05-04).
-          # Prefer OPEN; fall back to most-recently-closed; reopen if needed.
-          existing=$(gh issue list --repo "$REPO" --state all \
-            --search "$title in:title" \
-            --json number,state,closedAt --limit 20 \
-            --jq '([.[] | select(.state == "OPEN")] + ([.[] | select(.state == "CLOSED")] | sort_by(.closedAt) | reverse))[0] // empty' \
-            || echo "")
-          log_tail=$(tail -c 3000 catalog.log)
-          body="Nightly catalog validation failed.
-
-          Workflow run: $RUN_URL
-
-          Tail of pytest output:
-          \`\`\`
-          $log_tail
-          \`\`\`
-
-          First step in triage: open the failing entry in companies.yaml,
-          curl the (provider, slug) against the upstream board manually,
-          and either replace the slug or drop the row in a follow-up PR."
-          if [ -n "$existing" ]; then
-            num=$(echo "$existing" | jq -r '.number')
-            state=$(echo "$existing" | jq -r '.state')
-            if [ "$state" = "CLOSED" ]; then
-              gh issue reopen "$num" --repo "$REPO" \
-                --comment "Reopened by validate-catalog: a new live-validation run failed after this issue was closed."
-            fi
-            gh issue comment "$num" --repo "$REPO" --body "$body"
-          else
-            gh issue create --repo "$REPO" --title "$title" \
-              --label "catalog-validation" \
-              --body "$body" || \
-            gh issue create --repo "$REPO" --title "$title" --body "$body"
-          fi
+        uses: ./.github/actions/upsert-tracking-issue
+        with:
+          title: '[catalog] live validation failing'
+          labels: 'catalog-validation'
+          reopen-comment: 'Reopened by validate-catalog: a new live-validation run failed after this issue was closed.'
+          body: ${{ steps.body.outputs.body }}


### PR DESCRIPTION
## Primary changes
- Adds `.github/actions/upsert-tracking-issue/action.yml`, a composite action that encapsulates the find-or-comment-or-reopen tracking-issue pattern hardened across `cron.yml` and `validate-catalog.yml`.
- Both workflows now call the action instead of carrying the same bash script. Inputs: `title`, `body`, `labels`, `reopen-comment`, `github-token`.
- `cron.yml::alert-on-failure` picked up an `actions/checkout@v5` step (required for `uses: ./.github/actions/...`).
- `validate-catalog.yml` builds the failure body in a `Build issue body` step and threads it through `$GITHUB_OUTPUT` so the `body:` input is a fully-rendered string. Heredoc delimiter `TRACKING_EOF` is unlikely to appear in pytest output.

## Reviewer walkthrough
- Start with `.github/actions/upsert-tracking-issue/action.yml`, which extracts the shared find-or-comment-or-reopen flow behind inputs `title`, `body`, `labels`, `reopen-comment`, and `github-token`.
- Then review `.github/workflows/cron.yml`, where `alert-on-failure` now checks out the repo and calls the local composite action instead of carrying inline issue-management bash.
- Finish with `.github/workflows/validate-catalog.yml`, where a `Build issue body` step renders the failure report before passing the fully rendered string into the shared action.

## Correctness and invariants
The action's bash mirrors the cron.yml original verbatim:
- `gh issue list --state all --search "$title in:title"`
- `--jq '([.[] | select(.state == "OPEN")] + ([.[] | select(.state == "CLOSED")] | sort_by(.closedAt) | reverse))[0] // empty'`
- Reopen (with reopen-comment) → comment; or create (with label-fallback to no-label create on failure).

Drift between the two consumers — exactly what review on #107 caught — is now structurally impossible.

## Testing and QA
- [x] `uv run python -c "import yaml; ..."` — both workflows + the action parse cleanly
- [x] `yamllint` — clean
- [x] Job graph and step ordering manually verified (cron.yml retains all 6 jobs; validate-catalog.yml gained a Build issue body step before the upsert call)
- [ ] **Operator step:** `workflow_dispatch` `cron.yml` with one job deliberately failing, confirm a tracking issue is opened. Repeat with the issue closed to confirm reopen+comment. Same drill on `validate-catalog.yml`.
- [ ] CI green

Refs: commits 28e5ce5 / #78 (the incident this pattern exists to prevent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves #112