### PR TITLE
cleanup: remove worker queue migration image gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev --frozen
 
 FROM python:3.14-slim-bookworm AS runtime
-LABEL org.opencontainers.image.requires-infra-bundle="phase-b"
 WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
 COPY app/ ./app/


### PR DESCRIPTION
## Summary
- remove the temporary OCI image label that required the coordinated infra bundle
- restore the normal app image bump/deploy flow now that the destructive queue-column migration has been applied in production

## Verification
- git diff --check
- rg -n "requires-infra-bundle|phase-b" Dockerfile .github app scripts alembic tests || true
- docker build --target runtime --label org.opencontainers.image.test=phase-b-label-removal -t job-application-agent:label-cleanup-check .
- docker image inspect job-application-agent:label-cleanup-check --format '{{ json .Config.Labels }}'