### PR TITLE
fix(auth): handle concurrent profile creation

### DIFF
--- a/app/services/profile_service.py
+++ b/app/services/profile_service.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 
 import structlog
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -28,8 +29,14 @@ async def get_or_create_profile(user_id: uuid.UUID, session: AsyncSession) -> Us
     if profile is None:
         profile = UserProfile(user_id=user_id)
         session.add(profile)
-        await session.commit()
-        await session.refresh(profile)
+        try:
+            await session.commit()
+            await session.refresh(profile)
+        except IntegrityError:
+            await session.rollback()
+            profile = await get_profile_by_user(user_id, session)
+            if profile is None:
+                raise
     return profile
 
 

--- a/tests/integration/test_profile_service.py
+++ b/tests/integration/test_profile_service.py
@@ -1,0 +1,53 @@
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.user import User
+from app.services import profile_service
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_profile_recovers_from_concurrent_insert(
+    asyncpg_url,
+    db_session,
+    monkeypatch,
+):
+    user = User(
+        id=uuid.uuid4(),
+        email=f"race-{uuid.uuid4()}@test.com",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+        hashed_password="",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    original_get = profile_service.get_profile_by_user
+    stale_reads_remaining = 2
+
+    async def stale_first_read(user_id, session):
+        nonlocal stale_reads_remaining
+        if stale_reads_remaining > 0:
+            stale_reads_remaining -= 1
+            return None
+        return await original_get(user_id, session)
+
+    monkeypatch.setattr(profile_service, "get_profile_by_user", stale_first_read)
+
+    engine = create_async_engine(asyncpg_url, echo=False)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def create_profile():
+        async with factory() as session:
+            return await profile_service.get_or_create_profile(user.id, session)
+
+    first = await create_profile()
+    second = await create_profile()
+
+    assert first.user_id == user.id
+    assert second.user_id == user.id
+    assert first.id == second.id
+
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- recover get_or_create_profile when a concurrent request creates the profile first
- add an integration regression for the user_profiles.user_id race observed in production after the wipe

## Production evidence
- Axiom showed two 500s at 2026-05-14T22:27:45Z on /api/applications
- stack trace: duplicate key violates user_profiles_user_id_key from app/api/deps.py -> profile_service.get_or_create_profile

## Verification
- uv run pytest tests/integration/test_profile_service.py -v
- uv run pytest tests/integration/test_profile_service.py tests/integration/test_profile_rematch.py tests/integration/test_applications_api_summary.py -v
- uv run ruff check app/services/profile_service.py tests/integration/test_profile_service.py