### PR TITLE
fix(worker): persist generated cover letter documents

### DIFF
--- a/app/worker/handlers/generate_cover_letter.py
+++ b/app/worker/handlers/generate_cover_letter.py
@@ -7,8 +7,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
 from sqlmodel import select
 
+from app.config import get_settings
 from app.database import get_session_factory
-from app.models.application import Application
+from app.models.application import Application, GeneratedDocument
 from app.models.work_queue import WorkQueue
 from app.worker.handlers import HANDLERS, TransientError
 from app.worker.payloads import GenerateCoverLetterPayload
@@ -118,6 +119,31 @@ class GenerateCoverLetterHandler:
         app.generation_status = "ready"
         app.updated_at = datetime.now(UTC)
         session.add(app)
+
+        existing_doc = (
+            await session.execute(
+                select(GeneratedDocument).where(
+                    GeneratedDocument.application_id == app.id,
+                    GeneratedDocument.doc_type == "cover_letter",
+                )
+            )
+        ).scalar_one_or_none()
+        if existing_doc is None:
+            session.add(
+                GeneratedDocument(
+                    application_id=app.id,
+                    doc_type="cover_letter",
+                    content_md=content,
+                    generation_model=get_settings().llm_generation_model,
+                    structured_content=None,
+                )
+            )
+        else:
+            existing_doc.content_md = content
+            existing_doc.generation_model = get_settings().llm_generation_model
+            existing_doc.structured_content = None
+            session.add(existing_doc)
+
         await log.ainfo(
             "worker.generate_cover_letter.done",
             application_id=str(app.id),

--- a/tests/integration/test_handler_generate_cover_letter.py
+++ b/tests/integration/test_handler_generate_cover_letter.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import sqlalchemy as sa
 
-from app.models.application import Application
+from app.models.application import Application, GeneratedDocument
 from app.models.job import Job
 from app.models.user import User
 from app.models.user_profile import UserProfile
@@ -81,9 +81,18 @@ async def test_generate_cover_letter_handler_generates_and_flips_ready(db_sessio
     refreshed = (
         await db_session.execute(sa.select(Application).where(Application.id == app_id))
     ).scalar_one()
+    doc = (
+        await db_session.execute(
+            sa.select(GeneratedDocument).where(
+                GeneratedDocument.application_id == app_id,
+                GeneratedDocument.doc_type == "cover_letter",
+            )
+        )
+    ).scalar_one()
     assert refreshed.generation_status == "ready"
     assert refreshed.cover_letter_content == "GENERATED COVER LETTER"
     assert refreshed.generated_at is not None
+    assert doc.content_md == "GENERATED COVER LETTER"
     assert mock_llm.call_count == 1
 
 


### PR DESCRIPTION
## Summary
- make the async generate-cover-letter worker create/update the cover-letter GeneratedDocument row
- keep Application.cover_letter_content/status updates unchanged
- add a regression assertion for the worker handler document side effect

## Root cause
The Phase B worker handler called generate_materials_llm(), then only wrote Application.cover_letter_content and generation_status=ready. The UI renders from ApplicationDetail.documents, so production jobs could complete successfully while the page still had no cover-letter document to display.

## Production repair already run
Inserted missing cover-letter document rows for ready applications that had cover_letter_content but no cover_letter GeneratedDocument. Repaired rows: 1.

## Verification
- Red: `uv run pytest tests/integration/test_handler_generate_cover_letter.py::test_generate_cover_letter_handler_generates_and_flips_ready` failed with NoResultFound before the fix
- Green: same test passed after the fix
- `uv run pytest tests/integration/test_handler_generate_cover_letter.py tests/integration/test_cover_letter_async_endpoint.py tests/integration/test_application_service_lifecycle.py` -> 18 passed, 20 existing JWT test-key warnings
- `uv run ruff check app/worker/handlers/generate_cover_letter.py tests/integration/test_handler_generate_cover_letter.py` -> All checks passed
- `git diff --check` -> clean
