### PR TITLE
fix(matching): bump JD truncation 12k → 20k

### DIFF
--- a/app/agents/matching_agent.py
+++ b/app/agents/matching_agent.py
@@ -26,7 +26,7 @@ from app.config import get_settings
 
 log = structlog.get_logger()
 
-MAX_JOB_DESC_CHARS = 12000
+MAX_JOB_DESC_CHARS = 20000
 
 
 def truncate_description(desc: str, max_chars: int = MAX_JOB_DESC_CHARS) -> str:

--- a/tests/unit/test_matching_agent.py
+++ b/tests/unit/test_matching_agent.py
@@ -53,12 +53,12 @@ def test_score_result_has_summary_field():
     assert sr.summary == "Senior backend role, Python+AWS, hybrid NYC."
 
 
-def test_max_job_desc_chars_is_12k():
-    # Bumped from 8k. Gemini 2.5 has plenty of context — 8k was an arbitrary
-    # latency-era cap and was clipping a non-trivial fraction of real postings
-    # (anecdotally far more than 5-10%). 12k keeps prompts well under input
-    # budget while keeping the longer JDs intact.
-    assert MAX_JOB_DESC_CHARS == 12000
+def test_max_job_desc_chars_is_20k():
+    # Bumped 8k → 12k → 20k. Gemini 2.5 has plenty of context; the cap exists
+    # to keep prompt cost predictable, not to fit the model. 20k captures the
+    # tail of real postings (long JD + benefits + boilerplate) without
+    # truncating anything but the most pathologically long descriptions.
+    assert MAX_JOB_DESC_CHARS == 20000
 
 
 def test_truncate_description_passes_through_at_threshold():


### PR DESCRIPTION
## Summary
- Raise `MAX_JOB_DESC_CHARS` from 12000 to 20000 in `app/agents/matching_agent.py`.
- Update the corresponding unit test (renamed `test_max_job_desc_chars_is_20k`, comment now documents the 8k → 12k → 20k progression).

Captures the long tail of postings (long JD + benefits + boilerplate) without truncating. Gemini 2.5 has plenty of context; the cap exists to keep prompt cost predictable, not to fit the model.


## Primary changes

- Raise `MAX_JOB_DESC_CHARS` from `12000` to `20000` in `app/agents/matching_agent.py`.
- Rename the unit test to `test_max_job_desc_chars_is_20k` and update its rationale comment to document the `8k → 12k → 20k` progression.

## Reviewer walkthrough

1. Review `app/agents/matching_agent.py` to confirm the production change is the `MAX_JOB_DESC_CHARS` bump from `12000` to `20000`.
2. Review `tests/unit/test_matching_agent.py` to confirm the renamed assertion and updated rationale comment stay aligned with the new cap.
3. Sanity-check the stated behavior: longer job descriptions should stop truncating in the common “JD + benefits + boilerplate” cases, while the cap still exists to keep prompt cost predictable.

## Correctness and invariants

- `truncate_description()` should now pass through job descriptions up to `20000` characters before truncating.
- The test name, assertion, and rationale comment should stay aligned with the production constant so future cap changes are explicit.
- The cap change is meant to reduce avoidable truncation on long real-world postings, not to fit a model-context limit.

## Testing and QA
- [x] `uv run pytest tests/unit/test_matching_agent.py` (9 passed locally)
- [ ] CI green on this PR
- [ ] Post-merge `deploy` + `smoke-prod` jobs green on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
