### PR TITLE
Fix onboarding search readiness CTA

### DIFF
--- a/app/agents/onboarding.py
+++ b/app/agents/onboarding.py
@@ -41,14 +41,15 @@ Your goals:
    - Ask for a city or metro area (e.g. "San Francisco Bay Area", "New York", "Austin")
    - OR confirm they want remote-only positions (set remote_ok=true, leave target_locations empty)
    - A vague answer like "open to anything" is not enough — pin down a location or remote-only
-4. Learn which **companies** the user wants to follow — REQUIRED. Job sourcing
-   is built around the companies the user explicitly tracks. Ask for company
-   names as the user would say them (e.g. "Stripe", "Linear", "ByteDance").
-   Examples to suggest if the user is unsure: stripe, anthropic, datadog,
-   figma, notion, vercel, airtable, linear. Save them as
-   `target_companies: ["Stripe", "Linear", ...]` (a flat list of display
-   names — the backend resolves each to the right ATS automatically).
-   Confirm any company that is unfamiliar.
+4. Select a starter set of **companies** to follow — REQUIRED. Job sourcing is
+   built around followed companies, but most users do not have strong company
+   preferences. If they name companies, use those. Otherwise call
+   `list_curated_companies`, pick a few companies from their resume,
+   background, target roles, seniority, skills, industries, and locations, then
+   save them as `target_companies: ["Stripe", "Linear", ...]` (a flat list of
+   display names — the backend resolves each to the right ATS automatically).
+   Explain the starter set briefly and invite edits later. Confirm any company
+   that is unfamiliar.
 5. Understand their key skills and experience highlights they want to emphasize.
 6. Note any companies or industries to exclude.
 7. Confirm their contact info (LinkedIn, GitHub, portfolio).
@@ -84,13 +85,16 @@ before wrapping up.
 Once the profile is search-ready, summarize what you've captured and tell the
 user they can update preferences anytime by chatting here.
 
-When the user asks about company suggestions, what companies you can
-recommend, or asks you to find companies that match their profile: call
-`list_curated_companies` first to see what's available. Then propose 3 to 8
-picks based on the user's `target_roles`, `seniority`, `search_keywords`, and
-`work_experiences`. Briefly explain each pick (one sentence is enough). Save
-the user's selections via `save_profile_updates({"target_companies": [...]})`.
-Prefer curated names; off-list names work but are slower and unverified."""
+When target companies are missing, do not block by asking the user to invent a
+company wishlist. If you have enough signal from the user's resume, background,
+`target_roles`, `seniority`, `search_keywords`, `work_experiences`, skills,
+industries, or locations, call `list_curated_companies` and select 3 to 5
+starter companies that fit those signals. Briefly explain each pick (one
+sentence is enough), save them via
+`save_profile_updates({"target_companies": [...]})`, and tell the user they can
+swap companies anytime. If there is not enough background yet, ask for the
+missing role/background signal first. Prefer curated names; off-list names work
+but are slower and unverified."""
 
 PROFILE_SCALAR_FIELDS = frozenset(
     {

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -2,9 +2,9 @@
 
 If the agent mutates the user's profile during a turn (detected via a
 before/after snapshot of profile.updated_at), the endpoint emits an
-`event: meta\\ndata: {"profile_mutated": true}\\n\\n` event before
-the terminal `[DONE]`. The frontend uses this to render an inline
-'Search now' CTA under the mutating reply.
+`event: meta` payload before the terminal `[DONE]`. The payload reports both
+the mutation and whether the profile has enough provider slugs for a manual
+search to actually start.
 """
 
 import json
@@ -12,11 +12,12 @@ import json
 import structlog
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
 
 from app.api.deps import get_current_profile
 from app.database import get_db, get_session_factory
+from app.models.company import Company
 from app.models.user_profile import UserProfile
 
 log = structlog.get_logger()
@@ -31,6 +32,32 @@ async def _profile_updated_at(session_factory, profile_id):
             await s.execute(select(UserProfile.updated_at).where(UserProfile.id == profile_id))
         ).first()
     return row[0] if row else None
+
+
+async def _profile_can_start_search(session_factory, profile_id) -> bool:
+    """Return true only when /api/jobs/sync has at least one provider slug pair
+    to enqueue and the location gate is satisfied."""
+    async with session_factory() as s:
+        profile = await s.get(UserProfile, profile_id)
+        if profile is None:
+            return False
+
+        has_location = bool(profile.target_locations) or bool(profile.remote_ok)
+        company_ids = list(profile.target_company_ids or [])
+        if not has_location or not company_ids:
+            return False
+
+        rows = (
+            await s.execute(
+                select(Company.provider_slugs).where(col(Company.id).in_(company_ids))
+            )
+        ).scalars().all()
+
+    for provider_slugs in rows:
+        for slug in (provider_slugs or {}).values():
+            if isinstance(slug, str) and slug.strip():
+                return True
+    return False
 
 
 @router.post("/messages")
@@ -109,7 +136,11 @@ async def send_message(
             # AFTER the agent finishes, check for profile mutation.
             after = await _profile_updated_at(factory, profile.id)
             if before != after:
-                yield 'event: meta\ndata: {"profile_mutated": true}\n\n'
+                payload = {
+                    "profile_mutated": True,
+                    "search_startable": await _profile_can_start_search(factory, profile.id),
+                }
+                yield f"event: meta\ndata: {json.dumps(payload)}\n\n"
         except BudgetExhausted as exc:
             await log.awarning("chat.budget_exhausted", resumes_at=exc.resumes_at.isoformat())
             payload = {

--- a/frontend/src/components/chat/Chat.test.tsx
+++ b/frontend/src/components/chat/Chat.test.tsx
@@ -56,14 +56,14 @@ describe('Chat', () => {
     globalThis.fetch = originalFetch
   })
 
-  it('renders a Search now button when the agent reply emits profile_mutated meta', async () => {
+  it('renders a Search now button when the agent reply says search can start', async () => {
     const originalFetch = globalThis.fetch
     let syncCalled = false
     globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
       if (url === '/api/chat/messages') {
         const body =
           'data: {"content":"updated"}\n\n' +
-          'event: meta\ndata: {"profile_mutated": true}\n\n' +
+          'event: meta\ndata: {"profile_mutated": true, "search_startable": true}\n\n' +
           'data: [DONE]\n\n'
         return Promise.resolve(sseStreamResponse(body))
       }
@@ -84,6 +84,28 @@ describe('Chat', () => {
     const cta = await screen.findByRole('button', { name: /search now/i })
     await user.click(cta)
     await waitFor(() => expect(syncCalled).toBe(true))
+    globalThis.fetch = originalFetch
+  })
+
+  it('does not render Search now when profile changed but search lacks provider slugs', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url === '/api/chat/messages') {
+        const body =
+          'data: {"content":"updated"}\n\n' +
+          'event: meta\ndata: {"profile_mutated": true, "search_startable": false}\n\n' +
+          'data: [DONE]\n\n'
+        return Promise.resolve(sseStreamResponse(body))
+      }
+      return originalFetch(url)
+    }) as typeof fetch
+
+    const user = userEvent.setup()
+    render(withCtx(<Chat />))
+    await user.type(screen.getByPlaceholderText(/type your/i), 'set roles')
+    await user.click(screen.getByRole('button', { name: /^send$/i }))
+    await waitFor(() => expect(screen.getByText('updated')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /search now/i })).not.toBeInTheDocument()
     globalThis.fetch = originalFetch
   })
 })

--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -8,8 +8,8 @@ import { track } from '../../lib/track'
 interface Message {
   role: 'user' | 'assistant'
   content: string
-  /** True when the agent indicated it mutated the profile during this turn. */
-  profileMutated?: boolean
+  /** True when the agent indicated a manual search can start after this turn. */
+  searchStartable?: boolean
   error?: boolean
 }
 
@@ -78,7 +78,10 @@ export function Chat({ initialPrompt }: ChatProps) {
           if (meta.profile_mutated) {
             setMessages((prev) => {
               const out = [...prev]
-              out[out.length - 1] = { ...out[out.length - 1], profileMutated: true }
+              out[out.length - 1] = {
+                ...out[out.length - 1],
+                searchStartable: meta.search_startable === true,
+              }
               return out
             })
             qc.invalidateQueries({ queryKey: ['profile'] })
@@ -131,7 +134,7 @@ export function Chat({ initialPrompt }: ChatProps) {
                 : 'bg-surface-2 text-text rounded-bl-sm'
             }`}>
               {m.content || (sending && i === messages.length - 1 ? '…' : '')}
-              {m.role === 'assistant' && m.profileMutated && (
+              {m.role === 'assistant' && m.searchStartable && (
                 <div className="mt-2 pt-2 border-t border-border">
                   <Button
                     size="sm"

--- a/tests/e2e/test_chat_flow.py
+++ b/tests/e2e/test_chat_flow.py
@@ -215,11 +215,91 @@ async def test_chat_emits_meta_event_when_profile_mutated(test_app):
     joined = "\n".join(lines)
     assert "event: meta" in joined, f"missing meta event; got:\n{joined}"
     assert '"profile_mutated": true' in joined, f"missing payload; got:\n{joined}"
+    assert '"search_startable": false' in joined, f"missing search gate payload; got:\n{joined}"
 
     # Order: meta MUST appear before [DONE]
     meta_idx = next(i for i, line in enumerate(lines) if line == "event: meta")
     done_idx = next(i for i, line in enumerate(lines) if line == "data: [DONE]")
     assert meta_idx < done_idx, "meta event must precede [DONE]"
+
+
+@pytest.mark.asyncio
+async def test_chat_meta_marks_search_startable_when_profile_has_provider_slugs(test_app):
+    """The chat CTA should only appear when a manual sync can actually walk at
+    least one provider slug for the profile."""
+    from datetime import UTC, datetime
+    from unittest.mock import MagicMock, patch
+
+    from langchain_core.messages import AIMessageChunk
+    from sqlalchemy import select, update
+
+    from app.database import get_session_factory
+    from app.models.company import Company
+    from app.models.user_profile import UserProfile
+
+    await test_app.get("/api/profile")
+
+    factory = get_session_factory()
+    async with factory() as s:
+        profile = (await s.execute(select(UserProfile).limit(1))).scalar_one()
+        company = Company(
+            canonical_name="Stripe",
+            normalized_key=f"stripe-{profile.id}",
+            provider_slugs={"greenhouse": "stripe"},
+            resolved_at=datetime.now(UTC),
+        )
+        s.add(company)
+        await s.flush()
+        await s.execute(
+            update(UserProfile)
+            .where(UserProfile.id == profile.id)
+            .values(
+                remote_ok=True,
+                target_locations=[],
+                target_company_ids=[company.id],
+                updated_at=datetime.now(UTC),
+            )
+        )
+        await s.commit()
+        profile_id = profile.id
+
+    async def stream_then_mutate(*args, **kwargs):
+        yield (AIMessageChunk(content="ok"), {})
+        async with factory() as s:
+            await s.execute(
+                update(UserProfile)
+                .where(UserProfile.id == profile_id)
+                .values(updated_at=datetime.now(UTC))
+            )
+            await s.commit()
+
+    fake_graph = MagicMock()
+    fake_graph.astream = stream_then_mutate
+
+    from app.main import app as fastapi_app
+
+    prev_checkpointer = getattr(fastapi_app.state, "checkpointer", None)
+    fastapi_app.state.checkpointer = MagicMock()
+    try:
+        with patch("app.agents.onboarding.build_graph", return_value=fake_graph):
+            async with test_app.stream(
+                "POST",
+                "/api/chat/messages",
+                json={"message": "set my companies"},
+            ) as resp:
+                assert resp.status_code == 200
+                lines = []
+                async for line in resp.aiter_lines():
+                    lines.append(line)
+                    if line == "data: [DONE]":
+                        break
+    finally:
+        fastapi_app.state.checkpointer = prev_checkpointer
+
+    joined = "\n".join(lines)
+    assert "event: meta" in joined, f"missing meta event; got:\n{joined}"
+    assert '"profile_mutated": true' in joined, f"missing profile mutation payload; got:\n{joined}"
+    assert '"search_startable": true' in joined, f"missing true search gate payload; got:\n{joined}"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_onboarding_prompt.py
+++ b/tests/unit/test_onboarding_prompt.py
@@ -66,6 +66,18 @@ def test_prompt_proactively_asks_for_target_companies():
     )
 
 
+def test_prompt_selects_companies_from_resume_when_user_has_no_preference():
+    """Most users do not arrive with a company wishlist. The agent should use
+    resume/background signals to choose a small starter set, not block on a
+    preference question."""
+    from app.agents.onboarding import SYSTEM_PROMPT
+
+    lower = SYSTEM_PROMPT.lower()
+    assert "resume" in lower or "background" in lower
+    assert "select" in lower or "pick" in lower or "choose" in lower
+    assert "few" in lower or "3 to" in lower or "3-5" in lower
+
+
 def test_prompt_does_not_mention_target_company_slugs():
     """After E1 the agent talks in company display names only — no slugs,
     no provider buckets in the user-facing instruction."""


### PR DESCRIPTION
## Summary
- Gate the chat "Search now" CTA on a backend-computed search_startable flag instead of any profile mutation.
- Compute search_startable from the real sync prerequisites: location/remote readiness plus at least one followed company provider slug.
- Update onboarding guidance to pick a small starter company set from resume/background signals when users have no company preference.

## Test Plan
- uv run pytest tests/unit/test_onboarding_prompt.py tests/e2e/test_chat_flow.py -q
- uv run ruff check app/api/chat.py app/agents/onboarding.py tests/e2e/test_chat_flow.py tests/unit/test_onboarding_prompt.py
- npm test -- Chat.test.tsx
- npm run typecheck