### PR TITLE
docs: refresh worker queue operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,11 +126,8 @@ jobs:
 
   build-and-push:
     # Build + push to GHCR, then dispatch a bump into panibrat-infra.
-    # Replaces the old GCP path (migrate → Cloud Run deploy → smoke against Cloud Run URL).
-    # Alembic migrations now happen on the box (Phase B will add the dedicated
-    # alembic-upgrade compose service; for Phase A the existing in-app behavior
-    # — migrations run during local dev only, prod migrations stay manual until
-    # Phase B — is preserved).
+    # Alembic migrations run on the box through panibrat-infra's release-profile
+    # alembic-upgrade service during the job-search deploy.
     runs-on: ubuntu-latest
     needs: [test, frontend, e2e-browser]
     # main push for normal flow; workflow_dispatch lets us bootstrap a GHCR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ cd frontend && npm install && npm run dev   # :5173, proxies /api + /health to :
 
 Required env: `DATABASE_URL`, `GOOGLE_API_KEY`. Full list: `app/config.py::Settings`.
 
-**Migrations**: always use `make migrate ARGS="..."` (or `uv run python scripts/alembic_safe.py ...`), never plain `alembic`. The wrapper blocks write commands (`upgrade` / `downgrade` / `stamp` / `merge` / `revision --autogenerate`) against non-local hosts unless `I_KNOW_ITS_PROD=1` is set. Running `alembic upgrade head` against Neon from a dev laptop is the exact outage mode of commit 28e5ce5 (schema ahead of deployed code → every `select(Application)` 500s). **Phase A (post-Hetzner-migration) prod migrations are run manually on the box**: SSH in as personal user, `sudo -u deploy bash -lc 'cd /srv/panibrat-infra && docker compose run --rm job-search-api alembic upgrade head'`. Phase B will introduce a dedicated `alembic-upgrade` compose service that runs as part of every deploy.
+**Migrations**: always use `make migrate ARGS="..."` (or `uv run python scripts/alembic_safe.py ...`), never plain `alembic`. The wrapper blocks write commands (`upgrade` / `downgrade` / `stamp` / `merge` / `revision --autogenerate`) against non-local hosts unless `I_KNOW_ITS_PROD=1` is set. Running `alembic upgrade head` against Neon from a dev laptop is the exact outage mode of commit 28e5ce5 (schema ahead of deployed code → every `select(Application)` 500s). Production migrations run on the Hetzner box through the `alembic-upgrade` compose release profile during `panibrat-infra` deploys.
 
 ## Tests
 
@@ -49,17 +49,19 @@ Onboarding (`app/agents/onboarding.py`) is the only agent that uses `AsyncPostgr
 
 Matching agent uses `asyncio.Semaphore` + 1.5s sleep + 10s/30s exponential backoff on 429; falls back to `score=0.0` after retries. `ScoreResult.strengths/gaps` coerces prose to lists.
 
-### Scheduler
+### Worker queue and cron
 
-No in-process scheduler. `app/scheduler/tasks.py` is invoked via `POST /internal/cron/{sync,generation-queue,maintenance}` with `X-Cron-Secret`. **Triggered by `supercronic` running on the Hetzner box** (`panibrat-infra/supercronic.crontab`). The old `.github/workflows/cron.yml` was deleted during the Hetzner migration. Crontab times are UTC; same schedule as before. Phase B (worker + queue) will replace the heavy lifting that lives behind these endpoints with a continuously-running worker; the cron endpoints will remain as thin "enqueue + return" handlers.
+No in-process scheduler. Cron endpoints are thin enqueuers protected by `X-Cron-Secret`: `POST /internal/cron/sync`, `POST /internal/cron/generation-reconcile`, and `POST /internal/cron/maintenance`. They are triggered by `supercronic` on the Hetzner box (`panibrat-infra/supercronic.crontab`). Long-running work is processed by the always-on `python -m app.worker` process through Postgres `work_queue`.
+
+`work_queue` job types are `fetch-slug`, `match`, `generate-cover-letter`, and `maintenance`. The worker owns claiming, lease timeouts, transient retry/backoff, terminal failure handling, and lease-checked finalization.
 
 ### Generation contract
 
-`generate_materials()` (`app/services/application_service.py`) runs the cover-letter graph synchronously and returns the saved `GeneratedDocument`. The HTTP entrypoint is `POST /api/applications/{id}/cover-letter` — the request blocks for the duration of the LLM call (≈10–30s) and there is no background task, no checkpointer, no interrupt, and no `/resume` endpoint. Valid `generation_status` values: `none · generating · ready · failed`. Single-writer rule: `generate_materials` owns the status writes (`generating` → `ready`/`failed`); the API route does nothing but await it.
+`POST /api/applications/{id}/cover-letter` is asynchronous. It flips `generation_status` to `pending`, enqueues a `generate-cover-letter:{application_id}` work row, and returns `202 {"status":"pending","job_id":...}`. Clients poll `GET /api/applications/{id}/cover-letter/status`. Valid `generation_status` values: `none · pending · generating · ready · failed`. There is no checkpointer, interrupt, or `/resume` endpoint; regeneration is modeled as a new queue request from `none`, `ready`, or `failed`.
 
 ### Observability
 
-Logs ship to **Axiom** (hosted) via Vector running on the Hetzner box. structlog emits plain JSON; Vector reads container stdout via the Docker socket and ships to two datasets: `job-search` (this app) and `infra` (Caddy + supercronic + vector itself + unattended-upgrades). `structlog.processors.format_exc_info` turns `exc_info=True` / `log.aexception` into a readable traceback in the log payload. No Sentry, no GCP Error Reporting; the dedicated Cloud Run severity processor was deleted during the Hetzner migration. Queries via Axiom UI or the Axiom MCP server (see `panibrat-infra/docs/runbooks/apl-primer.md`).
+Logs ship to **Axiom** (hosted) via Vector running on the Hetzner box. structlog emits plain JSON; Vector reads container stdout via the Docker socket and ships API logs to `job-search`; worker, Caddy, supercronic, and unattended-upgrades logs go to `infra`. `structlog.processors.format_exc_info` turns `exc_info=True` / `log.aexception` into a readable traceback in the log payload. No Sentry. Queries via Axiom UI or the Axiom MCP server (see `panibrat-infra/docs/runbooks/apl-primer.md`).
 
 ## Hard app-level limits (not DB constraints)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Job Application Agent
 
-AI-powered job search assistant: ingests Greenhouse company boards, scores each role against your profile, and generates a tailored cover letter on demand.
+AI-powered job search assistant: follows companies across supported ATS providers, scores each role against your profile, and queues tailored cover-letter generation.
 
 **Live demo:** https://job-search.panibrat.com
 
@@ -9,13 +9,13 @@ AI-powered job search assistant: ingests Greenhouse company boards, scores each 
 ```
 Resume upload + onboarding chat
         ↓
-  Greenhouse public board sync (target_company_slugs)
+  Company sync across supported ATS providers
         ↓
-  Matching agent scores each job
+  Worker fetches jobs and scores matches
         ↓
-  Visitor reviews matches → clicks "Generate cover letter"
+  Visitor reviews matches → queues a cover letter
         ↓
-  "Open application" → Greenhouse form → "Mark as applied"
+  "Open application" → ATS form → "Mark as applied"
 ```
 
 ## Tech stack
@@ -54,7 +54,7 @@ cd frontend && npm run build            # build to app/static/
 
 ## Deployment
 
-See [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for the full GCP + Neon provisioning guide.
+See [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for the current GHCR + Hetzner deployment flow.
 
 ## License
 

--- a/app/services/application_service.py
+++ b/app/services/application_service.py
@@ -1,8 +1,9 @@
 """
-Application service — generate_materials() drives the cover-letter agent.
+Application service — queue cover-letter generation and run the generation graph.
 
-Synchronous: callers (the API route) await this directly. No checkpointer,
-no interrupt, no resume. generation_status: none -> generating -> ready/failed.
+HTTP requests enqueue work and return 202; app.worker later calls the LLM helper.
+No checkpointer, interrupt, or resume endpoint. generation_status:
+none -> pending -> generating -> ready/failed.
 """
 
 import time

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,241 +1,80 @@
 # Deployment Reference
 
-## 1. Neon Postgres
+Production runs on the Hetzner host managed by
+[`panibrat-infra`](https://github.com/maksym-panibrat/panibrat-infra). This app
+repo builds and publishes the image; the infra repo owns compose, Caddy,
+supercronic, Vector, release migrations, rollback, and host secrets.
 
-Create a project at <https://neon.tech>, grab the **pooled** connection string, replace `postgresql://` with `postgresql+asyncpg://`, save as `DATABASE_URL`.
+## Runtime Shape
 
-## 2. Google Cloud setup
+- `job-search-api`: FastAPI serving `job-search.panibrat.com`.
+- `job-search-worker`: same image, `python -m app.worker`, consuming Postgres
+  `work_queue`.
+- `alembic-upgrade`: release-profile compose service run during deploy.
+- `supercronic`: external scheduler that calls thin internal cron enqueuers.
+- Neon Postgres remains external.
+- Logs ship through Vector to Axiom.
 
-Install gcloud: <https://cloud.google.com/sdk/docs/install>
+## Normal Deploy Flow
 
-```bash
-gcloud auth login
-gcloud projects create job-application-agent-493810
-gcloud config set project job-application-agent-493810
-gcloud billing projects link job-application-agent-493810 --billing-account=BILLING_ACCOUNT_ID
-gcloud services enable run.googleapis.com artifactregistry.googleapis.com secretmanager.googleapis.com iamcredentials.googleapis.com cloudbuild.googleapis.com clouderrorreporting.googleapis.com
-gcloud artifacts repositories create app --repository-format=docker --location=us-central1
-```
+1. Push to `main`.
+2. `ci.yml` runs backend, frontend, browser E2E, then builds the Docker image.
+3. The image is pushed to GHCR as both `:<commit-sha>` and `:main`.
+4. CI sends a `bump-app-image` repository dispatch to `panibrat-infra` with
+   `app=job-search` and the commit SHA.
+5. `panibrat-infra/.github/workflows/bump.yml` opens a one-line `compose.yml`
+   bump PR.
+6. Merging that PR triggers `panibrat-infra/.github/workflows/deploy.yml`.
+7. The deploy script SSHes to the host, pulls the image, pauses supercronic,
+   runs Alembic through the release profile, starts API and worker, verifies
+   health, reloads Caddy, and resumes supercronic unless it was operator-paused.
 
-## 3. Secrets in Secret Manager
+The active operational runbooks live in `panibrat-infra/docs/runbooks/`,
+especially `deploy.md`, `rollback.md`, `cron.md`, and `observability.md`.
 
-### 3a. Required
+## Required GitHub Secrets
 
-```bash
-printf "%s" "GEMINI_KEY"                    | gcloud secrets create google-api-key --data-file=-      # https://aistudio.google.com/apikey
-printf "%s" "postgresql+asyncpg://..."      | gcloud secrets create database-url --data-file=-
-printf "%s" "$(openssl rand -hex 32)"       | gcloud secrets create cron-shared-secret --data-file=-
-printf "%s" "$(openssl rand -hex 32)"       | gcloud secrets create jwt-secret --data-file=-
-```
-
-Google OAuth credentials are required in production; see §3b.
-
-The `cron-shared-secret` value also goes into GHA as `CRON_SHARED_SECRET` (§4):
-
-```bash
-gcloud secrets versions access latest --secret=cron-shared-secret
-```
-
-### 3b. Google OAuth (required)
-
-Required for sign-in (single-user fallback was removed). Deploy probes these with `gcloud secrets describe` and fails closed if absent.
-
-1. <https://console.cloud.google.com/apis/credentials> → OAuth consent screen: External, scopes `email openid profile`, add yourself as a test user.
-2. Create credentials → OAuth client ID → Web application.
-3. Authorized redirect URI: `https://<cloud-run-url>/auth/google/callback`.
-4. Store the client id + secret:
-   ```bash
-   printf "%s" "CLIENT_ID"     | gcloud secrets create google-oauth-client-id --data-file=-
-   printf "%s" "CLIENT_SECRET" | gcloud secrets create google-oauth-client-secret --data-file=-
-   ```
-
-> Error monitoring uses **GCP Cloud Error Reporting** (§8). No Sentry DSN needed.
-
-### 3c. Per-secret IAM (rare)
-
-Project-level `secretAccessor` (§5) covers new secrets. If a deploy fails with `Permission denied` on a specific one:
-
-```bash
-SA="github-deployer@job-application-agent-493810.iam.gserviceaccount.com"
-for s in google-oauth-client-id google-oauth-client-secret; do
-  gcloud secrets add-iam-policy-binding "$s" --member="serviceAccount:$SA" --role="roles/secretmanager.secretAccessor"
-done
-```
-
-## 4. GitHub repo secrets
-
-**Settings → Secrets and variables → Actions** (or `gh secret set <name>`):
-
-| Secret | When | Value |
+| Secret | Used by | Purpose |
 |---|---|---|
-| `GCP_PROJECT_ID` | required | `job-application-agent-493810` |
-| `GCP_WORKLOAD_IDENTITY_PROVIDER` | required | Output of §5 |
-| `GCP_SERVICE_ACCOUNT` | required | `github-deployer@job-application-agent-493810.iam.gserviceaccount.com` |
-| `CRON_SHARED_SECRET` | required | `gcloud secrets versions access latest --secret=cron-shared-secret` |
-| `CLOUD_RUN_URL` | after §6 | Cloud Run service URL |
-| `SMOKE_BEARER_TOKEN` | smoke-prod only | §7b |
+| `INFRA_DISPATCH_TOKEN` | `ci.yml` | Allows this repo to dispatch the image bump into `panibrat-infra`. |
+| `GITHUB_TOKEN` | GitHub Actions | Publishes package images to GHCR. |
 
-## 5. Workload Identity Federation
+Application runtime secrets are not stored in this repo. They live on the
+Hetzner box under `/srv/job-search/.env` and are restored/rotated through the
+infra repo procedures.
 
-```bash
-PROJECT=job-application-agent-493810
-SA=github-deployer@${PROJECT}.iam.gserviceaccount.com
-REPO=maksym-panibrat/job-application-agent
+## Worker Queue Contract
 
-gcloud iam service-accounts create github-deployer --display-name="GitHub Actions deployer"
+The public API avoids long-running LLM/fetch work:
 
-for role in roles/run.admin roles/artifactregistry.writer roles/secretmanager.secretAccessor roles/iam.serviceAccountUser roles/cloudbuild.builds.editor roles/storage.admin roles/logging.viewer; do
-  gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SA" --role="$role"
-done
+- `POST /api/jobs/sync` returns `202`, prunes invalid followed companies,
+  enqueues stale provider slugs, and synchronously scores only cached jobs for
+  quick UI feedback.
+- `POST /api/applications/{id}/cover-letter` returns `202`, flips the
+  application to `pending`, and enqueues `generate-cover-letter`.
+- Clients poll `GET /api/applications/{id}/cover-letter/status` while the
+  worker moves generation through `pending -> generating -> ready/failed`.
 
-gcloud iam workload-identity-pools create github-pool --location=global --display-name="GitHub Actions"
-POOL_ID=$(gcloud iam workload-identity-pools describe github-pool --location=global --format="value(name)")
+Cron endpoints are protected by `X-Cron-Secret` and enqueue work only:
 
-gcloud iam workload-identity-pools providers create-oidc github-provider \
-  --location=global --workload-identity-pool=github-pool \
-  --issuer-uri="https://token.actions.githubusercontent.com" \
-  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
-  --attribute-condition="assertion.repository=='${REPO}'"
+- `POST /internal/cron/sync` enqueues stale `fetch-slug` jobs.
+- `POST /internal/cron/generation-reconcile` re-enqueues orphaned pending cover
+  letters.
+- `POST /internal/cron/maintenance` enqueues one daily maintenance job.
 
-gcloud iam service-accounts add-iam-policy-binding $SA \
-  --role="roles/iam.workloadIdentityUser" \
-  --member="principalSet://iam.googleapis.com/${POOL_ID}/attribute.repository/${REPO}"
+`app.worker` owns queue claiming, lease timeouts, retries, terminal failure
+handling, and finalization.
 
-# Copy the provider resource name into GHA as GCP_WORKLOAD_IDENTITY_PROVIDER
-gcloud iam workload-identity-pools providers describe github-provider \
-  --location=global --workload-identity-pool=github-pool --format="value(name)"
-```
-
-## 6. After first deploy
-
-Capture the service URL for `CLOUD_RUN_URL`:
+## Local Verification Before Merge
 
 ```bash
-gcloud run services describe api --region us-central1 --format="value(status.url)"
+uv run ruff check app/ tests/
+uv run pytest tests/unit/
+uv run pytest tests/integration/
+cd frontend && npm test && npm run build
 ```
 
-Optional demo-data seed (one-time):
-
-```bash
-IMAGE=us-central1-docker.pkg.dev/job-application-agent-493810/app/api:latest
-SA=github-deployer@job-application-agent-493810.iam.gserviceaccount.com
-
-gcloud run jobs create seed-demo --image "$IMAGE" --region us-central1 \
-  --command="/app/.venv/bin/python,scripts/seed_demo_profile.py" \
-  --set-secrets="DATABASE_URL=database-url:latest" \
-  --set-env-vars="PYTHONPATH=/app" \
-  --service-account="$SA"
-gcloud run jobs execute seed-demo --region us-central1 --wait
-```
-
-`PYTHONPATH=/app` and the full venv path are required because Cloud Run's default `PATH` doesn't include the venv.
-
-## 7. Smoke-prod CI (optional)
-
-`smoke-prod` in `ci.yml` runs `scripts/smoke/golden_path.py` against prod after every deploy.
-
-### 7a. Seed the smoke user
-
-```bash
-DATABASE_URL=$(gcloud secrets versions access latest --secret=database-url) \
-  uv run python scripts/seed_smoke_user.py
-```
-
-Idempotent. Creates `smoke@panibrat.com` (UUID `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`).
-
-### 7b. Generate + register the JWT
-
-```bash
-make smoke-token | tail -1 | gh secret set SMOKE_BEARER_TOKEN --repo <owner>/<repo>
-```
-
-Signed with `JWT_SECRET`, valid 30 days.
-
-### 7c. Validate
-
-Push to main. Smoke steps 8a–8d and 9 are XFAIL until the backend flows they test land.
-
-## 8. Observability — GCP Cloud Error Reporting
-
-Errors auto-group at <https://console.cloud.google.com/errors> because `app/main.py::_add_cloud_run_severity` writes `severity=ERROR` and the `@type: …ReportedErrorEvent` marker, and `structlog.processors.format_exc_info` turns `exc_info=True` into a readable traceback under `exception`.
-
-```bash
-# Recent errors
-gcloud logging read 'severity>=ERROR AND resource.type="cloud_run_revision"' --limit=20 --format=json \
-  | jq '.[] | {time: .timestamp, event: .jsonPayload.event, error: .jsonPayload.error, trace: .jsonPayload.exception}'
-
-# A specific cron failure
-gcloud logging read 'resource.type="cloud_run_revision" AND jsonPayload.event="cron.generation_queue.failed"' --limit=5 --format=json | jq '.[].jsonPayload'
-
-# Tail the app
-gcloud run services logs read api --region=us-central1 --limit=200
-```
-
-Cron events (`app/api/internal_cron.py::_run_cron`, each tagged `cron_job=<name>`):
-
-- `cron.<name>.started` / `.completed` — INFO
-- `cron.<name>.budget_exhausted` — WARNING, 200 response
-- `cron.<name>.failed` — ERROR with stack trace, 500 response, ingested by Error Reporting
-
-Alerts: Error Reporting UI → **Notifications** for email/webhook. For Slack/PagerDuty, route a Cloud Logging sink through Pub/Sub.
-
-## 9. Manual actions
-
-### First-time (in order)
-
-1. Neon + `DATABASE_URL` — §1
-2. `gcloud services enable ...` — §2
-3. Required secrets — §3a
-4. SA + Workload Identity — §5
-5. `GCP_*` + `CRON_SHARED_SECRET` in GHA — §4
-6. Push to main (first deploy)
-7. `CLOUD_RUN_URL` in GHA — §6
-8. Demo seed (optional) — §6
-
-### Optional features
-
-| Feature | Setup | Ref |
-|---|---|---|
-| Google sign-in | OAuth client + `google-oauth-client-{id,secret}` secrets + redirect URI | §3b |
-| smoke-prod CI | Seed smoke user + `SMOKE_BEARER_TOKEN` | §7a, §7b |
-| Error alerts | Error Reporting → Notifications | §8 |
-
-### Maintenance
-
-| Cadence | Action |
-|---|---|
-| 30 days | Rotate `SMOKE_BEARER_TOKEN`: `make smoke-token \| tail -1 \| gh secret set SMOKE_BEARER_TOKEN` |
-| Quarterly | Rotate `cron-shared-secret`; mirror to GHA |
-| Quarterly | Rotate `jwt-secret` — **invalidates every active session**; regenerate smoke token after |
-| On URL change | Update `CLOUD_RUN_URL` (§4) and OAuth redirects (§3b) |
-
-### Verification
-
-```bash
-URL=$(gcloud run services describe api --region=us-central1 --format='value(status.url)')
-SECRET=$(gcloud secrets versions access latest --secret=cron-shared-secret)
-
-gh run list --workflow=ci.yml --branch=main --limit=1 --json conclusion,status
-curl -s "$URL/health"                                                       # {"status":"ok",...}
-curl -s -X POST -H "X-Cron-Secret: $SECRET" "$URL/internal/cron/maintenance"  # {"status":"ok",...}
-```
-
-First real 500 shows up at <https://console.cloud.google.com/errors> within ~1 min.
-
-## Troubleshooting
-
-Missing IAM role for the deploy SA:
-
-```bash
-gcloud projects add-iam-policy-binding job-application-agent-493810 \
-  --member="serviceAccount:github-deployer@job-application-agent-493810.iam.gserviceaccount.com" \
-  --role="<role>"
-```
-
-| Error fragment | Missing role |
-|---|---|
-| `forbidden from accessing the bucket [*_cloudbuild]` | `roles/storage.admin` |
-| `can only stream logs if you are Viewer/Owner` | `roles/logging.viewer` |
-| `Secret projects/.../secrets/<name>/versions/latest was not found` | Secret doesn't exist (§3) or SA lacks `roles/secretmanager.secretAccessor` on it (§3c) |
-
-Then `gh run rerun <run-id> --failed`.
+For a full local stack, run the frontend dev server and API separately as shown
+in the README. Production verification after deploy belongs in
+`panibrat-infra` because that repo has the host, compose, Caddy, and Axiom
+context.

--- a/docs/superpowers/plans/2026-04-28-job-sync-match-pipeline.md
+++ b/docs/superpowers/plans/2026-04-28-job-sync-match-pipeline.md
@@ -1,5 +1,10 @@
 # Job Sync & Match Pipeline Implementation Plan
 
+> Historical implementation plan. Superseded by the deployed worker-queue
+> architecture. Do not execute tasks from this file; use `README.md`,
+> `CLAUDE.md`, `docs/DEPLOYMENT.md`, `app/api/internal_cron.py`, and
+> `app/worker/` for the current contract.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace the synchronous `POST /api/jobs/sync` (which blew past Cloud Run's 300s timeout) with a 202-returning, queue-driven pipeline that fetches each Greenhouse slug at most once per 6h, matches strictly within a user's slug list, auto-prunes invalid slugs, and seeds 5 defaults to brand-new users.

--- a/docs/superpowers/specs/2026-04-28-job-sync-match-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-28-job-sync-match-pipeline-design.md
@@ -1,5 +1,10 @@
 # Job Sync & Match Pipeline — Design
 
+> Historical design document. Superseded by the deployed worker-queue
+> architecture. Do not use this as the current operational contract; use
+> `README.md`, `CLAUDE.md`, `docs/DEPLOYMENT.md`, `app/api/internal_cron.py`,
+> and `app/worker/` instead.
+
 **Status:** Draft
 **Owner:** maksym@panibrat.com
 **Date:** 2026-04-28

--- a/docs/superpowers/specs/2026-05-06-frontend-ux-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-06-frontend-ux-redesign-design.md
@@ -1,5 +1,10 @@
 # Frontend UX redesign
 
+> Historical design document. Several operational references in this file
+> predate the deployed worker-queue migration and Hetzner deployment. Do not use
+> it as the current runtime contract; use `README.md`, `CLAUDE.md`,
+> `docs/DEPLOYMENT.md`, `app/api/internal_cron.py`, and `app/worker/` instead.
+
 **Date:** 2026-05-06
 **Status:** Draft for review
 **Author:** Maksym Panibratenko (with Claude)


### PR DESCRIPTION
## Summary
- Refresh README, CLAUDE.md, and deployment docs for the deployed worker queue and async cover-letter flow
- Replace the retired Cloud Run deployment reference with the current GHCR -> panibrat-infra deploy flow
- Mark older Superpowers plans/specs as historical where they describe pre-worker runtime contracts

## Verification
- uv run ruff check app/services/application_service.py
- git diff --check
- stale-reference scan for Phase B/GCP/old cron endpoint terms in current operational docs

Note: .coverage is an existing untracked local artifact and is not included.