### PR TITLE
Fix sync starvation behind match backlog

### DIFF
--- a/app/worker/queue_service.py
+++ b/app/worker/queue_service.py
@@ -107,7 +107,15 @@ async def claim_one(
                     AND (claimed_by IS NULL OR claimed_by <> :worker_id)
                   )
                 )
-              ORDER BY enqueued_at ASC
+              ORDER BY
+                CASE job_type
+                  WHEN 'generate-cover-letter' THEN 0
+                  WHEN 'fetch-slug' THEN 1
+                  WHEN 'maintenance' THEN 2
+                  WHEN 'match' THEN 3
+                  ELSE 4
+                END ASC,
+                enqueued_at ASC
               FOR UPDATE SKIP LOCKED
               LIMIT 1
             )

--- a/tests/integration/test_queue_service.py
+++ b/tests/integration/test_queue_service.py
@@ -111,6 +111,34 @@ async def test_claim_one_picks_oldest_pending_row(db_session):
 
 
 @pytest.mark.asyncio
+async def test_claim_one_prioritizes_fetch_slug_ahead_of_older_match_backlog(db_session):
+    older_match = await enqueue(
+        db_session,
+        job_type="match",
+        payload={"application_id": "older"},
+        dedupe_key="match:older",
+    )
+    newer_fetch = await enqueue(
+        db_session,
+        job_type="fetch-slug",
+        payload={"provider": "greenhouse", "slug": "openai"},
+        dedupe_key="fetch-slug:greenhouse:openai",
+    )
+    await db_session.execute(
+        text("UPDATE work_queue SET enqueued_at = now() - interval '1 hour' WHERE id = :id"),
+        {"id": older_match},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(db_session, worker_id="w1", visibility_timeout_s=600)
+    await db_session.commit()
+
+    assert claimed is not None
+    assert claimed.id == newer_fetch
+    assert claimed.job_type == "fetch-slug"
+
+
+@pytest.mark.asyncio
 async def test_claim_one_empty_returns_none(db_session):
     claimed = await claim_one(db_session, worker_id="w1", visibility_timeout_s=600)
 


### PR DESCRIPTION
## Summary
- prioritize interactive worker jobs ahead of bulk match jobs in queue claiming
- add a regression test for fetch-slug starvation behind older match backlog

## Context
A user could see "Searching 49 of 50 boards…" for a long time because /api/sync/status reports syncing while any fetch-slug work exists, but the worker claimed jobs FIFO across all job types. A newly queued fetch-slug could sit behind thousands of older match jobs.

## Verification
- python3 -m py_compile app/worker/queue_service.py
- git diff --check

Targeted pytest was attempted but this sandbox could not access the existing uv cache and PyPI network access was blocked, so test dependencies could not be installed here.