### PR TITLE
Fix profile setup keyword gate

### DIFF
--- a/frontend/src/components/chat/ChatDrawer.tsx
+++ b/frontend/src/components/chat/ChatDrawer.tsx
@@ -8,6 +8,7 @@ const PROMPT_BY_SLUG: Record<string, string> = {
   set_resume:    'Help me upload or describe my resume.',
   set_roles:     'What roles am I targeting?',
   set_locations: 'Where am I open to working? Any locations or remote-only?',
+  set_companies: 'Which companies should I follow for new jobs?',
   set_keywords:  'What technologies / keywords matter most for my search?',
   change_profile: 'I want to change something in my profile.',
 }

--- a/frontend/src/components/feed/ProfileCompletenessCard.test.tsx
+++ b/frontend/src/components/feed/ProfileCompletenessCard.test.tsx
@@ -52,6 +52,11 @@ describe('ProfileCompletenessCard', () => {
     expect(container.firstChild).toBeNull()
   })
 
+  it('does not require optional search keywords for a healthy profile', () => {
+    const { container } = renderCard(fullProfile({ search_keywords: [] }))
+    expect(container.firstChild).toBeNull()
+  })
+
   it('renders setup state when resume missing', () => {
     renderCard(fullProfile({ base_resume_md: null }))
     expect(screen.getByText(/set up your search/i)).toBeInTheDocument()
@@ -61,6 +66,11 @@ describe('ProfileCompletenessCard', () => {
   it('renders setup state when target_roles is empty', () => {
     renderCard(fullProfile({ target_roles: [] }))
     expect(screen.getByText(/target roles/i)).toBeInTheDocument()
+  })
+
+  it('renders setup state when no companies are followed', () => {
+    renderCard(fullProfile({ target_companies: [] }))
+    expect(screen.getByText(/followed companies/i)).toBeInTheDocument()
   })
 
   it('renders the paused state when search_active=false', () => {

--- a/frontend/src/components/feed/ProfileCompletenessCard.tsx
+++ b/frontend/src/components/feed/ProfileCompletenessCard.tsx
@@ -18,7 +18,7 @@ function checks(profile: Profile): CheckItem[] {
     { id: 'resume',    label: 'Resume',         done: !!profile.base_resume_md,        promptSlug: 'set_resume' },
     { id: 'roles',     label: 'Target roles',   done: profile.target_roles.length > 0, promptSlug: 'set_roles' },
     { id: 'locations', label: 'Locations',      done: profile.target_locations.length > 0 || !!profile.remote_ok, promptSlug: 'set_locations' },
-    { id: 'keywords',  label: 'Search keywords', done: profile.search_keywords.length > 0, promptSlug: 'set_keywords' },
+    { id: 'companies', label: 'Followed companies', done: (profile.target_companies?.length ?? 0) > 0, promptSlug: 'set_companies' },
   ]
 }
 


### PR DESCRIPTION
## Summary
- Stop treating optional search keywords as a required profile setup item.
- Require followed companies in the setup card, matching the company-driven sourcing flow.
- Add a chat deep-link prompt for the followed companies setup row.

## Test Plan
- npm test -- src/components/feed/ProfileCompletenessCard.test.tsx
- npm run typecheck
- npm test