### PR TITLE
fix(frontend): authenticate analytics events

### DIFF
--- a/frontend/src/lib/track.test.ts
+++ b/frontend/src/lib/track.test.ts
@@ -27,6 +27,7 @@ describe('track()', () => {
   })
 
   it('does not fetch synchronously — flushes after the timer', async () => {
+    sessionStorage.setItem('access_token', 'test-token')
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
     globalThis.fetch = fetchSpy as typeof fetch
     const { track, _reset } = await import('./track')
@@ -36,6 +37,7 @@ describe('track()', () => {
   })
 
   it('flushes the queue after 5 seconds', async () => {
+    sessionStorage.setItem('access_token', 'test-token')
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
     globalThis.fetch = fetchSpy as typeof fetch
     const { track, _reset } = await import('./track')
@@ -52,7 +54,32 @@ describe('track()', () => {
     expect(typeof body.session_id).toBe('string')
   })
 
+  it('sends the bearer token when flushing events', async () => {
+    sessionStorage.setItem('access_token', 'event-token')
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+    const { track, _reset } = await import('./track')
+    currentReset = _reset
+    track('feed.viewed')
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect((fetchSpy.mock.calls[0][1] as RequestInit).headers).toMatchObject({
+      Authorization: 'Bearer event-token',
+    })
+  })
+
+  it('drops queued events without an access token', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+    const { track, _reset } = await import('./track')
+    currentReset = _reset
+    track('auth.signin_clicked', { method: 'google' })
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
   it('flushes on pagehide', async () => {
+    sessionStorage.setItem('access_token', 'test-token')
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
     globalThis.fetch = fetchSpy as typeof fetch
     const { track, _reset } = await import('./track')
@@ -63,6 +90,7 @@ describe('track()', () => {
   })
 
   it('caps each batch at 50 events', async () => {
+    sessionStorage.setItem('access_token', 'test-token')
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
     globalThis.fetch = fetchSpy as typeof fetch
     const { track, _reset } = await import('./track')
@@ -75,6 +103,7 @@ describe('track()', () => {
   })
 
   it('swallows fetch errors silently', async () => {
+    sessionStorage.setItem('access_token', 'test-token')
     const fetchSpy = vi.fn().mockRejectedValue(new Error('network'))
     globalThis.fetch = fetchSpy as typeof fetch
     const { track, _reset } = await import('./track')
@@ -84,6 +113,7 @@ describe('track()', () => {
   })
 
   it('persists session_id across calls', async () => {
+    sessionStorage.setItem('access_token', 'test-token')
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
     globalThis.fetch = fetchSpy as typeof fetch
     const { track, _reset } = await import('./track')

--- a/frontend/src/lib/track.ts
+++ b/frontend/src/lib/track.ts
@@ -1,8 +1,9 @@
 /** In-app event tracking — see spec section 7.
  *
  *  Public API: `track(name, properties?)`. Calls are buffered and flushed
- *  every 5s and on `pagehide`. Failures are swallowed so analytics never
- *  break the app. */
+ *  every 5s and on `pagehide`. The server requires an authenticated profile,
+ *  so calls made before a JWT exists are skipped client-side. Failures are
+ *  swallowed so analytics never break the app. */
 
 interface EventIn {
   name: string
@@ -31,6 +32,11 @@ function getSessionId(): string {
 async function flush(): Promise<void> {
   flushTimer = null
   if (queue.length === 0) return
+  const token = sessionStorage.getItem('access_token')
+  if (!token) {
+    queue.length = 0
+    return
+  }
   const batch = queue.splice(0, MAX_BATCH)
   if (queue.length > 0 && flushTimer == null) {
     flushTimer = window.setTimeout(flush, FLUSH_MS)
@@ -38,7 +44,10 @@ async function flush(): Promise<void> {
   try {
     await fetch('/api/events', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
       body: JSON.stringify({ session_id: getSessionId(), events: batch }),
       keepalive: true,
     })
@@ -48,6 +57,7 @@ async function flush(): Promise<void> {
 }
 
 export function track(name: string, properties?: Record<string, unknown>): void {
+  if (!sessionStorage.getItem('access_token')) return
   queue.push({
     name,
     properties,


### PR DESCRIPTION
## Summary
- send Authorization bearer token when flushing /api/events
- skip analytics events while no access token exists, matching the authenticated endpoint contract
- add regression coverage for authenticated and unauthenticated tracking behavior

## Verification
- npm run test -- --run src/lib/track.test.ts
- npm run typecheck
- uv run pytest tests/integration/test_events_api.py
- git diff --check
- npm run test -- --run