### PR TITLE
fix(smoke): accept cron sync accepted status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ migrate-status:
 # Store the printed token as the SMOKE_BEARER_TOKEN GitHub Actions secret.
 # ---------------------------------------------------------------------------
 smoke-token:
-	uv run python scripts/make_smoke_token.py
+	@uv run python scripts/make_smoke_token.py
 
 # ---------------------------------------------------------------------------
 # seed-smoke-user

--- a/scripts/smoke/golden_path.py
+++ b/scripts/smoke/golden_path.py
@@ -33,7 +33,7 @@ Step mapping (matches stabilisation plan):
     Step 3  GET /api/profile               → 200 with smoke user's profile
     Step 4  PATCH /api/profile             → update full_name, assert round-trip
     Step 5  GET /api/applications          → 200 list (may be empty)
-    Step 6  POST /internal/cron/sync       → 200 {"status": "ok"}  (X-Cron-Secret gated;
+    Step 6  POST /internal/cron/sync       → 202 {"status": "ok"}  (X-Cron-Secret gated;
                                              may be slow)
     Step 7  POST /api/chat/messages        → 200 SSE stream with assistant response
                                              (proves Gemini pipeline wired to prod)
@@ -318,7 +318,7 @@ async def step6_cron_sync(
     cron_secret: str,
     verbose: bool,
 ) -> StepResult:
-    """POST /internal/cron/sync → 200 {"status": "ok"}.
+    """POST /internal/cron/sync → 202 {"status": "ok"}.
 
     Gated by X-Cron-Secret header (verify_secret dep in app/api/internal_cron.py).
     Uses a longer timeout (SYNC_TIMEOUT_S) because this calls external job APIs.
@@ -358,8 +358,12 @@ async def step6_cron_sync(
             "body": body,
         }
 
-    if r.status_code != 200:
-        return False, {"step": 6, "error": f"Expected 200, got {r.status_code}", "body": body}
+    if r.status_code not in (200, 202):
+        return False, {
+            "step": 6,
+            "error": f"Expected 200/202, got {r.status_code}",
+            "body": body,
+        }
 
     # After PR 4, BudgetExhausted returns 200 + {"status": "budget_exhausted", "resumes_at": ...}
     # instead of silently returning "ok". Both are valid pass outcomes from prod's perspective.

--- a/tests/unit/test_smoke_golden_path.py
+++ b/tests/unit/test_smoke_golden_path.py
@@ -1,0 +1,31 @@
+import httpx
+import pytest
+
+from scripts.smoke.golden_path import step6_cron_sync
+
+
+@pytest.mark.asyncio
+async def test_cron_sync_accepts_202_accepted():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["X-Cron-Secret"] == "secret"
+        return httpx.Response(
+            202,
+            json={
+                "enqueued": [1, 2],
+                "pruned": 0,
+                "active_profiles": 1,
+                "status": "ok",
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ok, details = await step6_cron_sync(
+            client,
+            "https://job-search.example",
+            "secret",
+            verbose=False,
+        )
+
+    assert ok is True
+    assert details["step"] == 6
+    assert details["status"] == "ok"


### PR DESCRIPTION
## Summary
- accept 202 Accepted from /internal/cron/sync in the golden-path smoke script
- silence make smoke-token so command substitution captures only the JWT
- add a focused unit regression for the 202 cron sync smoke response

## Verification
- uv run pytest tests/unit/test_smoke_golden_path.py -v
- uv run ruff check scripts/smoke/golden_path.py tests/unit/test_smoke_golden_path.py