### PR TITLE
fix(catalog): update Maven Clinic Greenhouse slug

### DIFF
--- a/app/data/catalog/companies.yaml
+++ b/app/data/catalog/companies.yaml
@@ -394,7 +394,7 @@ companies:
     tags: [biotech, b2c, late-stage]
   - canonical_name: Maven Clinic
     providers:
-      greenhouse: maven
+      greenhouse: mavenclinic
     tags: [b2b, b2c, late-stage]
   # Climate
   - canonical_name: Watershed


### PR DESCRIPTION
## Summary
- Update the Maven Clinic Greenhouse catalog slug from `maven` to `mavenclinic`
- Fix nightly live catalog validation for issue #149

## Test Plan
- `uv run pytest tests/integration/test_catalog_live.py --catalog-live -v -k Maven`
- `uv run pytest tests/unit/test_company_catalog_parse.py tests/unit/test_slug_company_mapping.py -v`

Closes #149