### PR TITLE
fix(sync): reconcile idle status and stop idle polling

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -1,5 +1,7 @@
 """Jobs sync and query endpoints."""
 
+from datetime import UTC, datetime
+
 import structlog
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
@@ -101,6 +103,22 @@ async def sync_status(
     else:
         state = "idle"
 
+    last_sync_summary = profile.last_sync_summary
+    if (
+        state == "idle"
+        and profile.last_sync_requested_at is not None
+        and (
+            profile.last_sync_completed_at is None
+            or profile.last_sync_completed_at < profile.last_sync_requested_at
+        )
+    ):
+        profile.last_sync_completed_at = datetime.now(UTC)
+        if isinstance(last_sync_summary, dict):
+            last_sync_summary = {**last_sync_summary, "queued_slugs": []}
+            profile.last_sync_summary = last_sync_summary
+        session.add(profile)
+        await session.commit()
+
     return {
         "state": state,
         "slugs_total": len(pairs),
@@ -112,6 +130,6 @@ async def sync_status(
         "last_sync_completed_at": profile.last_sync_completed_at.isoformat()
         if profile.last_sync_completed_at
         else None,
-        "last_sync_summary": profile.last_sync_summary,
+        "last_sync_summary": last_sync_summary,
         "invalid_slugs": sorted(invalid_slugs),
     }

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -138,6 +138,22 @@ describe('AppShell sync (header button)', () => {
     )
   })
 
+  it('stops polling sync status after an idle response', async () => {
+    let statusCalls = 0
+    server.use(
+      http.get('/api/sync/status', () => {
+        statusCalls += 1
+        return HttpResponse.json(idleStatus)
+      }),
+    )
+    renderShell()
+
+    await waitFor(() => expect(statusCalls).toBe(1))
+    await new Promise((r) => setTimeout(r, 3_500))
+
+    expect(statusCalls).toBe(1)
+  }, 6_000)
+
   it('reflects live sync state in the button aria-label and disables it', async () => {
     server.use(
       http.get('/api/sync/status', () => HttpResponse.json({

--- a/frontend/src/lib/useSyncControl.ts
+++ b/frontend/src/lib/useSyncControl.ts
@@ -36,12 +36,14 @@ export function useSyncControl({ enabled = true }: UseSyncControlOptions = {}): 
   const qc = useQueryClient()
   const { show } = useToast()
   const [status, setStatus] = useState<SyncStatus | null>(null)
+  const [pollKick, setPollKick] = useState(0)
   const prevState = useRef<SyncStatus['state'] | null>(null)
   const fastSyncTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!enabled) return
     let cancelled = false
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
     async function poll() {
       try {
         const body = await api.getSyncStatus()
@@ -51,14 +53,19 @@ export function useSyncControl({ enabled = true }: UseSyncControlOptions = {}): 
           qc.invalidateQueries({ queryKey: ['applications'] })
         }
         prevState.current = body.state
+        if (body.state !== 'idle') {
+          timeoutId = setTimeout(poll, POLL_MS)
+        }
       } catch {
         // Silent — control just stays "Sync now" without live state.
       }
     }
     poll()
-    const id = setInterval(poll, POLL_MS)
-    return () => { cancelled = true; clearInterval(id) }
-  }, [qc, enabled])
+    return () => {
+      cancelled = true
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+  }, [qc, enabled, pollKick])
 
   // Cleanup any in-flight delayed invalidation on unmount so it can't fire
   // against a stale QueryClient (e.g., after sign-out).
@@ -77,6 +84,7 @@ export function useSyncControl({ enabled = true }: UseSyncControlOptions = {}): 
       // Belt-and-suspenders for fast syncs that finish before the poller
       // catches a non-idle state — surfaces `matched_now` cache hits in the feed.
       if (fastSyncTimeout.current) clearTimeout(fastSyncTimeout.current)
+      setPollKick((value) => value + 1)
       fastSyncTimeout.current = setTimeout(
         () => qc.invalidateQueries({ queryKey: ['applications'] }),
         FAST_SYNC_INVALIDATE_MS,

--- a/tests/integration/test_sync_status_endpoint.py
+++ b/tests/integration/test_sync_status_endpoint.py
@@ -9,6 +9,7 @@ from sqlmodel import SQLModel
 
 import app.models  # noqa: F401
 from app.models.company import Company
+from app.models.slug_fetch import SlugFetch
 from app.services import slug_registry_service
 
 
@@ -81,3 +82,47 @@ async def test_status_lists_invalid_slugs(client, auth_headers, seeded_user, db_
     response = await client.get("/api/sync/status", headers=auth_headers)
     body = response.json()
     assert body["invalid_slugs"] == ["openai"]
+
+
+@pytest.mark.asyncio
+async def test_status_reconciles_stale_queued_summary_when_idle(
+    client, auth_headers, seeded_user, db_session
+):
+    _, profile = seeded_user
+    company = Company(
+        canonical_name="Anthropic",
+        normalized_key="anthropic",
+        provider_slugs={"greenhouse": "anthropic"},
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.add(company)
+    await db_session.commit()
+    await db_session.refresh(company)
+
+    profile.target_company_ids = [company.id]
+    profile.last_sync_requested_at = datetime(2026, 5, 14, 4, 0, tzinfo=UTC)
+    profile.last_sync_completed_at = datetime(2026, 5, 13, 22, 45, tzinfo=UTC)
+    profile.last_sync_summary = {
+        "queued_slugs": ["anthropic"],
+        "matched_now": 0,
+        "pruned_slugs": 0,
+    }
+    db_session.add(profile)
+    db_session.add(
+        SlugFetch(
+            source="greenhouse",
+            slug="anthropic",
+            queued_at=None,
+            claimed_at=None,
+            last_status="ok",
+            last_fetched_at=datetime(2026, 5, 14, 4, 0, 20, tzinfo=UTC),
+        )
+    )
+    await db_session.commit()
+
+    response = await client.get("/api/sync/status", headers=auth_headers)
+    body = response.json()
+
+    assert body["state"] == "idle"
+    assert body["last_sync_summary"]["queued_slugs"] == []
+    assert body["last_sync_completed_at"] >= "2026-05-14T04:00:00"


### PR DESCRIPTION
## Summary
- clear stale last_sync_summary.queued_slugs when /api/sync/status live counts are idle
- advance last_sync_completed_at when status reconciliation proves a requested sync has drained
- stop the header sync control from polling /api/sync/status forever after an idle response; a manual sync click kicks polling again

## Verification
- uv run pytest tests/integration/test_sync_status_endpoint.py tests/integration/test_jobs_endpoint.py
- uv run ruff check app/api/jobs.py tests/integration/test_sync_status_endpoint.py
- npm run test -- --run src/components/AppShell.test.tsx
- npm run typecheck
- git diff --check