### PR TITLE
fix(matching): enforce remote-only location gate

### DIFF
--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 class ProfileLike(Protocol):
     target_locations: list[str]
+    remote_ok: bool
 
 
 class JobLike(Protocol):
@@ -35,12 +36,15 @@ OFFICE_ATTENDANCE_PATTERNS = (
     r"\bmust(?:\s+be)?\s+located\s+near\b",
 )
 OFFICE_ATTENDANCE_GAP = "Requires recurring office attendance outside target locations"
+REMOTE_ONLY_GAP = "remote-only profile but job is not explicitly remote"
 
 
 def evaluate_remote_policy(profile: ProfileLike, job: JobLike) -> RemotePolicyVerdict:
     text = _job_text(job)
 
     if not _requires_office_attendance(text):
+        if _is_remote_only_profile(profile) and not _is_explicitly_remote(job):
+            return RemotePolicyVerdict(hard_mismatch=True, gap=REMOTE_ONLY_GAP)
         return RemotePolicyVerdict(hard_mismatch=False)
 
     if _matches_target_location(profile, _job_description_text(job)):
@@ -76,7 +80,7 @@ def _requires_office_attendance(text: str) -> bool:
 
 
 def _matches_target_location(profile: ProfileLike, text: str) -> bool:
-    target_locations = getattr(profile, "target_locations", None) or []
+    target_locations = _real_target_locations(profile)
     normalized_text = _normalize_text(text)
     return any(
         _contains_token_phrase(normalized_text, str(location))
@@ -96,3 +100,52 @@ def _contains_token_phrase(normalized_text: str, phrase: str) -> bool:
 
 def _normalize_text(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", " ", text.lower())
+
+
+def _is_remote_only_profile(profile: ProfileLike) -> bool:
+    return bool(getattr(profile, "remote_ok", False)) and not _real_target_locations(profile)
+
+
+def _real_target_locations(profile: ProfileLike) -> list[str]:
+    target_locations = getattr(profile, "target_locations", None) or []
+    return [
+        str(location)
+        for location in target_locations
+        if location and not _is_remote_pseudo_location(str(location))
+    ]
+
+
+def _is_remote_pseudo_location(location: str) -> bool:
+    normalized = _normalize_text(location).strip()
+    return normalized == "remote" or normalized.startswith("remote ")
+
+
+def _is_explicitly_remote(job: JobLike) -> bool:
+    location = _normalize_text(str(getattr(job, "location", None) or ""))
+    workplace_type = _normalize_text(str(getattr(job, "workplace_type", None) or ""))
+    description = _normalize_text(_job_description_text(job))
+
+    if _contains_token_phrase(workplace_type, "remote"):
+        return True
+    if _contains_token_phrase(location, "remote"):
+        return True
+    return _description_has_remote_work_evidence(description)
+
+
+def _description_has_remote_work_evidence(normalized_text: str) -> bool:
+    if not normalized_text:
+        return False
+    negative_patterns = (
+        r"\b(?:not|non|no)\s+remote\b",
+        r"\bremote\s+(?:work\s+)?(?:not|unavailable|unsupported)\b",
+        r"\bdoes\s+not\s+(?:allow|support|offer)\s+remote\b",
+    )
+    if any(re.search(pattern, normalized_text) is not None for pattern in negative_patterns):
+        return False
+    positive_patterns = (
+        r"\bremote\s+(?:role|position|job|work|employee|employees|team)\b",
+        r"\b(?:fully|100)\s+remote\b",
+        r"\bwork\s+from\s+home\b",
+        r"\bwfh\b",
+    )
+    return any(re.search(pattern, normalized_text) is not None for pattern in positive_patterns)

--- a/tests/integration/test_match_scoring.py
+++ b/tests/integration/test_match_scoring.py
@@ -73,6 +73,8 @@ async def _seed_job(
         company_name=company_name,
         apply_url="https://example.com/apply",
         description="A great engineering role.",
+        location="Remote",
+        workplace_type="remote",
         salary=salary,
         posted_at=posted_at,
     )
@@ -434,6 +436,8 @@ async def test_score_and_match_persists_match_score(db_session):
         company_name="Airbnb",
         company_id=airbnb_co.id,
         apply_url="https://x",
+        location="Remote",
+        workplace_type="remote",
         is_active=True,
     )
     db_session.add(job)
@@ -545,6 +549,10 @@ async def test_score_cached_skips_jobs_with_active_match_work(db_session):
 async def test_score_and_match_persists_summary_and_uses_location(db_session):
     """Scored Application gets match_summary populated and rationale stays for audit."""
     profile = await _seed_profile(db_session)
+    profile.target_locations = ["Berlin"]
+    db_session.add(profile)
+    await db_session.commit()
+
     job = Job(
         source="greenhouse",
         external_id=str(uuid.uuid4()),

--- a/tests/unit/test_match_service.py
+++ b/tests/unit/test_match_service.py
@@ -45,16 +45,18 @@ def _make_profile() -> UserProfile:
 def _make_job(
     job_id: uuid.UUID | None = None,
     *,
+    title: str = "Software Engineer",
+    company_name: str = "Acme Corp",
     description: str = "A great job.",
-    location: str | None = None,
-    workplace_type: str | None = None,
+    location: str | None = "Remote",
+    workplace_type: str | None = "remote",
 ) -> Job:
     return Job(
         id=job_id or uuid.uuid4(),
         source="adzuna",
         external_id=str(uuid.uuid4()),
-        title="Software Engineer",
-        company_name="Acme Corp",
+        title=title,
+        company_name=company_name,
         apply_url="https://example.com/apply",
         location=location,
         workplace_type=workplace_type,
@@ -129,6 +131,52 @@ def test_remote_policy_does_not_cap_matching_target_location():
 
     assert adjusted.score == 0.92
     assert adjusted.gaps == original_gaps
+
+
+@pytest.mark.asyncio
+async def test_remote_only_city_location_at_threshold_is_auto_rejected():
+    setup_env()
+    from app.services.match_service import score_and_match
+
+    app_id = uuid.uuid4()
+    job_id = uuid.uuid4()
+    app = _make_application(app_id=app_id, job_id=job_id)
+    job = _make_job(
+        job_id=job_id,
+        title="Staff Software Engineer - AI Research Infrastructure",
+        company_name="Databricks",
+        location="Mountain View, California; New York City, New York; San Francisco, California",
+        workplace_type=None,
+        description="Build research infrastructure for large-scale AI workloads.",
+    )
+    session = _make_mock_session(app)
+
+    score_result = _make_score_result(str(app_id), score=0.65)
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke.return_value = {"scores": [score_result]}
+
+    profile = _make_profile()
+    profile.target_locations = []
+    profile.remote_ok = True
+
+    with (
+        patch(_GET_SKILLS, new=AsyncMock(return_value=[])),
+        patch(_GET_EXPS, new=AsyncMock(return_value=[])),
+        patch(_GET_OR_CREATE, new=AsyncMock(return_value=app)),
+        patch(_BUILD_GRAPH, return_value=mock_graph),
+        patch(_GET_SETTINGS) as mock_get_settings,
+    ):
+        settings = MagicMock()
+        settings.match_score_threshold = 0.65
+        mock_get_settings.return_value = settings
+
+        scored = await score_and_match(profile, session, jobs=[job])
+
+    assert scored == []
+    assert app.status == "auto_rejected"
+    assert app.match_score == 0.29
+    assert "remote-only profile" in app.match_rationale
+    assert any("remote-only profile" in gap for gap in app.match_gaps)
 
 
 def _make_mock_session(app: MagicMock):

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 from app.services.remote_policy import evaluate_remote_policy
 
 
-def _profile(target_locations: list[str]) -> SimpleNamespace:
-    return SimpleNamespace(target_locations=target_locations)
+def _profile(target_locations: list[str], remote_ok: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(target_locations=target_locations, remote_ok=remote_ok)
 
 
 def test_remote_only_profile_rejects_required_office_attendance():
@@ -67,6 +67,49 @@ def test_provider_remote_location_does_not_satisfy_target_location_allowlist():
     assert verdict.hard_mismatch is True
 
 
+def test_remote_only_profile_rejects_city_location_without_remote_evidence():
+    profile = _profile(target_locations=[], remote_ok=True)
+    job = SimpleNamespace(
+        location="Mountain View, California; New York City, New York; San Francisco, California",
+        workplace_type=None,
+        description="Build research infrastructure for large-scale AI workloads.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is True
+    assert "remote-only" in verdict.gap
+
+
+def test_remote_only_profile_allows_explicit_remote_location():
+    profile = _profile(target_locations=[], remote_ok=True)
+    job = SimpleNamespace(
+        location="Remote - US",
+        workplace_type=None,
+        description="Build research infrastructure for large-scale AI workloads.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_remote_pseudo_location_is_not_office_target_location():
+    profile = _profile(target_locations=["Remote"], remote_ok=True)
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Remote role, but candidates must work from the NYC office twice a week.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is True
+
+
 def test_hybrid_schedule_required_is_office_attendance():
     profile = _profile(target_locations=[])
     job = SimpleNamespace(
@@ -96,7 +139,7 @@ def test_must_be_located_near_target_city_is_office_attendance():
 
 
 def test_hybrid_metadata_with_unrelated_requirement_is_not_office_attendance():
-    profile = _profile(target_locations=[])
+    profile = _profile(target_locations=[], remote_ok=False)
     job = SimpleNamespace(
         location="Berlin, Germany",
         workplace_type="hybrid",


### PR DESCRIPTION
## Summary
- Reject remote-only profile matches unless the job has explicit remote evidence
- Treat Remote/Remote - US as pseudo-locations, not physical office allowlist entries
- Add service-level regression for the Databricks city-only threshold pass case

## Test Plan
- uv run pytest tests/unit/ -q
- uv run ruff check app/ tests/