### PR TITLE
fix(docker): build runtime venv with matching python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
         run: |
           SHA=${{ github.sha }}
           docker build -t ghcr.io/maksym-panibrat/job-application-agent:$SHA -t ghcr.io/maksym-panibrat/job-application-agent:main .
+          docker run --rm --entrypoint sh ghcr.io/maksym-panibrat/job-application-agent:$SHA -c 'python -c "import uvicorn, alembic, fastapi; import app.worker" && alembic --version'
           docker push ghcr.io/maksym-panibrat/job-application-agent:$SHA
           docker push ghcr.io/maksym-panibrat/job-application-agent:main
       - name: Dispatch bump to panibrat-infra

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN npm ci
 COPY frontend/ ./
 RUN npm run build
 
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm AS builder
+FROM ghcr.io/astral-sh/uv:python3.14-bookworm AS builder
 WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev --frozen


### PR DESCRIPTION
## Summary
- build the production virtualenv with Python 3.14 to match the runtime image
- add a Docker image runtime import guard before pushing GHCR images

## Verification
- docker build -t job-application-agent:runtime-venv-fix .
- docker run --rm --entrypoint sh job-application-agent:runtime-venv-fix -c 'python -c "import uvicorn, alembic, fastapi; import app.worker" && alembic --version'\n- git diff --check\n\n## Production context\nThe Phase B deploy exposed that the previous image virtualenv was built under Python 3.12 and copied into a Python 3.14 runtime, causing runtime imports like uvicorn and alembic to fail. Production was rolled back to the previous image while this fix is built.