### PR TITLE
Split worker lanes and add deterministic US-only match prefilter

### DIFF
--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -149,11 +149,8 @@ US_COUNTRY_PATTERNS = (
     re.compile(r"(?<![A-Za-z0-9])usa(?![A-Za-z0-9])", re.IGNORECASE),
     re.compile(r"(?<![A-Za-z0-9])US(?![A-Za-z0-9])"),
 )
-US_STATE_ABBREVIATION_RE = re.compile(
-    rf"(?<![A-Za-z0-9])(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
-)
 CITY_STATE_RE = re.compile(
-    rf"\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){{0,3}},\s*"
+    rf"(?<!,\s)\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){{0,3}},\s*"
     rf"(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
 )
 CONTEXTUAL_STATE_ABBREVIATION_RE = re.compile(
@@ -224,12 +221,10 @@ def _matches_target_location(profile: ProfileLike, text: str) -> bool:
 def _has_us_location_signal(job: JobLike) -> bool:
     text = _job_owned_text(job)
     normalized_text = _normalize_text(text)
-    location_text = str(getattr(job, "location", None) or "")
 
     return (
         any(pattern.search(text) is not None for pattern in US_COUNTRY_PATTERNS)
         or any(_contains_token_phrase(normalized_text, state) for state in US_STATE_NAMES)
-        or US_STATE_ABBREVIATION_RE.search(location_text) is not None
         or CITY_STATE_RE.search(text) is not None
         or CONTEXTUAL_STATE_ABBREVIATION_RE.search(text) is not None
     )

--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -35,6 +35,131 @@ OFFICE_ATTENDANCE_PATTERNS = (
     r"\bmust(?:\s+be)?\s+located\s+near\b",
 )
 OFFICE_ATTENDANCE_GAP = "Requires recurring office attendance outside target locations"
+NON_US_POSITION_GAP = "Position is not US-based"
+
+US_STATE_NAMES = (
+    "alabama",
+    "alaska",
+    "arizona",
+    "arkansas",
+    "california",
+    "colorado",
+    "connecticut",
+    "delaware",
+    "florida",
+    "georgia",
+    "hawaii",
+    "idaho",
+    "illinois",
+    "indiana",
+    "iowa",
+    "kansas",
+    "kentucky",
+    "louisiana",
+    "maine",
+    "maryland",
+    "massachusetts",
+    "michigan",
+    "minnesota",
+    "mississippi",
+    "missouri",
+    "montana",
+    "nebraska",
+    "nevada",
+    "new hampshire",
+    "new jersey",
+    "new mexico",
+    "new york",
+    "north carolina",
+    "north dakota",
+    "ohio",
+    "oklahoma",
+    "oregon",
+    "pennsylvania",
+    "rhode island",
+    "south carolina",
+    "south dakota",
+    "tennessee",
+    "texas",
+    "utah",
+    "vermont",
+    "virginia",
+    "washington",
+    "west virginia",
+    "wisconsin",
+    "wyoming",
+)
+US_STATE_ABBREVIATIONS = (
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+    "DC",
+)
+US_STATE_ABBREVIATION_PATTERN = "|".join(US_STATE_ABBREVIATIONS)
+US_COUNTRY_PATTERNS = (
+    re.compile(r"(?<![A-Za-z0-9])united\s+states(?![A-Za-z0-9])", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z0-9])u\.s\.a?\.?(?![A-Za-z0-9])", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z0-9])usa(?![A-Za-z0-9])", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z0-9])US(?![A-Za-z0-9])"),
+)
+US_STATE_ABBREVIATION_RE = re.compile(
+    rf"(?<![A-Za-z0-9])(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
+)
+CITY_STATE_RE = re.compile(
+    rf"\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){{0,3}},\s*"
+    rf"(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
+)
+CONTEXTUAL_STATE_ABBREVIATION_RE = re.compile(
+    rf"\b(?:based\s+in|located\s+in|from|in|within|near)\s+"
+    rf"(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
+)
 
 
 def evaluate_remote_policy(profile: ProfileLike, job: JobLike) -> RemotePolicyVerdict:
@@ -49,14 +174,25 @@ def evaluate_remote_policy(profile: ProfileLike, job: JobLike) -> RemotePolicyVe
     return RemotePolicyVerdict(hard_mismatch=True, gap=OFFICE_ATTENDANCE_GAP)
 
 
+def evaluate_us_location_policy(job: JobLike) -> RemotePolicyVerdict:
+    if _has_us_location_signal(job):
+        return RemotePolicyVerdict(hard_mismatch=False)
+
+    return RemotePolicyVerdict(hard_mismatch=True, gap=NON_US_POSITION_GAP)
+
+
 def _job_text(job: JobLike) -> str:
+    return _job_owned_text(job).lower()
+
+
+def _job_owned_text(job: JobLike) -> str:
     fields = (
         getattr(job, "location", None),
         getattr(job, "workplace_type", None),
         getattr(job, "description", None),
         getattr(job, "description_raw", None),
     )
-    return " ".join(str(field) for field in fields if field).lower()
+    return " ".join(str(field) for field in fields if field)
 
 
 def _job_description_text(job: JobLike) -> str:
@@ -82,6 +218,20 @@ def _matches_target_location(profile: ProfileLike, text: str) -> bool:
         _contains_token_phrase(normalized_text, str(location))
         for location in target_locations
         if location
+    )
+
+
+def _has_us_location_signal(job: JobLike) -> bool:
+    text = _job_owned_text(job)
+    normalized_text = _normalize_text(text)
+    location_text = str(getattr(job, "location", None) or "")
+
+    return (
+        any(pattern.search(text) is not None for pattern in US_COUNTRY_PATTERNS)
+        or any(_contains_token_phrase(normalized_text, state) for state in US_STATE_NAMES)
+        or US_STATE_ABBREVIATION_RE.search(location_text) is not None
+        or CITY_STATE_RE.search(text) is not None
+        or CONTEXTUAL_STATE_ABBREVIATION_RE.search(text) is not None
     )
 
 

--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -199,6 +199,7 @@ EXCLUSIONARY_US_NAME_PATTERNS = (
     ),
 )
 EXCLUSIONARY_US_ABBREVIATION_PATTERNS = (
+    re.compile(r"(?<![A-Za-z0-9])non[-\s]+U\.?S\.?(?![A-Za-z0-9])", re.IGNORECASE),
     re.compile(
         rf"\b(?i:{EXCLUSIONARY_US_PREFIX_PATTERN})\b.{{0,80}}"
         rf"(?<![A-Za-z0-9-]){US_LOCATION_ABBREVIATION_TOKEN_PATTERN}"

--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -159,6 +159,27 @@ NON_US_LOCATION_TOKENS = (
     "europe",
     "european union",
 )
+NON_US_LOCATION_TOKEN_PATTERN = "|".join(
+    re.escape(token) for token in sorted(NON_US_LOCATION_TOKENS, key=len, reverse=True)
+)
+CONTEXTUAL_NON_US_LOCATION_PATTERNS = (
+    re.compile(
+        rf"\b(?:based\s+in|located\s+in)\b.{{0,80}}"
+        rf"(?<![A-Za-z0-9])(?:{NON_US_LOCATION_TOKEN_PATTERN})(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b(?:remote|work(?:ing)?|hire|hiring|eligible|open)\b.{{0,40}}"
+        rf"\bfrom\b.{{0,40}}"
+        rf"(?<![A-Za-z0-9])(?:{NON_US_LOCATION_TOKEN_PATTERN})(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b(?:candidates?|applicants?|employees?|workers?)\s+from\b.{{0,40}}"
+        rf"(?<![A-Za-z0-9])(?:{NON_US_LOCATION_TOKEN_PATTERN})(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+)
 CITY_STATE_RE = re.compile(
     rf"(?<!,\s)\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){{0,3}},\s*"
     rf"(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
@@ -288,7 +309,7 @@ def _has_us_location_signal(job: JobLike) -> bool:
 def _has_overriding_non_us_location_signal(job: JobLike) -> bool:
     location = getattr(job, "location", None)
     if not location:
-        return False
+        return _has_contextual_non_us_description_location_signal(job)
 
     location_text = str(location)
     normalized_location = _normalize_text(location_text)
@@ -301,7 +322,17 @@ def _has_overriding_non_us_location_signal(job: JobLike) -> bool:
     if _has_positive_us_location_signal(location_text):
         return False
 
-    return not _is_ambiguous_location_text(normalized_location)
+    return not _is_ambiguous_location_text(
+        normalized_location
+    ) or _has_contextual_non_us_description_location_signal(job)
+
+
+def _has_contextual_non_us_description_location_signal(job: JobLike) -> bool:
+    description_text = _job_description_text(job)
+    return any(
+        pattern.search(description_text) is not None
+        for pattern in CONTEXTUAL_NON_US_LOCATION_PATTERNS
+    )
 
 
 def _has_positive_us_location_signal(text: str) -> bool:

--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -277,17 +277,11 @@ def _matches_target_location(profile: ProfileLike, text: str) -> bool:
 
 def _has_us_location_signal(job: JobLike) -> bool:
     text = _job_owned_text(job)
-    normalized_text = _normalize_text(text)
 
     if _has_exclusionary_us_location_signal(text):
         return False
 
-    return (
-        any(pattern.search(text) is not None for pattern in US_COUNTRY_PATTERNS)
-        or any(_contains_token_phrase(normalized_text, state) for state in US_STATE_NAMES)
-        or CITY_STATE_RE.search(text) is not None
-        or CONTEXTUAL_STATE_ABBREVIATION_RE.search(text) is not None
-    )
+    return _has_positive_us_location_signal(text)
 
 
 def _has_overriding_non_us_location_signal(job: JobLike) -> bool:
@@ -296,14 +290,40 @@ def _has_overriding_non_us_location_signal(job: JobLike) -> bool:
         return False
 
     location_text = str(location)
-    if any(pattern.search(location_text) for pattern in US_COUNTRY_PATTERNS):
-        return False
-
     normalized_location = _normalize_text(location_text)
-    return any(
+    if any(
         _contains_token_phrase(normalized_location, token)
         for token in NON_US_LOCATION_TOKENS
+    ):
+        return True
+
+    if _has_positive_us_location_signal(location_text):
+        return False
+
+    return not _is_ambiguous_location_text(normalized_location)
+
+
+def _has_positive_us_location_signal(text: str) -> bool:
+    normalized_text = _normalize_text(text)
+    return (
+        any(pattern.search(text) is not None for pattern in US_COUNTRY_PATTERNS)
+        or any(_contains_token_phrase(normalized_text, state) for state in US_STATE_NAMES)
+        or CITY_STATE_RE.search(text) is not None
+        or CONTEXTUAL_STATE_ABBREVIATION_RE.search(text) is not None
     )
+
+
+def _is_ambiguous_location_text(normalized_location: str) -> bool:
+    if not normalized_location:
+        return True
+    return normalized_location in {
+        "remote",
+        "remote anywhere",
+        "anywhere",
+        "worldwide",
+        "global",
+        "distributed",
+    }
 
 
 def _has_exclusionary_us_location_signal(text: str) -> bool:

--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -149,6 +149,16 @@ US_COUNTRY_PATTERNS = (
     re.compile(r"(?<![A-Za-z0-9])usa(?![A-Za-z0-9])", re.IGNORECASE),
     re.compile(r"(?<![A-Za-z0-9])US(?![A-Za-z0-9])"),
 )
+NON_US_LOCATION_TOKENS = (
+    "canada",
+    "united kingdom",
+    "uk",
+    "germany",
+    "tbilisi",
+    "india",
+    "europe",
+    "european union",
+)
 CITY_STATE_RE = re.compile(
     rf"(?<!,\s)\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){{0,3}},\s*"
     rf"(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
@@ -216,6 +226,9 @@ def evaluate_remote_policy(profile: ProfileLike, job: JobLike) -> RemotePolicyVe
 
 
 def evaluate_us_location_policy(job: JobLike) -> RemotePolicyVerdict:
+    if _has_overriding_non_us_location_signal(job):
+        return RemotePolicyVerdict(hard_mismatch=True, gap=NON_US_POSITION_GAP)
+
     if _has_us_location_signal(job):
         return RemotePolicyVerdict(hard_mismatch=False)
 
@@ -274,6 +287,22 @@ def _has_us_location_signal(job: JobLike) -> bool:
         or any(_contains_token_phrase(normalized_text, state) for state in US_STATE_NAMES)
         or CITY_STATE_RE.search(text) is not None
         or CONTEXTUAL_STATE_ABBREVIATION_RE.search(text) is not None
+    )
+
+
+def _has_overriding_non_us_location_signal(job: JobLike) -> bool:
+    location = getattr(job, "location", None)
+    if not location:
+        return False
+
+    location_text = str(location)
+    if any(pattern.search(location_text) for pattern in US_COUNTRY_PATTERNS):
+        return False
+
+    normalized_location = _normalize_text(location_text)
+    return any(
+        _contains_token_phrase(normalized_location, token)
+        for token in NON_US_LOCATION_TOKENS
     )
 
 

--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -157,6 +157,50 @@ CONTEXTUAL_STATE_ABBREVIATION_RE = re.compile(
     rf"\b(?:based\s+in|located\s+in|from|in|within|near)\s+"
     rf"(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
 )
+US_COUNTRY_OR_STATE_NAME_PATTERN = "|".join(
+    (
+        r"united\s+states",
+        r"u\.s\.a?\.?",
+        "usa",
+        *tuple(re.escape(state) for state in US_STATE_NAMES),
+    )
+)
+US_LOCATION_NAME_TOKEN_PATTERN = rf"(?:the\s+)?(?:{US_COUNTRY_OR_STATE_NAME_PATTERN})"
+US_LOCATION_ABBREVIATION_TOKEN_PATTERN = rf"(?:US|{US_STATE_ABBREVIATION_PATTERN})"
+EXCLUSIONARY_US_PREFIX_PATTERN = (
+    r"(?:not\s+(?:available|open|accepted|considered|allowed|permitted)"
+    r"|unavailable|excluding|excludes?|except(?:ing)?|outside(?:\s+of)?|not\s+based)"
+)
+EXCLUSIONARY_US_SUFFIX_PATTERN = (
+    r"(?:not\s+(?:eligible|accepted|considered|allowed|permitted|available)"
+    r"|ineligible|excluded|unavailable)"
+)
+EXCLUSIONARY_US_NAME_PATTERNS = (
+    re.compile(
+        rf"\b{EXCLUSIONARY_US_PREFIX_PATTERN}\b.{{0,80}}"
+        rf"(?<![A-Za-z0-9]){US_LOCATION_NAME_TOKEN_PATTERN}(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"(?<![A-Za-z0-9]){US_LOCATION_NAME_TOKEN_PATTERN}(?![A-Za-z0-9])"
+        rf".{{0,80}}\b(?:applicants?|candidates?|residents?|workers?)?\s*"
+        rf"(?:are|is)?\s*{EXCLUSIONARY_US_SUFFIX_PATTERN}\b",
+        re.IGNORECASE,
+    ),
+)
+EXCLUSIONARY_US_ABBREVIATION_PATTERNS = (
+    re.compile(
+        rf"\b(?i:{EXCLUSIONARY_US_PREFIX_PATTERN})\b.{{0,80}}"
+        rf"(?<![A-Za-z0-9-]){US_LOCATION_ABBREVIATION_TOKEN_PATTERN}"
+        rf"(?![A-Za-z0-9])"
+    ),
+    re.compile(
+        rf"(?<![A-Za-z0-9-]){US_LOCATION_ABBREVIATION_TOKEN_PATTERN}"
+        rf"(?![A-Za-z0-9]).{{0,80}}"
+        rf"\b(?i:(?:applicants?|candidates?|residents?|workers?)?\s*"
+        rf"(?:are|is)?\s*{EXCLUSIONARY_US_SUFFIX_PATTERN})\b"
+    ),
+)
 
 
 def evaluate_remote_policy(profile: ProfileLike, job: JobLike) -> RemotePolicyVerdict:
@@ -222,11 +266,24 @@ def _has_us_location_signal(job: JobLike) -> bool:
     text = _job_owned_text(job)
     normalized_text = _normalize_text(text)
 
+    if _has_exclusionary_us_location_signal(text):
+        return False
+
     return (
         any(pattern.search(text) is not None for pattern in US_COUNTRY_PATTERNS)
         or any(_contains_token_phrase(normalized_text, state) for state in US_STATE_NAMES)
         or CITY_STATE_RE.search(text) is not None
         or CONTEXTUAL_STATE_ABBREVIATION_RE.search(text) is not None
+    )
+
+
+def _has_exclusionary_us_location_signal(text: str) -> bool:
+    return any(
+        pattern.search(text) is not None
+        for pattern in (
+            *EXCLUSIONARY_US_NAME_PATTERNS,
+            *EXCLUSIONARY_US_ABBREVIATION_PATTERNS,
+        )
     )
 
 

--- a/app/worker/config.py
+++ b/app/worker/config.py
@@ -1,11 +1,24 @@
 """Worker-process configuration. Spec § Concurrency knobs."""
+from dataclasses import dataclass
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+@dataclass(frozen=True)
+class WorkerLane:
+    name: str
+    job_types: tuple[str, ...] | None
+    concurrency: int
 
 
 class WorkerSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="WORKER_")
 
     concurrency: int = 4
+    llm_job_types: str | None = None
+    llm_concurrency: int = 6
+    slow_job_types: str | None = None
+    slow_concurrency: int = 20
     poll_interval_s: int = 3
     visibility_timeout_s: int = 600
     drain_budget_s: int = 80
@@ -13,3 +26,54 @@ class WorkerSettings(BaseSettings):
     transient_backoff_max_s: int = 300
     unknown_type_backoff_s: int = 300
     mark_done_retry_backoff_s: int = 60
+
+    @property
+    def lanes_enabled(self) -> bool:
+        return self.llm_job_types is not None or self.slow_job_types is not None
+
+    def lane_configs(self) -> list[WorkerLane]:
+        lanes: list[WorkerLane] = []
+        if self.lanes_enabled:
+            llm_types = self._parse_job_types(self.llm_job_types)
+            slow_types = self._parse_job_types(self.slow_job_types)
+            if llm_types:
+                lanes.append(
+                    WorkerLane(
+                        name="llm",
+                        job_types=llm_types,
+                        concurrency=self.llm_concurrency,
+                    )
+                )
+            if slow_types:
+                lanes.append(
+                    WorkerLane(
+                        name="slow",
+                        job_types=slow_types,
+                        concurrency=self.slow_concurrency,
+                    )
+                )
+            if lanes:
+                return lanes
+
+        return [
+            WorkerLane(
+                name="default",
+                job_types=None,
+                concurrency=self.concurrency,
+            )
+        ]
+
+    @staticmethod
+    def _parse_job_types(value: str | None) -> tuple[str, ...]:
+        if value is None:
+            return ()
+
+        job_types = []
+        seen = set()
+        for item in value.split(","):
+            job_type = item.strip()
+            if not job_type or job_type in seen:
+                continue
+            job_types.append(job_type)
+            seen.add(job_type)
+        return tuple(job_types)

--- a/app/worker/handlers/match.py
+++ b/app/worker/handlers/match.py
@@ -5,11 +5,18 @@ from sqlmodel import select
 
 from app.config import get_settings
 from app.models.application import Application
+from app.models.job import Job
+from app.models.user_profile import UserProfile
 from app.models.work_queue import WorkQueue
+from app.services.remote_policy import evaluate_remote_policy
 from app.worker.handlers import HANDLERS, TransientError
 from app.worker.payloads import MatchPayload
 
 log = structlog.get_logger()
+
+
+def _deterministic_rejection_score(threshold: float) -> float:
+    return max(0.0, min(0.29, threshold - 0.01))
 
 
 class MatchHandler:
@@ -39,6 +46,42 @@ class MatchHandler:
             return
         if app.match_score is not None:
             await log.ainfo("worker.match.skip_replay", application_id=str(app.id))
+            return
+
+        job = await session.get(Job, app.job_id)
+        profile = await session.get(UserProfile, app.profile_id)
+        if job is None or profile is None:
+            await log.awarning(
+                "worker.match.domain_missing",
+                application_id=str(app.id),
+                job_id=str(app.job_id),
+                profile_id=str(app.profile_id),
+                job_found=job is not None,
+                profile_found=profile is not None,
+            )
+            return
+
+        verdict = evaluate_remote_policy(profile, job)
+        if verdict.hard_mismatch:
+            settings = get_settings()
+            gap = verdict.gap or "Deterministic match policy mismatch"
+            app.match_score = _deterministic_rejection_score(
+                settings.match_score_threshold
+            )
+            app.match_summary = (
+                "Deterministic mismatch: recurring office attendance requirement"
+            )
+            app.match_rationale = gap
+            app.match_strengths = []
+            app.match_gaps = [gap]
+            if app.status == "pending_review":
+                app.status = "auto_rejected"
+            session.add(app)
+            await log.ainfo(
+                "worker.match.deterministic_reject",
+                application_id=str(app.id),
+                score=app.match_score,
+            )
             return
 
         from app.agents import matching_agent

--- a/app/worker/handlers/match.py
+++ b/app/worker/handlers/match.py
@@ -8,7 +8,7 @@ from app.models.application import Application
 from app.models.job import Job
 from app.models.user_profile import UserProfile
 from app.models.work_queue import WorkQueue
-from app.services.remote_policy import evaluate_remote_policy
+from app.services.remote_policy import evaluate_remote_policy, evaluate_us_location_policy
 from app.worker.handlers import HANDLERS, TransientError
 from app.worker.payloads import MatchPayload
 
@@ -61,6 +61,28 @@ class MatchHandler:
             )
             return
 
+        verdict = evaluate_us_location_policy(job)
+        if verdict.hard_mismatch:
+            settings = get_settings()
+            gap = verdict.gap or "Deterministic match policy mismatch"
+            app.match_score = _deterministic_rejection_score(
+                settings.match_score_threshold
+            )
+            app.match_summary = "Deterministic mismatch: non-US position"
+            app.match_rationale = gap
+            app.match_strengths = []
+            app.match_gaps = [gap]
+            if app.status == "pending_review":
+                app.status = "auto_rejected"
+            session.add(app)
+            await log.ainfo(
+                "worker.match.deterministic_reject",
+                application_id=str(app.id),
+                policy="us_location",
+                score=app.match_score,
+            )
+            return
+
         verdict = evaluate_remote_policy(profile, job)
         if verdict.hard_mismatch:
             settings = get_settings()
@@ -80,6 +102,7 @@ class MatchHandler:
             await log.ainfo(
                 "worker.match.deterministic_reject",
                 application_id=str(app.id),
+                policy="remote_office",
                 score=app.match_score,
             )
             return

--- a/app/worker/main.py
+++ b/app/worker/main.py
@@ -78,6 +78,14 @@ async def _release_for_retry(session_factory, job_row, seconds: int) -> None:
         await session.commit()
 
 
+async def _cancel_pending(tasks: set[asyncio.Task] | list[asyncio.Task]) -> None:
+    pending = [task for task in tasks if not task.done()]
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
 async def _handle_one(
     job_row,
     session_factory,
@@ -234,61 +242,79 @@ async def _run_lane(
     shutdown_task: asyncio.Task,
 ) -> None:
     inflight: set[asyncio.Task] = set()
+    cancelled = False
 
-    while not _shutdown.is_set():
-        if len(inflight) >= lane.concurrency:
-            await asyncio.wait(
-                inflight | {shutdown_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            continue
-
-        async with session_factory() as session:
-            job = await claim_one(
-                session,
-                worker_id=_worker_id,
-                visibility_timeout_s=settings.visibility_timeout_s,
-                job_types=lane.job_types,
-            )
-            await session.commit()
-
-        if job is None:
-            try:
-                await asyncio.wait_for(
-                    asyncio.shield(shutdown_task),
-                    timeout=settings.poll_interval_s,
+    try:
+        while not _shutdown.is_set():
+            if len(inflight) >= lane.concurrency:
+                await asyncio.wait(
+                    inflight | {shutdown_task},
+                    return_when=asyncio.FIRST_COMPLETED,
                 )
-            except TimeoutError:
-                pass
-            continue
+                continue
 
+            async with session_factory() as session:
+                job = await claim_one(
+                    session,
+                    worker_id=_worker_id,
+                    visibility_timeout_s=settings.visibility_timeout_s,
+                    job_types=lane.job_types,
+                )
+                await session.commit()
+
+            if job is None:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(shutdown_task),
+                        timeout=settings.poll_interval_s,
+                    )
+                except TimeoutError:
+                    pass
+                continue
+
+            await log.ainfo(
+                "worker.job_start",
+                lane=lane.name,
+                job_id=job.id,
+                job_type=job.job_type,
+                attempts=job.attempts,
+                worker_id=_worker_id,
+            )
+            task = asyncio.create_task(
+                _handle_one(job, session_factory, settings, lane=lane.name)
+            )
+            inflight.add(task)
+            task.add_done_callback(inflight.discard)
+    except asyncio.CancelledError:
+        cancelled = True
+        raise
+    finally:
         await log.ainfo(
-            "worker.job_start",
+            "worker.shutdown_drain_start",
             lane=lane.name,
-            job_id=job.id,
-            job_type=job.job_type,
-            attempts=job.attempts,
-            worker_id=_worker_id,
+            inflight=len(inflight),
+            drain_budget_s=settings.drain_budget_s,
         )
-        task = asyncio.create_task(
-            _handle_one(job, session_factory, settings, lane=lane.name)
+        if cancelled:
+            await _cancel_pending(inflight)
+        elif inflight:
+            _, pending = await asyncio.wait(
+                inflight,
+                timeout=settings.drain_budget_s,
+            )
+            if pending:
+                await log.awarning(
+                    "worker.shutdown_drain_timeout",
+                    lane=lane.name,
+                    pending=len(pending),
+                    drain_budget_s=settings.drain_budget_s,
+                )
+                await _cancel_pending(list(pending))
+        await log.ainfo(
+            "worker.shutdown_drain_done",
+            lane=lane.name,
+            inflight=sum(1 for task in inflight if not task.done()),
         )
-        inflight.add(task)
-        task.add_done_callback(inflight.discard)
-
-    await log.ainfo(
-        "worker.shutdown_drain_start",
-        lane=lane.name,
-        inflight=len(inflight),
-        drain_budget_s=settings.drain_budget_s,
-    )
-    if inflight:
-        await asyncio.wait(inflight, timeout=settings.drain_budget_s)
-    await log.ainfo(
-        "worker.shutdown_drain_done",
-        lane=lane.name,
-        inflight=len(inflight),
-    )
 
 
 async def run() -> None:
@@ -332,4 +358,15 @@ async def run() -> None:
         )
         for lane in lanes
     ]
-    await asyncio.gather(*lane_tasks)
+    try:
+        await asyncio.gather(*lane_tasks)
+    except asyncio.CancelledError:
+        _shutdown.set()
+        await _cancel_pending(lane_tasks)
+        raise
+    except Exception:
+        _shutdown.set()
+        await _cancel_pending(lane_tasks)
+        raise
+    finally:
+        await _cancel_pending([shutdown_task])

--- a/app/worker/main.py
+++ b/app/worker/main.py
@@ -11,7 +11,7 @@ import uuid
 import structlog
 
 from app.database import get_session_factory
-from app.worker.config import WorkerSettings
+from app.worker.config import WorkerLane, WorkerSettings
 from app.worker.handlers import (  # noqa: F401
     HANDLERS,
     TransientError,
@@ -78,7 +78,13 @@ async def _release_for_retry(session_factory, job_row, seconds: int) -> None:
         await session.commit()
 
 
-async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> None:
+async def _handle_one(
+    job_row,
+    session_factory,
+    settings: WorkerSettings,
+    *,
+    lane: str,
+) -> None:
     handler = HANDLERS.get(job_row.job_type)
     if handler is None:
         async with session_factory() as session:
@@ -91,6 +97,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
             await session.commit()
         await log.awarning(
             "worker.unknown_job_type",
+            lane=lane,
             job_id=job_row.id,
             job_type=job_row.job_type,
         )
@@ -107,6 +114,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         except Exception:
             await log.aexception(
                 "worker.terminal_failure_hook_retry",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
             )
@@ -121,6 +129,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         else:
             await log.aerror(
                 "worker.handler_max_attempts",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
                 attempts=job_row.attempts,
@@ -145,6 +154,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
             await session.commit()
         await log.awarning(
             "worker.transient_failure",
+            lane=lane,
             job_id=job_row.id,
             job_type=job_row.job_type,
             error=str(exc),
@@ -157,6 +167,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         except Exception:
             await log.aexception(
                 "worker.terminal_failure_hook_retry",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
             )
@@ -171,6 +182,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         else:
             await log.aexception(
                 "worker.job_failed",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
             )
@@ -185,6 +197,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
     except Exception:
         await log.aexception(
             "worker.mark_done_failed",
+            lane=lane,
             job_id=job_row.id,
             job_type=job_row.job_type,
         )
@@ -197,6 +210,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         except Exception:
             await log.aexception(
                 "worker.mark_done_release_failed",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
             )
@@ -204,6 +218,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
     else:
         await log.ainfo(
             "worker.job_done",
+            lane=lane,
             job_id=job_row.id,
             job_type=job_row.job_type,
             worker_id=_worker_id,
@@ -211,40 +226,29 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         )
 
 
-async def run() -> None:
-    settings = WorkerSettings()
-    _shutdown.clear()
-    try:
-        loop = asyncio.get_running_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, _shutdown.set)
-    except (NotImplementedError, RuntimeError, ValueError):
-        pass
-
+async def _run_lane(
+    lane: WorkerLane,
+    *,
+    settings: WorkerSettings,
+    session_factory,
+    shutdown_task: asyncio.Task,
+) -> None:
     inflight: set[asyncio.Task] = set()
-    shutdown_task = asyncio.create_task(_shutdown.wait(), name="shutdown-waiter")
-    factory = get_session_factory()
-
-    await log.ainfo(
-        "worker.started",
-        worker_id=_worker_id,
-        concurrency=settings.concurrency,
-        visibility_timeout_s=settings.visibility_timeout_s,
-    )
 
     while not _shutdown.is_set():
-        if len(inflight) >= settings.concurrency:
+        if len(inflight) >= lane.concurrency:
             await asyncio.wait(
                 inflight | {shutdown_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
             continue
 
-        async with factory() as session:
+        async with session_factory() as session:
             job = await claim_one(
                 session,
                 worker_id=_worker_id,
                 visibility_timeout_s=settings.visibility_timeout_s,
+                job_types=lane.job_types,
             )
             await session.commit()
 
@@ -260,20 +264,72 @@ async def run() -> None:
 
         await log.ainfo(
             "worker.job_start",
+            lane=lane.name,
             job_id=job.id,
             job_type=job.job_type,
             attempts=job.attempts,
             worker_id=_worker_id,
         )
-        task = asyncio.create_task(_handle_one(job, factory, settings))
+        task = asyncio.create_task(
+            _handle_one(job, session_factory, settings, lane=lane.name)
+        )
         inflight.add(task)
         task.add_done_callback(inflight.discard)
 
     await log.ainfo(
         "worker.shutdown_drain_start",
+        lane=lane.name,
         inflight=len(inflight),
         drain_budget_s=settings.drain_budget_s,
     )
     if inflight:
         await asyncio.wait(inflight, timeout=settings.drain_budget_s)
-    await log.ainfo("worker.shutdown_drain_done", inflight=len(inflight))
+    await log.ainfo(
+        "worker.shutdown_drain_done",
+        lane=lane.name,
+        inflight=len(inflight),
+    )
+
+
+async def run() -> None:
+    settings = WorkerSettings()
+    lanes = settings.lane_configs()
+    _shutdown.clear()
+    try:
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, _shutdown.set)
+    except (NotImplementedError, RuntimeError, ValueError):
+        pass
+
+    shutdown_task = asyncio.create_task(_shutdown.wait(), name="shutdown-waiter")
+    factory = get_session_factory()
+
+    await log.ainfo(
+        "worker.started",
+        worker_id=_worker_id,
+        concurrency=settings.concurrency,
+        lanes=[
+            {
+                "name": lane.name,
+                "concurrency": lane.concurrency,
+                "job_types": lane.job_types,
+            }
+            for lane in lanes
+        ],
+        visibility_timeout_s=settings.visibility_timeout_s,
+    )
+
+    lane_tasks = [
+        asyncio.create_task(
+            _run_lane(
+                lane,
+                settings=settings,
+                session_factory=factory,
+                shutdown_task=shutdown_task,
+            ),
+            name=f"worker-lane-{lane.name}",
+        )
+        for lane in lanes
+    ]
+    await asyncio.gather(*lane_tasks)

--- a/app/worker/queue_service.py
+++ b/app/worker/queue_service.py
@@ -90,15 +90,26 @@ async def claim_one(
     *,
     worker_id: str,
     visibility_timeout_s: int,
+    job_types: list[str] | tuple[str, ...] | None = None,
 ) -> WorkQueue | None:
     """Atomically claim the next pending or stale non-self in-progress row."""
+    params: dict[str, Any] = {"timeout": visibility_timeout_s, "worker_id": worker_id}
+    job_type_filter = ""
+    if job_types is not None:
+        allowed_job_types = [job_type for job_type in job_types if job_type]
+        if not allowed_job_types:
+            return None
+        params["job_types"] = allowed_job_types
+        job_type_filter = "AND job_type = ANY(CAST(:job_types AS text[]))"
+
     result = await session.execute(
         text(
-            """
+            f"""
             WITH claimed AS (
               SELECT id
               FROM work_queue
               WHERE (not_before IS NULL OR not_before <= now())
+                {job_type_filter}
                 AND (
                   status = 'pending'
                   OR (
@@ -126,7 +137,7 @@ async def claim_one(
                       work_queue.dedupe_key
             """
         ),
-        {"timeout": visibility_timeout_s, "worker_id": worker_id},
+        params,
     )
     row = result.first()
     if row is None:

--- a/app/worker/queue_service.py
+++ b/app/worker/queue_service.py
@@ -96,7 +96,9 @@ async def claim_one(
     params: dict[str, Any] = {"timeout": visibility_timeout_s, "worker_id": worker_id}
     job_type_filter = ""
     if job_types is not None:
-        allowed_job_types = [job_type for job_type in job_types if job_type]
+        allowed_job_types = [
+            normalized for job_type in job_types if (normalized := job_type.strip())
+        ]
         if not allowed_job_types:
             return None
         params["job_types"] = allowed_job_types

--- a/docs/superpowers/plans/2026-05-14-worker-lanes-and-match-prefilter.md
+++ b/docs/superpowers/plans/2026-05-14-worker-lanes-and-match-prefilter.md
@@ -1,0 +1,992 @@
+# Worker Lanes And Match Prefilter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run one physical worker process with separate in-process LLM and slow-lane pools, and skip LLM matching for deterministic hard remote-policy mismatches.
+
+**Architecture:** Keep one `work_queue` table and add filtered claiming by job type. The worker starts either the current single unfiltered pool or two named lane pools from env config. The match handler loads the application, job, and profile, runs `evaluate_remote_policy()` before `matching_agent.score_one()`, and persists visible deterministic rejections.
+
+**Tech Stack:** Python 3.12, FastAPI app code, SQLModel/SQLAlchemy async sessions, Postgres `FOR UPDATE SKIP LOCKED`, pytest, pytest-asyncio.
+
+---
+
+## File Structure
+
+- Modify `app/worker/queue_service.py`: add optional `job_types` filtering to `claim_one()`.
+- Modify `tests/integration/test_queue_service.py`: prove filtered claiming preserves FIFO, `not_before`, and stale lease behavior.
+- Modify `app/worker/config.py`: add lane env vars and parsing helpers to `WorkerSettings`.
+- Modify `app/worker/main.py`: introduce lane pool orchestration inside one process and pass lane allowlists to `claim_one()`.
+- Modify `tests/integration/test_worker_lifecycle.py`: prove one process runs independent LLM and slow pools.
+- Modify `app/worker/handlers/match.py`: add deterministic pre-LLM remote-policy rejection.
+- Modify `tests/integration/test_handler_match.py`: prove visible deterministic rejection and no LLM call.
+- Optional docs check only: `docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md` already defines the behavior and should not need implementation edits.
+
+## Task 1: Filtered Queue Claiming
+
+**Files:**
+- Modify: `app/worker/queue_service.py`
+- Test: `tests/integration/test_queue_service.py`
+
+- [ ] **Step 1: Write failing tests for job-type filtered claims**
+
+Append these tests to `tests/integration/test_queue_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_claim_one_filters_to_allowed_job_types(db_session):
+    fetch_id = await enqueue(db_session, job_type="fetch-slug", payload={"order": "old"})
+    match_id = await enqueue(db_session, job_type="match", payload={"order": "new"})
+    await db_session.execute(
+        text("UPDATE work_queue SET enqueued_at = now() - interval '1 hour' WHERE id = :id"),
+        {"id": fetch_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match", "generate-cover-letter"],
+    )
+    await db_session.commit()
+
+    assert claimed is not None
+    assert claimed.id == match_id
+    assert claimed.job_type == "match"
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_preserves_not_before(db_session):
+    row_id = await enqueue(db_session, job_type="match", payload={})
+    await db_session.execute(
+        text(
+            "UPDATE work_queue SET not_before = now() + interval '5 minutes' "
+            "WHERE id = :id"
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match"],
+    )
+
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_reclaims_matching_stale_row(db_session):
+    row_id = await enqueue(db_session, job_type="match", payload={})
+    await db_session.execute(
+        text(
+            """
+            UPDATE work_queue
+            SET status='in_progress',
+                claimed_at = now() - interval '700 seconds',
+                claimed_by = 'dead-worker',
+                attempts = 1
+            WHERE id = :id
+            """
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match"],
+    )
+    await db_session.commit()
+
+    assert claimed is not None
+    assert claimed.id == row_id
+    assert claimed.claimed_by == "llm-worker"
+    assert claimed.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_ignores_other_stale_rows(db_session):
+    row_id = await enqueue(db_session, job_type="fetch-slug", payload={})
+    await db_session.execute(
+        text(
+            """
+            UPDATE work_queue
+            SET status='in_progress',
+                claimed_at = now() - interval '700 seconds',
+                claimed_by = 'dead-worker',
+                attempts = 1
+            WHERE id = :id
+            """
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match", "generate-cover-letter"],
+    )
+
+    assert claimed is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_queue_service.py::test_claim_one_filters_to_allowed_job_types tests/integration/test_queue_service.py::test_claim_one_job_type_filter_preserves_not_before tests/integration/test_queue_service.py::test_claim_one_job_type_filter_reclaims_matching_stale_row tests/integration/test_queue_service.py::test_claim_one_job_type_filter_ignores_other_stale_rows -v
+```
+
+Expected: FAIL with `TypeError: claim_one() got an unexpected keyword argument 'job_types'`.
+
+- [ ] **Step 3: Implement filtered claiming**
+
+In `app/worker/queue_service.py`, change the `claim_one()` signature and query setup to this shape:
+
+```python
+async def claim_one(
+    session: AsyncSession,
+    *,
+    worker_id: str,
+    visibility_timeout_s: int,
+    job_types: list[str] | tuple[str, ...] | None = None,
+) -> WorkQueue | None:
+    """Atomically claim the next pending or stale non-self in-progress row."""
+    params: dict[str, Any] = {
+        "timeout": visibility_timeout_s,
+        "worker_id": worker_id,
+    }
+    job_type_filter = ""
+    if job_types is not None:
+        normalized_job_types = [job_type for job_type in job_types if job_type]
+        if not normalized_job_types:
+            return None
+        params["job_types"] = normalized_job_types
+        job_type_filter = "AND job_type = ANY(CAST(:job_types AS text[]))"
+
+    result = await session.execute(
+        text(
+            f"""
+            WITH claimed AS (
+              SELECT id
+              FROM work_queue
+              WHERE (not_before IS NULL OR not_before <= now())
+                {job_type_filter}
+                AND (
+                  status = 'pending'
+                  OR (
+                    status = 'in_progress'
+                    AND claimed_at < now() - make_interval(secs => :timeout)
+                    AND (claimed_by IS NULL OR claimed_by <> :worker_id)
+                  )
+                )
+              ORDER BY enqueued_at ASC
+              FOR UPDATE SKIP LOCKED
+              LIMIT 1
+            )
+            UPDATE work_queue
+            SET status = 'in_progress',
+                claimed_at = now(),
+                claimed_by = :worker_id,
+                attempts = work_queue.attempts + 1
+            FROM claimed
+            WHERE work_queue.id = claimed.id
+            RETURNING work_queue.id, work_queue.job_type, work_queue.payload,
+                      work_queue.status, work_queue.enqueued_at,
+                      work_queue.claimed_at, work_queue.claimed_by,
+                      work_queue.not_before, work_queue.completed_at,
+                      work_queue.attempts, work_queue.last_error,
+                      work_queue.dedupe_key
+            """
+        ),
+        params,
+    )
+```
+
+Keep the existing row-to-`WorkQueue` mapping unchanged below this block.
+
+- [ ] **Step 4: Run queue service tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_queue_service.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/worker/queue_service.py tests/integration/test_queue_service.py
+git commit -m "feat(worker): filter queue claims by job type"
+```
+
+## Task 2: Worker Lane Configuration
+
+**Files:**
+- Modify: `app/worker/config.py`
+- Test: `tests/unit/test_worker_config.py`
+
+- [ ] **Step 1: Write failing config tests**
+
+Append these tests to `tests/unit/test_worker_config.py`:
+
+```python
+def test_worker_settings_default_single_pool(monkeypatch):
+    monkeypatch.delenv("WORKER_LLM_JOB_TYPES", raising=False)
+    monkeypatch.delenv("WORKER_SLOW_JOB_TYPES", raising=False)
+
+    settings = WorkerSettings()
+
+    assert settings.lanes_enabled is False
+    assert settings.lane_configs() == [
+        WorkerLane(name="default", job_types=None, concurrency=settings.concurrency)
+    ]
+
+
+def test_worker_settings_parses_lane_job_types(monkeypatch):
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", " match, generate-cover-letter,match ")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "6")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "fetch-slug, maintenance")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "20")
+
+    settings = WorkerSettings()
+
+    assert settings.lanes_enabled is True
+    assert settings.lane_configs() == [
+        WorkerLane(
+            name="llm",
+            job_types=("match", "generate-cover-letter"),
+            concurrency=6,
+        ),
+        WorkerLane(
+            name="slow",
+            job_types=("fetch-slug", "maintenance"),
+            concurrency=20,
+        ),
+    ]
+```
+
+Ensure the top of `tests/unit/test_worker_config.py` imports both names:
+
+```python
+from app.worker.config import WorkerLane, WorkerSettings
+```
+
+- [ ] **Step 2: Run config tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_worker_config.py -v
+```
+
+Expected: FAIL because `WorkerLane`, `lanes_enabled`, and `lane_configs()` do not exist.
+
+- [ ] **Step 3: Implement lane config parsing**
+
+Replace `app/worker/config.py` with:
+
+```python
+"""Worker-process configuration. Spec § Concurrency knobs."""
+from dataclasses import dataclass
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+@dataclass(frozen=True)
+class WorkerLane:
+    name: str
+    job_types: tuple[str, ...] | None
+    concurrency: int
+
+
+class WorkerSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="WORKER_")
+
+    concurrency: int = 4
+    poll_interval_s: int = 3
+    visibility_timeout_s: int = 600
+    drain_budget_s: int = 80
+    transient_backoff_base_s: int = 30
+    transient_backoff_max_s: int = 300
+    unknown_type_backoff_s: int = 300
+    mark_done_retry_backoff_s: int = 60
+
+    llm_job_types: str | None = None
+    llm_concurrency: int = 6
+    slow_job_types: str | None = None
+    slow_concurrency: int = 20
+
+    @property
+    def lanes_enabled(self) -> bool:
+        return bool(self.llm_job_types or self.slow_job_types)
+
+    def lane_configs(self) -> list[WorkerLane]:
+        if not self.lanes_enabled:
+            return [
+                WorkerLane(
+                    name="default",
+                    job_types=None,
+                    concurrency=self.concurrency,
+                )
+            ]
+
+        lanes: list[WorkerLane] = []
+        llm_types = _parse_job_types(self.llm_job_types)
+        slow_types = _parse_job_types(self.slow_job_types)
+        if llm_types:
+            lanes.append(
+                WorkerLane(
+                    name="llm",
+                    job_types=llm_types,
+                    concurrency=self.llm_concurrency,
+                )
+            )
+        if slow_types:
+            lanes.append(
+                WorkerLane(
+                    name="slow",
+                    job_types=slow_types,
+                    concurrency=self.slow_concurrency,
+                )
+            )
+        if not lanes:
+            return [
+                WorkerLane(
+                    name="default",
+                    job_types=None,
+                    concurrency=self.concurrency,
+                )
+            ]
+        return lanes
+
+
+def _parse_job_types(raw: str | None) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+
+    seen: set[str] = set()
+    parsed: list[str] = []
+    for item in raw.split(","):
+        job_type = item.strip()
+        if not job_type or job_type in seen:
+            continue
+        seen.add(job_type)
+        parsed.append(job_type)
+    return tuple(parsed)
+```
+
+- [ ] **Step 4: Run config tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_worker_config.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/worker/config.py tests/unit/test_worker_config.py
+git commit -m "feat(worker): add lane configuration"
+```
+
+## Task 3: In-Process Worker Lane Pools
+
+**Files:**
+- Modify: `app/worker/main.py`
+- Test: `tests/integration/test_worker_lifecycle.py`
+
+- [ ] **Step 1: Write failing worker lifecycle tests**
+
+Append these tests to `tests/integration/test_worker_lifecycle.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_worker_lanes_process_allowed_job_types(db_session, monkeypatch):
+    from app.worker.handlers import HANDLERS
+
+    calls: list[str] = []
+
+    class Record:
+        max_attempts = 3
+
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def __call__(self, session, row):
+            calls.append(self.name)
+
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", "test-llm")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "1")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "test-slow")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "1")
+    monkeypatch.setitem(HANDLERS, "test-llm", Record("llm"))
+    monkeypatch.setitem(HANDLERS, "test-slow", Record("slow"))
+
+    await enqueue(db_session, job_type="test-llm", payload={})
+    await enqueue(db_session, job_type="test-slow", payload={})
+    await db_session.commit()
+
+    async def stop_soon():
+        while len(calls) < 2:
+            await asyncio.sleep(0.05)
+        worker_main._shutdown.set()
+
+    await asyncio.gather(worker_main.run(), stop_soon())
+
+    assert sorted(calls) == ["llm", "slow"]
+
+
+@pytest.mark.asyncio
+async def test_slow_lane_drains_while_llm_lane_is_saturated(db_session, monkeypatch):
+    started_llm = asyncio.Event()
+    release_llm = asyncio.Event()
+    slow_done = asyncio.Event()
+    from app.worker.handlers import HANDLERS
+
+    class SlowLlm:
+        max_attempts = 3
+
+        async def __call__(self, session, row):
+            started_llm.set()
+            await release_llm.wait()
+
+    class FastSlow:
+        max_attempts = 3
+
+        async def __call__(self, session, row):
+            slow_done.set()
+
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", "test-llm-blocking")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "1")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "test-slow-fast")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "1")
+    monkeypatch.setitem(HANDLERS, "test-llm-blocking", SlowLlm())
+    monkeypatch.setitem(HANDLERS, "test-slow-fast", FastSlow())
+
+    await enqueue(db_session, job_type="test-llm-blocking", payload={})
+    await enqueue(db_session, job_type="test-slow-fast", payload={})
+    await db_session.commit()
+
+    async def stop_after_slow_done():
+        await started_llm.wait()
+        await asyncio.wait_for(slow_done.wait(), timeout=2)
+        release_llm.set()
+        worker_main._shutdown.set()
+
+    await asyncio.gather(worker_main.run(), stop_after_slow_done())
+
+    statuses = (
+        await db_session.execute(
+            text(
+                """
+                SELECT job_type, status
+                FROM work_queue
+                WHERE job_type IN ('test-llm-blocking', 'test-slow-fast')
+                ORDER BY job_type
+                """
+            )
+        )
+    ).all()
+    assert statuses == [
+        ("test-llm-blocking", "done"),
+        ("test-slow-fast", "done"),
+    ]
+```
+
+- [ ] **Step 2: Run worker lifecycle tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_worker_lifecycle.py::test_worker_lanes_process_allowed_job_types tests/integration/test_worker_lifecycle.py::test_slow_lane_drains_while_llm_lane_is_saturated -v
+```
+
+Expected: FAIL because the current worker has one shared pool and does not read lane env vars.
+
+- [ ] **Step 3: Add lane-aware worker pool helpers**
+
+In `app/worker/main.py`, update imports:
+
+```python
+from app.worker.config import WorkerLane, WorkerSettings
+```
+
+Change `_handle_one()` to accept a lane name and include it in logs:
+
+```python
+async def _handle_one(
+    job_row,
+    session_factory,
+    settings: WorkerSettings,
+    *,
+    lane: str,
+) -> None:
+```
+
+Add `lane=lane` to `worker.unknown_job_type`, `worker.transient_failure`, `worker.handler_max_attempts`, `worker.job_failed`, `worker.mark_done_failed`, `worker.mark_done_release_failed`, and `worker.job_done` logs.
+
+Then add this helper above `run()`:
+
+```python
+async def _run_lane(
+    lane: WorkerLane,
+    *,
+    settings: WorkerSettings,
+    session_factory,
+    shutdown_task: asyncio.Task,
+) -> None:
+    inflight: set[asyncio.Task] = set()
+    await log.ainfo(
+        "worker.lane_started",
+        worker_id=_worker_id,
+        lane=lane.name,
+        concurrency=lane.concurrency,
+        job_types=list(lane.job_types) if lane.job_types is not None else "all",
+    )
+
+    while not _shutdown.is_set():
+        if len(inflight) >= lane.concurrency:
+            await asyncio.wait(
+                inflight | {shutdown_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            continue
+
+        async with session_factory() as session:
+            job = await claim_one(
+                session,
+                worker_id=_worker_id,
+                visibility_timeout_s=settings.visibility_timeout_s,
+                job_types=lane.job_types,
+            )
+            await session.commit()
+
+        if job is None:
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(shutdown_task),
+                    timeout=settings.poll_interval_s,
+                )
+            except TimeoutError:
+                pass
+            continue
+
+        await log.ainfo(
+            "worker.job_start",
+            job_id=job.id,
+            job_type=job.job_type,
+            attempts=job.attempts,
+            worker_id=_worker_id,
+            lane=lane.name,
+        )
+        task = asyncio.create_task(
+            _handle_one(job, session_factory, settings, lane=lane.name)
+        )
+        inflight.add(task)
+        task.add_done_callback(inflight.discard)
+
+    await log.ainfo(
+        "worker.lane_shutdown_drain_start",
+        lane=lane.name,
+        inflight=len(inflight),
+        drain_budget_s=settings.drain_budget_s,
+    )
+    if inflight:
+        await asyncio.wait(inflight, timeout=settings.drain_budget_s)
+    await log.ainfo(
+        "worker.lane_shutdown_drain_done",
+        lane=lane.name,
+        inflight=len(inflight),
+    )
+```
+
+- [ ] **Step 4: Replace `run()` loop with lane orchestration**
+
+In `app/worker/main.py`, keep signal setup and replace the single-pool loop in `run()` with:
+
+```python
+    shutdown_task = asyncio.create_task(_shutdown.wait(), name="shutdown-waiter")
+    factory = get_session_factory()
+    lanes = settings.lane_configs()
+
+    await log.ainfo(
+        "worker.started",
+        worker_id=_worker_id,
+        lanes=[
+            {
+                "name": lane.name,
+                "concurrency": lane.concurrency,
+                "job_types": list(lane.job_types) if lane.job_types is not None else "all",
+            }
+            for lane in lanes
+        ],
+        visibility_timeout_s=settings.visibility_timeout_s,
+    )
+
+    lane_tasks = [
+        asyncio.create_task(
+            _run_lane(
+                lane,
+                settings=settings,
+                session_factory=factory,
+                shutdown_task=shutdown_task,
+            ),
+            name=f"worker-lane-{lane.name}",
+        )
+        for lane in lanes
+    ]
+    await asyncio.wait(lane_tasks, return_when=asyncio.ALL_COMPLETED)
+    await log.ainfo("worker.shutdown_done")
+```
+
+Remove the old `inflight` loop from `run()` after adding `_run_lane()`.
+
+- [ ] **Step 5: Run worker lifecycle tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_worker_lifecycle.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused worker and queue tests together**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_queue_service.py tests/integration/test_worker_lifecycle.py tests/unit/test_worker_config.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/worker/main.py tests/integration/test_worker_lifecycle.py
+git commit -m "feat(worker): run independent in-process lanes"
+```
+
+## Task 4: Deterministic Match Prefilter
+
+**Files:**
+- Modify: `app/worker/handlers/match.py`
+- Test: `tests/integration/test_handler_match.py`
+
+- [ ] **Step 1: Extend the match handler seed helper**
+
+In `tests/integration/test_handler_match.py`, replace `_seed_application()` with:
+
+```python
+async def _seed_application(
+    db_session,
+    *,
+    match_score: float | None = None,
+    app_status: str = "pending_review",
+    profile_locations: list[str] | None = None,
+    job_location: str | None = None,
+    workplace_type: str | None = None,
+    description: str | None = None,
+    description_raw: str | None = None,
+) -> Application:
+    user = User(id=uuid.uuid4(), email=f"match-handler-{uuid.uuid4()}@test.com")
+    db_session.add(user)
+    await db_session.commit()
+
+    company = Company(
+        canonical_name="Airbnb",
+        normalized_key=f"airbnb-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "airbnb"},
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.add(company)
+    await db_session.commit()
+    await db_session.refresh(company)
+
+    profile = UserProfile(
+        user_id=user.id,
+        target_company_ids=[company.id],
+        target_locations=profile_locations or [],
+        search_active=True,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+
+    job = Job(
+        source="greenhouse",
+        external_id=f"job-{uuid.uuid4()}",
+        title="Backend Engineer",
+        company_name="Airbnb",
+        company_id=company.id,
+        location=job_location,
+        workplace_type=workplace_type,
+        description=description,
+        description_raw=description_raw,
+        apply_url="https://example.com/job",
+        is_active=True,
+    )
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)
+
+    app = Application(
+        job_id=job.id,
+        profile_id=profile.id,
+        status=app_status,
+        match_score=match_score,
+        match_strengths=[],
+        match_gaps=[],
+    )
+    db_session.add(app)
+    await db_session.commit()
+    await db_session.refresh(app)
+    return app
+```
+
+- [ ] **Step 2: Write failing deterministic prefilter tests**
+
+Append these tests to `tests/integration/test_handler_match.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_visible_remote_policy_reject(db_session):
+    app = await _seed_application(
+        db_session,
+        description=(
+            "Remote role, but candidates must work from the NYC office twice a week."
+        ),
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "auto_rejected"
+    assert refreshed.match_score is not None
+    assert refreshed.match_score < 0.3
+    assert refreshed.match_summary == (
+        "Deterministic mismatch: recurring office attendance requirement"
+    )
+    assert refreshed.match_rationale == (
+        "Requires recurring office attendance outside target locations"
+    )
+    assert refreshed.match_strengths == []
+    assert refreshed.match_gaps == [
+        "Requires recurring office attendance outside target locations"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_preserves_user_owned_status(db_session):
+    app = await _seed_application(
+        db_session,
+        app_status="dismissed",
+        description="Candidates must work from the Toronto office twice a week.",
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "dismissed"
+    assert refreshed.match_score is not None
+    assert refreshed.match_gaps == [
+        "Requires recurring office attendance outside target locations"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_allows_target_location_match(db_session):
+    app = await _seed_application(
+        db_session,
+        profile_locations=["Toronto"],
+        description="Candidates must work from the Toronto office twice a week.",
+    )
+    handler = MatchHandler()
+
+    with patch(
+        "app.agents.matching_agent.score_one",
+        AsyncMock(
+            return_value={
+                "score": 0.83,
+                "summary": "location-compatible hybrid fit",
+                "rationale": "Toronto target location matches",
+                "strengths": ["Python"],
+                "gaps": [],
+            }
+        ),
+    ) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    assert mock_score.call_count == 1
+```
+
+- [ ] **Step 3: Run match handler tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_handler_match.py::test_match_handler_prefilter_visible_remote_policy_reject tests/integration/test_handler_match.py::test_match_handler_prefilter_preserves_user_owned_status tests/integration/test_handler_match.py::test_match_handler_prefilter_allows_target_location_match -v
+```
+
+Expected: FAIL because the handler always calls `matching_agent.score_one()` for unscored applications.
+
+- [ ] **Step 4: Implement deterministic prefilter helper**
+
+In `app/worker/handlers/match.py`, add imports:
+
+```python
+from app.models.job import Job
+from app.models.user_profile import UserProfile
+from app.services.remote_policy import evaluate_remote_policy
+```
+
+Add this helper above `MatchHandler`:
+
+```python
+def _deterministic_rejection_score(threshold: float) -> float:
+    return max(0.0, min(0.29, threshold - 0.01))
+```
+
+- [ ] **Step 5: Load job/profile and apply prefilter before LLM call**
+
+In `MatchHandler.__call__()`, after the `match_score is not None` short-circuit and before importing `matching_agent`, insert:
+
+```python
+        settings = get_settings()
+        job = (
+            await session.execute(select(Job).where(Job.id == app.job_id))
+        ).scalar_one_or_none()
+        profile = (
+            await session.execute(select(UserProfile).where(UserProfile.id == app.profile_id))
+        ).scalar_one_or_none()
+        if job is None or profile is None:
+            await log.awarning(
+                "worker.match.domain_missing",
+                application_id=str(app.id),
+                job_id=str(app.job_id),
+                profile_id=str(app.profile_id),
+                job_found=job is not None,
+                profile_found=profile is not None,
+            )
+            return
+
+        verdict = evaluate_remote_policy(profile, job)
+        if verdict.hard_mismatch:
+            gap = verdict.gap or "Deterministic match policy mismatch"
+            app.match_score = _deterministic_rejection_score(
+                settings.match_score_threshold
+            )
+            app.match_summary = (
+                "Deterministic mismatch: recurring office attendance requirement"
+            )
+            app.match_rationale = gap
+            app.match_strengths = []
+            app.match_gaps = [gap]
+            if app.status == "pending_review":
+                app.status = "auto_rejected"
+            session.add(app)
+            await log.ainfo(
+                "worker.match.prefilter_rejected",
+                application_id=str(app.id),
+                gap=gap,
+                score=app.match_score,
+            )
+            return
+```
+
+Then remove the later duplicate `settings = get_settings()` line before the threshold check, because settings is now loaded before the prefilter.
+
+- [ ] **Step 6: Run match handler tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_handler_match.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/worker/handlers/match.py tests/integration/test_handler_match.py
+git commit -m "feat(match): prefilter deterministic remote mismatches"
+```
+
+## Task 5: Full Verification
+
+**Files:**
+- No source edits expected.
+
+- [ ] **Step 1: Run focused backend tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_worker_config.py tests/unit/test_remote_policy.py tests/integration/test_queue_service.py tests/integration/test_worker_lifecycle.py tests/integration/test_handler_match.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run lint**
+
+Run:
+
+```bash
+uv run ruff check app/ tests/
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Check for unintended lockfile changes**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional source/test files are modified. If `uv.lock` changed and no dependency was intentionally added, restore it before committing.
+
+- [ ] **Step 4: Commit any verification-only cleanup**
+
+If lint required formatting or import-order edits, commit those exact files:
+
+```bash
+git add app/ tests/
+git commit -m "chore: tidy worker lane implementation"
+```
+
+If no files changed after verification, do not create a commit.

--- a/docs/superpowers/plans/2026-05-14-worker-lanes-and-match-prefilter.md
+++ b/docs/superpowers/plans/2026-05-14-worker-lanes-and-match-prefilter.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Run one physical worker process with separate in-process LLM and slow-lane pools, and skip LLM matching for deterministic hard remote-policy mismatches.
+**Goal:** Run one physical worker process with separate in-process LLM and slow-lane pools, and skip LLM matching for deterministic hard mismatches including non-US jobs and remote-policy failures.
 
-**Architecture:** Keep one `work_queue` table and add filtered claiming by job type. The worker starts either the current single unfiltered pool or two named lane pools from env config. The match handler loads the application, job, and profile, runs `evaluate_remote_policy()` before `matching_agent.score_one()`, and persists visible deterministic rejections.
+**Architecture:** Keep one `work_queue` table and add filtered claiming by job type. The worker starts either the current single unfiltered pool or two named lane pools from env config. The match handler loads the application, job, and profile, rejects jobs that are not explicitly US-based using only job-owned fields, then runs `evaluate_remote_policy()` before `matching_agent.score_one()`, and persists visible deterministic rejections.
 
 **Tech Stack:** Python 3.12, FastAPI app code, SQLModel/SQLAlchemy async sessions, Postgres `FOR UPDATE SKIP LOCKED`, pytest, pytest-asyncio.
 
@@ -17,7 +17,7 @@
 - Modify `app/worker/config.py`: add lane env vars and parsing helpers to `WorkerSettings`.
 - Modify `app/worker/main.py`: introduce lane pool orchestration inside one process and pass lane allowlists to `claim_one()`.
 - Modify `tests/integration/test_worker_lifecycle.py`: prove one process runs independent LLM and slow pools.
-- Modify `app/worker/handlers/match.py`: add deterministic pre-LLM remote-policy rejection.
+- Modify `app/worker/handlers/match.py`: add deterministic pre-LLM non-US and remote-policy rejection.
 - Modify `tests/integration/test_handler_match.py`: prove visible deterministic rejection and no LLM call.
 - Optional docs check only: `docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md` already defines the behavior and should not need implementation edits.
 
@@ -685,8 +685,21 @@ git commit -m "feat(worker): run independent in-process lanes"
 ## Task 4: Deterministic Match Prefilter
 
 **Files:**
+- Modify: `app/services/remote_policy.py`
 - Modify: `app/worker/handlers/match.py`
+- Test: `tests/unit/test_remote_policy.py`
 - Test: `tests/integration/test_handler_match.py`
+
+**Approved amendment:** The deterministic prefilter also enforces strict
+US-only job matching before the LLM call. Use only job-owned fields
+(`location`, `workplace_type`, `description`, `description_raw`) for this rule.
+Allow the LLM path only when those fields contain an explicit US signal such as
+`United States`, `USA`, `U.S.`, `US`, a US state name or abbreviation, or a
+recognizable city/state phrase such as `New York, NY`. Reject explicit non-US
+postings with no US signal. Reject ambiguous remote postings with no US signal.
+Persist the visible rejection with summary
+`Deterministic mismatch: non-US position` and gap/rationale
+`Position is not US-based`; preserve user-owned statuses.
 
 - [ ] **Step 1: Extend the match handler seed helper**
 

--- a/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
+++ b/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
@@ -15,7 +15,7 @@ draining independently.
 Matching also performs deterministic remote-policy enforcement after the LLM
 score. That still spends LLM capacity on jobs the code can already reject, such
 as roles requiring recurring office attendance outside the user's target
-locations.
+locations or roles that are not explicitly US-based.
 
 ## Goals
 
@@ -23,6 +23,7 @@ locations.
 - Keep total LLM job concurrency bounded to 6-8 concurrent jobs.
 - Allow fetch and maintenance work to drain separately from the LLM backlog.
 - Add deterministic pre-checks before LLM match scoring.
+- Restrict match scoring to jobs that are explicitly US-based.
 - Make deterministic match rejections visible and explicit in the normal
   application review surface.
 - Preserve the existing `work_queue` table, dedupe keys, lease ownership,
@@ -114,7 +115,35 @@ exits. A shutdown must not abandon in-flight jobs differently depending on lane.
 
 Before calling `matching_agent.score_one()` in the `match` handler, load the
 application's related job and profile and run deterministic pre-checks. The
-first pre-check is the existing remote policy:
+first pre-check is a strict US-location allowlist based only on job-owned
+fields:
+
+```text
+job.location
+job.workplace_type
+job.description
+job.description_raw
+```
+
+The handler may call the LLM only when those fields contain an explicit US
+signal, such as `United States`, `USA`, `U.S.`, `US`, a US state name or
+abbreviation, or a recognizable city/state phrase such as `New York, NY`.
+Postings with explicit non-US signals and no US signal are deterministic
+mismatches. Ambiguous remote postings with no US signal are also deterministic
+mismatches; absence of a location signal should not spend LLM budget.
+
+Persisted US-location rejection shape:
+
+```text
+status: auto_rejected, if the application is still pending_review
+match_score: below match_score_threshold
+match_summary: Deterministic mismatch: non-US position
+match_rationale: Position is not US-based
+match_strengths: []
+match_gaps: [Position is not US-based]
+```
+
+The second pre-check is the existing remote policy:
 
 ```text
 evaluate_remote_policy(profile, job)
@@ -203,6 +232,9 @@ Worker lifecycle tests:
 
 Match handler tests:
 
+- A non-US or ambiguous remote job persists a visible `auto_rejected`
+  application with explicit non-US summary, rationale, and gap.
+- A US-based job proceeds to the normal LLM scoring path.
 - A remote-policy hard mismatch persists a visible `auto_rejected` application
   with explicit summary, rationale, and gap.
 - The deterministic mismatch path does not call `matching_agent.score_one()`.

--- a/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
+++ b/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
@@ -46,7 +46,7 @@ job-type allowlist and concurrency cap.
 WORKER_LLM_JOB_TYPES=match,generate-cover-letter
 WORKER_LLM_CONCURRENCY=6
 WORKER_SLOW_JOB_TYPES=fetch-slug,maintenance
-WORKER_SLOW_CONCURRENCY=8
+WORKER_SLOW_CONCURRENCY=20
 ```
 
 Implementation can use asyncio tasks rather than OS threads because the current
@@ -84,7 +84,7 @@ job-search-worker
   WORKER_LLM_JOB_TYPES=match,generate-cover-letter
   WORKER_LLM_CONCURRENCY=6
   WORKER_SLOW_JOB_TYPES=fetch-slug,maintenance
-  WORKER_SLOW_CONCURRENCY=8
+  WORKER_SLOW_CONCURRENCY=20
 ```
 
 The LLM lane owns every job type that can call an LLM:
@@ -102,8 +102,8 @@ observability shows the provider API limit is not being approached. Cover-letter
 generation and match scoring share this same cap so the deployment cannot
 accidentally multiply LLM traffic by scaling separate LLM consumers.
 
-The slow-lane concurrency should start at `8`, matching the existing provider
-fetch concurrency expectation. It can be tuned independently because these jobs
+The slow-lane concurrency should start at `20`, matching the desired provider
+fetch drain capacity. It can be tuned independently because these jobs
 do not call LLM APIs.
 
 The process-level supervisor owns shutdown. On `SIGTERM` or `SIGINT`, it stops

--- a/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
+++ b/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
@@ -3,8 +3,9 @@
 ## Context
 
 Production currently uses one physical `work_queue` table and one worker process
-that claims any eligible job type. A large match backlog can consume worker
-capacity even when non-LLM work, such as provider fetching, is ready to run.
+that claims any eligible job type from one shared worker pool. A large match
+backlog can consume worker capacity even when non-LLM work, such as provider
+fetching, is ready to run.
 
 Live queue depth on 2026-05-14 showed thousands of pending `match` rows and only
 a few `fetch-slug` rows. That is the failure mode this design addresses: LLM
@@ -18,7 +19,7 @@ locations.
 
 ## Goals
 
-- Split worker runtime capacity into LLM and non-LLM lanes.
+- Split one physical worker process into LLM and non-LLM internal worker pools.
 - Keep total LLM job concurrency bounded to 6-8 concurrent jobs.
 - Allow fetch and maintenance work to drain separately from the LLM backlog.
 - Add deterministic pre-checks before LLM match scoring.
@@ -37,16 +38,27 @@ locations.
 
 ## Worker Lane Model
 
-Keep one physical `work_queue` table. Add a worker setting that restricts which
-job types a worker process may claim:
+Keep one physical `work_queue` table and one physical worker process. Inside
+that process, start multiple internal worker pools. Each pool has its own
+job-type allowlist and concurrency cap.
 
 ```text
-WORKER_JOB_TYPES=match,generate-cover-letter
-WORKER_JOB_TYPES=fetch-slug,maintenance
+WORKER_LLM_JOB_TYPES=match,generate-cover-letter
+WORKER_LLM_CONCURRENCY=6
+WORKER_NON_LLM_JOB_TYPES=fetch-slug,maintenance
+WORKER_NON_LLM_CONCURRENCY=8
 ```
 
-An unset `WORKER_JOB_TYPES` keeps the current behavior and allows all registered
-job types. This preserves local development and makes rollback simple.
+Implementation can use asyncio tasks rather than OS threads because the current
+worker stack is async. The required invariant is operational, not mechanical:
+one process runs multiple independent lane workers, and each lane enforces its
+own concurrency limit. If a future blocking operation requires actual threads,
+that can be hidden behind the lane worker interface without changing the queue
+contract.
+
+An unset lane configuration keeps the current behavior: one unfiltered pool
+using `WORKER_CONCURRENCY`. This preserves local development and makes rollback
+simple.
 
 `claim_one()` accepts an optional job-type allowlist. When present, the claim
 query only considers eligible rows whose `job_type` is in that allowlist. The
@@ -56,24 +68,23 @@ not-before semantics continue to apply.
 The worker startup log includes:
 
 - `worker_id`
-- `concurrency`
+- lane names
+- per-lane concurrency
 - `visibility_timeout_s`
-- configured `job_types`, using `all` when no filter is set
+- per-lane `job_types`, using `all` only for the rollback/default pool
 
 ## Production Runtime Shape
 
-Production runs two worker services from the same image:
+Production runs one worker service from the app image. That one process starts
+both internal lane pools:
 
 ```text
-job-search-worker-llm
+job-search-worker
   command: python -m app.worker
-  WORKER_JOB_TYPES=match,generate-cover-letter
-  WORKER_CONCURRENCY=6
-
-job-search-worker-non-llm
-  command: python -m app.worker
-  WORKER_JOB_TYPES=fetch-slug,maintenance
-  WORKER_CONCURRENCY=8
+  WORKER_LLM_JOB_TYPES=match,generate-cover-letter
+  WORKER_LLM_CONCURRENCY=6
+  WORKER_NON_LLM_JOB_TYPES=fetch-slug,maintenance
+  WORKER_NON_LLM_CONCURRENCY=8
 ```
 
 The LLM lane owns every job type that can call an LLM:
@@ -94,6 +105,10 @@ accidentally multiply LLM traffic by scaling separate LLM consumers.
 The non-LLM concurrency should start at `8`, matching the existing provider
 fetch concurrency expectation. It can be tuned independently because the lane
 does not call LLM APIs.
+
+The process-level supervisor owns shutdown. On `SIGTERM` or `SIGINT`, it stops
+all lane polling loops, waits for every in-flight lane task to finish, and then
+exits. A shutdown must not abandon in-flight jobs differently depending on lane.
 
 ## Deterministic Match Prefilter
 
@@ -140,7 +155,8 @@ Existing queue-depth emission remains useful because all rows stay in
 `work_queue`. Add lane context to worker logs so production can distinguish LLM
 and non-LLM consumers:
 
-- `worker.started` includes `job_types`
+- `worker.started` includes lane configuration
+- job claim/start/done/failure logs include `lane`
 - job completion/failure logs continue to include `job_type`
 
 Operational queue checks should group by `job_type` and `status`. The important
@@ -153,10 +169,11 @@ Filtered claiming must not alter finalization semantics:
 
 - `mark_done`, `mark_failed`, and `release_with_backoff` remain lease-owner
   scoped.
-- Unknown job types are only claimed by workers whose allowlist includes them,
-  or by unfiltered workers.
-- A misconfigured lane with no matching job types simply polls and idles.
-- If `WORKER_JOB_TYPES` contains whitespace, empty entries, or duplicate
+- Unknown job types are only claimed by a lane whose allowlist includes them,
+  or by the rollback/default unfiltered pool.
+- A misconfigured lane with no matching job types simply polls and idles; it
+  must not block the other lane.
+- If a lane job-type env var contains whitespace, empty entries, or duplicate
   entries, parsing trims and deduplicates the list.
 
 Deterministic prefilter failures are code failures, not domain mismatches. If
@@ -177,9 +194,12 @@ Queue service tests:
 
 Worker lifecycle tests:
 
-- A match-lane worker does not process `fetch-slug`.
-- A non-LLM worker does not process `match`.
-- Worker startup accepts comma-separated `WORKER_JOB_TYPES`.
+- One worker process starts both LLM and non-LLM lane pools.
+- The LLM lane does not process `fetch-slug` or `maintenance`.
+- The non-LLM lane does not process `match` or `generate-cover-letter`.
+- LLM concurrency is capped independently from non-LLM concurrency.
+- Non-LLM rows can complete while the LLM lane is saturated.
+- Worker startup accepts comma-separated lane job-type env vars.
 
 Match handler tests:
 
@@ -193,15 +213,16 @@ Match handler tests:
 
 ## Rollout
 
-1. Ship code that supports filtered claiming while leaving `WORKER_JOB_TYPES`
-   unset in the current worker.
-2. Deploy the code and verify the unfiltered worker still drains all job types.
-3. Update infra to run the LLM and non-LLM worker services with the environment
-   variables above.
+1. Ship code that supports filtered claiming and internal lane pools while
+   leaving lane env vars unset in production.
+2. Deploy the code and verify the default unfiltered pool still drains all job
+   types.
+3. Update the single worker service env to enable the LLM and non-LLM lanes.
 4. Verify queue depth grouped by job type:
    non-LLM rows should not wait behind match backlog.
-5. Keep the old single-worker service disabled but easy to restore for one
-   deploy cycle.
+5. Keep the default unfiltered-pool rollback path available for one deploy
+   cycle.
 
-Rollback is setting `WORKER_JOB_TYPES` unset and returning to a single worker
-service. No database migration rollback is required.
+Rollback is unsetting the lane env vars so the process returns to the existing
+single unfiltered pool using `WORKER_CONCURRENCY`. No database migration
+rollback is required.

--- a/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
+++ b/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
@@ -4,13 +4,13 @@
 
 Production currently uses one physical `work_queue` table and one worker process
 that claims any eligible job type from one shared worker pool. A large match
-backlog can consume worker capacity even when non-LLM work, such as provider
-fetching, is ready to run.
+backlog can consume worker capacity even when slow/background work, such as
+provider fetching, is ready to run.
 
 Live queue depth on 2026-05-14 showed thousands of pending `match` rows and only
 a few `fetch-slug` rows. That is the failure mode this design addresses: LLM
-work must be bounded by the API limit, while non-LLM work must keep draining
-independently.
+work must be bounded by the API limit, while slow/background work must keep
+draining independently.
 
 Matching also performs deterministic remote-policy enforcement after the LLM
 score. That still spends LLM capacity on jobs the code can already reject, such
@@ -19,7 +19,7 @@ locations.
 
 ## Goals
 
-- Split one physical worker process into LLM and non-LLM internal worker pools.
+- Split one physical worker process into LLM and slow internal worker pools.
 - Keep total LLM job concurrency bounded to 6-8 concurrent jobs.
 - Allow fetch and maintenance work to drain separately from the LLM backlog.
 - Add deterministic pre-checks before LLM match scoring.
@@ -45,8 +45,8 @@ job-type allowlist and concurrency cap.
 ```text
 WORKER_LLM_JOB_TYPES=match,generate-cover-letter
 WORKER_LLM_CONCURRENCY=6
-WORKER_NON_LLM_JOB_TYPES=fetch-slug,maintenance
-WORKER_NON_LLM_CONCURRENCY=8
+WORKER_SLOW_JOB_TYPES=fetch-slug,maintenance
+WORKER_SLOW_CONCURRENCY=8
 ```
 
 Implementation can use asyncio tasks rather than OS threads because the current
@@ -83,8 +83,8 @@ job-search-worker
   command: python -m app.worker
   WORKER_LLM_JOB_TYPES=match,generate-cover-letter
   WORKER_LLM_CONCURRENCY=6
-  WORKER_NON_LLM_JOB_TYPES=fetch-slug,maintenance
-  WORKER_NON_LLM_CONCURRENCY=8
+  WORKER_SLOW_JOB_TYPES=fetch-slug,maintenance
+  WORKER_SLOW_CONCURRENCY=8
 ```
 
 The LLM lane owns every job type that can call an LLM:
@@ -92,7 +92,7 @@ The LLM lane owns every job type that can call an LLM:
 - `match`
 - `generate-cover-letter`
 
-The non-LLM lane owns jobs that should not be blocked by LLM backlog:
+The slow lane owns jobs that should not be blocked by LLM backlog:
 
 - `fetch-slug`
 - `maintenance`
@@ -102,9 +102,9 @@ observability shows the provider API limit is not being approached. Cover-letter
 generation and match scoring share this same cap so the deployment cannot
 accidentally multiply LLM traffic by scaling separate LLM consumers.
 
-The non-LLM concurrency should start at `8`, matching the existing provider
-fetch concurrency expectation. It can be tuned independently because the lane
-does not call LLM APIs.
+The slow-lane concurrency should start at `8`, matching the existing provider
+fetch concurrency expectation. It can be tuned independently because these jobs
+do not call LLM APIs.
 
 The process-level supervisor owns shutdown. On `SIGTERM` or `SIGINT`, it stops
 all lane polling loops, waits for every in-flight lane task to finish, and then
@@ -153,14 +153,14 @@ the worker prefilter.
 
 Existing queue-depth emission remains useful because all rows stay in
 `work_queue`. Add lane context to worker logs so production can distinguish LLM
-and non-LLM consumers:
+and slow-lane consumers:
 
 - `worker.started` includes lane configuration
 - job claim/start/done/failure logs include `lane`
 - job completion/failure logs continue to include `job_type`
 
 Operational queue checks should group by `job_type` and `status`. The important
-runtime invariant is that pending non-LLM rows can drain even when `match`
+runtime invariant is that pending slow-lane rows can drain even when `match`
 backlog is large.
 
 ## Failure Handling
@@ -194,11 +194,11 @@ Queue service tests:
 
 Worker lifecycle tests:
 
-- One worker process starts both LLM and non-LLM lane pools.
+- One worker process starts both LLM and slow lane pools.
 - The LLM lane does not process `fetch-slug` or `maintenance`.
-- The non-LLM lane does not process `match` or `generate-cover-letter`.
-- LLM concurrency is capped independently from non-LLM concurrency.
-- Non-LLM rows can complete while the LLM lane is saturated.
+- The slow lane does not process `match` or `generate-cover-letter`.
+- LLM concurrency is capped independently from slow-lane concurrency.
+- Slow-lane rows can complete while the LLM lane is saturated.
 - Worker startup accepts comma-separated lane job-type env vars.
 
 Match handler tests:
@@ -217,9 +217,9 @@ Match handler tests:
    leaving lane env vars unset in production.
 2. Deploy the code and verify the default unfiltered pool still drains all job
    types.
-3. Update the single worker service env to enable the LLM and non-LLM lanes.
+3. Update the single worker service env to enable the LLM and slow lanes.
 4. Verify queue depth grouped by job type:
-   non-LLM rows should not wait behind match backlog.
+   slow-lane rows should not wait behind match backlog.
 5. Keep the default unfiltered-pool rollback path available for one deploy
    cycle.
 

--- a/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
+++ b/docs/superpowers/specs/2026-05-14-worker-lanes-and-match-prefilter-design.md
@@ -1,0 +1,207 @@
+# Worker Lanes And Match Prefilter Design
+
+## Context
+
+Production currently uses one physical `work_queue` table and one worker process
+that claims any eligible job type. A large match backlog can consume worker
+capacity even when non-LLM work, such as provider fetching, is ready to run.
+
+Live queue depth on 2026-05-14 showed thousands of pending `match` rows and only
+a few `fetch-slug` rows. That is the failure mode this design addresses: LLM
+work must be bounded by the API limit, while non-LLM work must keep draining
+independently.
+
+Matching also performs deterministic remote-policy enforcement after the LLM
+score. That still spends LLM capacity on jobs the code can already reject, such
+as roles requiring recurring office attendance outside the user's target
+locations.
+
+## Goals
+
+- Split worker runtime capacity into LLM and non-LLM lanes.
+- Keep total LLM job concurrency bounded to 6-8 concurrent jobs.
+- Allow fetch and maintenance work to drain separately from the LLM backlog.
+- Add deterministic pre-checks before LLM match scoring.
+- Make deterministic match rejections visible and explicit in the normal
+  application review surface.
+- Preserve the existing `work_queue` table, dedupe keys, lease ownership,
+  retry/backoff behavior, and maintenance cleanup.
+
+## Non-Goals
+
+- Create separate physical queue tables.
+- Build a general rules engine or structured job classifier.
+- Hide deterministic rejects from the UI.
+- Change provider fetch semantics.
+- Change cover-letter generation behavior beyond placing it in the LLM lane.
+
+## Worker Lane Model
+
+Keep one physical `work_queue` table. Add a worker setting that restricts which
+job types a worker process may claim:
+
+```text
+WORKER_JOB_TYPES=match,generate-cover-letter
+WORKER_JOB_TYPES=fetch-slug,maintenance
+```
+
+An unset `WORKER_JOB_TYPES` keeps the current behavior and allows all registered
+job types. This preserves local development and makes rollback simple.
+
+`claim_one()` accepts an optional job-type allowlist. When present, the claim
+query only considers eligible rows whose `job_type` is in that allowlist. The
+same lease timeout, `FOR UPDATE SKIP LOCKED`, ordering, attempts increment, and
+not-before semantics continue to apply.
+
+The worker startup log includes:
+
+- `worker_id`
+- `concurrency`
+- `visibility_timeout_s`
+- configured `job_types`, using `all` when no filter is set
+
+## Production Runtime Shape
+
+Production runs two worker services from the same image:
+
+```text
+job-search-worker-llm
+  command: python -m app.worker
+  WORKER_JOB_TYPES=match,generate-cover-letter
+  WORKER_CONCURRENCY=6
+
+job-search-worker-non-llm
+  command: python -m app.worker
+  WORKER_JOB_TYPES=fetch-slug,maintenance
+  WORKER_CONCURRENCY=8
+```
+
+The LLM lane owns every job type that can call an LLM:
+
+- `match`
+- `generate-cover-letter`
+
+The non-LLM lane owns jobs that should not be blocked by LLM backlog:
+
+- `fetch-slug`
+- `maintenance`
+
+The default LLM concurrency should start at `6`. It can be raised to `8` only if
+observability shows the provider API limit is not being approached. Cover-letter
+generation and match scoring share this same cap so the deployment cannot
+accidentally multiply LLM traffic by scaling separate LLM consumers.
+
+The non-LLM concurrency should start at `8`, matching the existing provider
+fetch concurrency expectation. It can be tuned independently because the lane
+does not call LLM APIs.
+
+## Deterministic Match Prefilter
+
+Before calling `matching_agent.score_one()` in the `match` handler, load the
+application's related job and profile and run deterministic pre-checks. The
+first pre-check is the existing remote policy:
+
+```text
+evaluate_remote_policy(profile, job)
+```
+
+If the verdict is a hard mismatch, the handler must not call the LLM. It
+persists a visible match result on the application and returns successfully so
+the queue row is marked done.
+
+Persisted deterministic rejection shape:
+
+```text
+status: auto_rejected, if the application is still pending_review
+match_score: below match_score_threshold
+match_summary: Deterministic mismatch: recurring office attendance requirement
+match_rationale: Requires recurring office attendance outside target locations
+match_strengths: []
+match_gaps: [Requires recurring office attendance outside target locations]
+```
+
+The exact score should be deterministic and below threshold. Use the same
+threshold-aware cap currently used by post-LLM remote policy enforcement:
+`max(0.0, min(0.29, threshold - 0.01))`.
+
+If the application is already user-owned state such as `dismissed` or `applied`,
+the prefilter must not overwrite that status. It may still persist the match
+score and rationale fields if the application is being rescored, but user-owned
+status remains authoritative.
+
+If the pre-check does not produce a hard mismatch, the handler proceeds to the
+current LLM scoring path. The existing post-LLM remote-policy cap should remain
+as a defense in depth path for any match scoring entrypoint that does not use
+the worker prefilter.
+
+## Observability
+
+Existing queue-depth emission remains useful because all rows stay in
+`work_queue`. Add lane context to worker logs so production can distinguish LLM
+and non-LLM consumers:
+
+- `worker.started` includes `job_types`
+- job completion/failure logs continue to include `job_type`
+
+Operational queue checks should group by `job_type` and `status`. The important
+runtime invariant is that pending non-LLM rows can drain even when `match`
+backlog is large.
+
+## Failure Handling
+
+Filtered claiming must not alter finalization semantics:
+
+- `mark_done`, `mark_failed`, and `release_with_backoff` remain lease-owner
+  scoped.
+- Unknown job types are only claimed by workers whose allowlist includes them,
+  or by unfiltered workers.
+- A misconfigured lane with no matching job types simply polls and idles.
+- If `WORKER_JOB_TYPES` contains whitespace, empty entries, or duplicate
+  entries, parsing trims and deduplicates the list.
+
+Deterministic prefilter failures are code failures, not domain mismatches. If
+loading related data or applying the pre-check raises unexpectedly, normal
+worker exception handling applies.
+
+## Testing
+
+Queue service tests:
+
+- `claim_one(..., job_types=["match"])` claims the oldest eligible `match` row
+  and ignores older non-match rows.
+- `claim_one(..., job_types=["fetch-slug", "maintenance"])` does not claim
+  `match` or `generate-cover-letter`.
+- `claim_one(..., job_types=None)` preserves current all-job behavior.
+- Future `not_before` and stale in-progress reclaim rules still work with a
+  job-type filter.
+
+Worker lifecycle tests:
+
+- A match-lane worker does not process `fetch-slug`.
+- A non-LLM worker does not process `match`.
+- Worker startup accepts comma-separated `WORKER_JOB_TYPES`.
+
+Match handler tests:
+
+- A remote-policy hard mismatch persists a visible `auto_rejected` application
+  with explicit summary, rationale, and gap.
+- The deterministic mismatch path does not call `matching_agent.score_one()`.
+- The deterministic mismatch path does not overwrite `dismissed` or `applied`
+  status.
+- A non-mismatch job still calls `matching_agent.score_one()` and persists the
+  normal LLM score.
+
+## Rollout
+
+1. Ship code that supports filtered claiming while leaving `WORKER_JOB_TYPES`
+   unset in the current worker.
+2. Deploy the code and verify the unfiltered worker still drains all job types.
+3. Update infra to run the LLM and non-LLM worker services with the environment
+   variables above.
+4. Verify queue depth grouped by job type:
+   non-LLM rows should not wait behind match backlog.
+5. Keep the old single-worker service disabled but easy to restore for one
+   deploy cycle.
+
+Rollback is setting `WORKER_JOB_TYPES` unset and returning to a single worker
+service. No database migration rollback is required.

--- a/tests/integration/test_handler_match.py
+++ b/tests/integration/test_handler_match.py
@@ -21,7 +21,7 @@ async def _seed_application(
     match_score: float | None = None,
     app_status: str = "pending_review",
     profile_locations: list[str] | None = None,
-    job_location: str | None = None,
+    job_location: str | None = "Remote - United States",
     workplace_type: str | None = None,
     description: str | None = None,
     description_raw: str | None = None,
@@ -127,7 +127,8 @@ async def test_match_handler_prefilter_visible_remote_policy_reject(db_session):
     app = await _seed_application(
         db_session,
         description=(
-            "Remote role, but candidates must work from the NYC office twice a week."
+            "Remote role in the United States, but candidates must work "
+            "from the New York, NY office twice a week."
         ),
     )
     app_id = app.id
@@ -162,7 +163,7 @@ async def test_match_handler_prefilter_preserves_user_owned_status(db_session):
     app = await _seed_application(
         db_session,
         app_status="dismissed",
-        description="Candidates must work from the Toronto office twice a week.",
+        description="Candidates must work from the New York, NY office twice a week.",
     )
     app_id = app.id
     handler = MatchHandler()
@@ -184,11 +185,67 @@ async def test_match_handler_prefilter_preserves_user_owned_status(db_session):
 
 
 @pytest.mark.asyncio
+async def test_match_handler_prefilter_visible_non_us_reject(db_session):
+    app = await _seed_application(
+        db_session,
+        job_location="Toronto, Canada",
+        workplace_type="remote",
+        description="Remote role open to candidates based in Canada.",
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "auto_rejected"
+    assert refreshed.match_score is not None
+    assert refreshed.match_score < 0.3
+    assert refreshed.match_summary == "Deterministic mismatch: non-US position"
+    assert refreshed.match_rationale == "Position is not US-based"
+    assert refreshed.match_strengths == []
+    assert refreshed.match_gaps == ["Position is not US-based"]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_non_us_preserves_user_owned_status(db_session):
+    app = await _seed_application(
+        db_session,
+        app_status="applied",
+        job_location="Remote",
+        workplace_type="remote",
+        description="Work from anywhere with a distributed engineering team.",
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "applied"
+    assert refreshed.match_score is not None
+    assert refreshed.match_summary == "Deterministic mismatch: non-US position"
+    assert refreshed.match_gaps == ["Position is not US-based"]
+
+
+@pytest.mark.asyncio
 async def test_match_handler_prefilter_allows_target_location_match(db_session):
     app = await _seed_application(
         db_session,
-        profile_locations=["Toronto"],
-        description="Candidates must work from the Toronto office twice a week.",
+        profile_locations=["San Francisco"],
+        description="Candidates must work from the San Francisco, CA office twice a week.",
     )
     handler = MatchHandler()
 

--- a/tests/integration/test_handler_match.py
+++ b/tests/integration/test_handler_match.py
@@ -15,7 +15,17 @@ from app.worker.handlers import HANDLERS
 from app.worker.handlers.match import MatchHandler
 
 
-async def _seed_application(db_session, *, match_score: float | None = None) -> Application:
+async def _seed_application(
+    db_session,
+    *,
+    match_score: float | None = None,
+    app_status: str = "pending_review",
+    profile_locations: list[str] | None = None,
+    job_location: str | None = None,
+    workplace_type: str | None = None,
+    description: str | None = None,
+    description_raw: str | None = None,
+) -> Application:
     user = User(id=uuid.uuid4(), email=f"match-handler-{uuid.uuid4()}@test.com")
     db_session.add(user)
     await db_session.commit()
@@ -33,6 +43,7 @@ async def _seed_application(db_session, *, match_score: float | None = None) -> 
     profile = UserProfile(
         user_id=user.id,
         target_company_ids=[company.id],
+        target_locations=profile_locations or ["San Francisco"],
         search_active=True,
     )
     db_session.add(profile)
@@ -45,6 +56,10 @@ async def _seed_application(db_session, *, match_score: float | None = None) -> 
         title="Backend Engineer",
         company_name="Airbnb",
         company_id=company.id,
+        location=job_location,
+        workplace_type=workplace_type,
+        description=description,
+        description_raw=description_raw,
         apply_url="https://example.com/job",
         is_active=True,
     )
@@ -55,6 +70,7 @@ async def _seed_application(db_session, *, match_score: float | None = None) -> 
     app = Application(
         job_id=job.id,
         profile_id=profile.id,
+        status=app_status,
         match_score=match_score,
         match_strengths=[],
         match_gaps=[],
@@ -104,6 +120,94 @@ async def test_match_handler_scores_one_application(db_session):
     assert mock_score.call_count == 1
     assert refreshed.match_score == 0.85
     assert refreshed.match_summary == "good fit"
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_visible_remote_policy_reject(db_session):
+    app = await _seed_application(
+        db_session,
+        description=(
+            "Remote role, but candidates must work from the NYC office twice a week."
+        ),
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "auto_rejected"
+    assert refreshed.match_score is not None
+    assert refreshed.match_score < 0.3
+    assert refreshed.match_summary == (
+        "Deterministic mismatch: recurring office attendance requirement"
+    )
+    assert refreshed.match_rationale == (
+        "Requires recurring office attendance outside target locations"
+    )
+    assert refreshed.match_strengths == []
+    assert refreshed.match_gaps == [
+        "Requires recurring office attendance outside target locations"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_preserves_user_owned_status(db_session):
+    app = await _seed_application(
+        db_session,
+        app_status="dismissed",
+        description="Candidates must work from the Toronto office twice a week.",
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "dismissed"
+    assert refreshed.match_score is not None
+    assert refreshed.match_gaps == [
+        "Requires recurring office attendance outside target locations"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_allows_target_location_match(db_session):
+    app = await _seed_application(
+        db_session,
+        profile_locations=["Toronto"],
+        description="Candidates must work from the Toronto office twice a week.",
+    )
+    handler = MatchHandler()
+
+    with patch(
+        "app.agents.matching_agent.score_one",
+        AsyncMock(
+            return_value={
+                "score": 0.83,
+                "summary": "location-compatible hybrid fit",
+                "rationale": "Toronto target location matches",
+                "strengths": ["Python"],
+                "gaps": [],
+            }
+        ),
+    ) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    assert mock_score.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_queue_service.py
+++ b/tests/integration/test_queue_service.py
@@ -278,3 +278,108 @@ async def test_release_with_backoff_raises_stale_lease_for_wrong_worker(db_sessi
     ).scalar_one()
     assert row.status == WorkQueueStatus.IN_PROGRESS
     assert row.claimed_by == "w1"
+
+
+@pytest.mark.asyncio
+async def test_claim_one_filters_to_allowed_job_types(db_session):
+    fetch_id = await enqueue(db_session, job_type="fetch-slug", payload={"order": "old"})
+    match_id = await enqueue(db_session, job_type="match", payload={"order": "new"})
+    await db_session.execute(
+        text("UPDATE work_queue SET enqueued_at = now() - interval '1 hour' WHERE id = :id"),
+        {"id": fetch_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match", "generate-cover-letter"],
+    )
+    await db_session.commit()
+
+    assert claimed is not None
+    assert claimed.id == match_id
+    assert claimed.job_type == "match"
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_preserves_not_before(db_session):
+    row_id = await enqueue(db_session, job_type="match", payload={})
+    await db_session.execute(
+        text(
+            "UPDATE work_queue SET not_before = now() + interval '5 minutes' "
+            "WHERE id = :id"
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match"],
+    )
+
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_reclaims_matching_stale_row(db_session):
+    row_id = await enqueue(db_session, job_type="match", payload={})
+    await db_session.execute(
+        text(
+            """
+            UPDATE work_queue
+            SET status='in_progress',
+                claimed_at = now() - interval '700 seconds',
+                claimed_by = 'dead-worker',
+                attempts = 1
+            WHERE id = :id
+            """
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match"],
+    )
+    await db_session.commit()
+
+    assert claimed is not None
+    assert claimed.id == row_id
+    assert claimed.claimed_by == "llm-worker"
+    assert claimed.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_ignores_other_stale_rows(db_session):
+    row_id = await enqueue(db_session, job_type="fetch-slug", payload={})
+    await db_session.execute(
+        text(
+            """
+            UPDATE work_queue
+            SET status='in_progress',
+                claimed_at = now() - interval '700 seconds',
+                claimed_by = 'dead-worker',
+                attempts = 1
+            WHERE id = :id
+            """
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match", "generate-cover-letter"],
+    )
+
+    assert claimed is None

--- a/tests/integration/test_queue_service.py
+++ b/tests/integration/test_queue_service.py
@@ -326,6 +326,22 @@ async def test_claim_one_job_type_filter_preserves_not_before(db_session):
 
 
 @pytest.mark.asyncio
+async def test_claim_one_job_type_filter_treats_whitespace_as_blank(db_session):
+    await enqueue(db_session, job_type="match", payload={})
+    await enqueue(db_session, job_type=" ", payload={})
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=[" ", ""],
+    )
+
+    assert claimed is None
+
+
+@pytest.mark.asyncio
 async def test_claim_one_job_type_filter_reclaims_matching_stale_row(db_session):
     row_id = await enqueue(db_session, job_type="match", payload={})
     await db_session.execute(

--- a/tests/integration/test_worker_lifecycle.py
+++ b/tests/integration/test_worker_lifecycle.py
@@ -232,6 +232,8 @@ async def test_worker_lanes_process_allowed_job_types(db_session, monkeypatch):
     from app.worker.handlers import HANDLERS
 
     calls: list[str] = []
+    started_lanes: list[str] = []
+    original_run_lane = worker_main._run_lane
 
     class Record:
         max_attempts = 3
@@ -249,6 +251,17 @@ async def test_worker_lanes_process_allowed_job_types(db_session, monkeypatch):
     monkeypatch.setitem(HANDLERS, "test-llm", Record("llm"))
     monkeypatch.setitem(HANDLERS, "test-slow", Record("slow"))
 
+    async def recording_run_lane(lane, *, settings, session_factory, shutdown_task):
+        started_lanes.append(lane.name)
+        await original_run_lane(
+            lane,
+            settings=settings,
+            session_factory=session_factory,
+            shutdown_task=shutdown_task,
+        )
+
+    monkeypatch.setattr(worker_main, "_run_lane", recording_run_lane)
+
     await enqueue(db_session, job_type="test-llm", payload={})
     await enqueue(db_session, job_type="test-slow", payload={})
     await db_session.commit()
@@ -260,6 +273,7 @@ async def test_worker_lanes_process_allowed_job_types(db_session, monkeypatch):
 
     await asyncio.gather(worker_main.run(), stop_soon())
 
+    assert sorted(started_lanes) == ["llm", "slow"]
     assert sorted(calls) == ["llm", "slow"]
 
 
@@ -295,10 +309,13 @@ async def test_slow_lane_drains_while_llm_lane_is_saturated(db_session, monkeypa
     await db_session.commit()
 
     async def stop_after_slow_done():
-        await started_llm.wait()
-        await asyncio.wait_for(slow_done.wait(), timeout=2)
-        release_llm.set()
-        worker_main._shutdown.set()
+        try:
+            await started_llm.wait()
+            await asyncio.wait_for(slow_done.wait(), timeout=2)
+            assert not release_llm.is_set()
+        finally:
+            release_llm.set()
+            worker_main._shutdown.set()
 
     await asyncio.gather(worker_main.run(), stop_after_slow_done())
 

--- a/tests/integration/test_worker_lifecycle.py
+++ b/tests/integration/test_worker_lifecycle.py
@@ -379,7 +379,7 @@ async def test_worker_run_cleans_up_sibling_lanes_when_one_lane_raises(monkeypat
     monkeypatch.setattr(worker_main, "_run_lane", fake_run_lane)
 
     with pytest.raises(RuntimeError, match="lane exploded"):
-        await worker_main.run()
+        await asyncio.wait_for(worker_main.run(), timeout=2)
 
     assert started_sibling.is_set()
     assert sibling_cancelled.is_set()
@@ -441,7 +441,7 @@ async def test_run_lane_cancels_inflight_after_drain_budget(monkeypatch):
     )
 
     try:
-        await handler_started.wait()
+        await asyncio.wait_for(handler_started.wait(), timeout=2)
         worker_main._shutdown.set()
         await lane_task
     finally:

--- a/tests/integration/test_worker_lifecycle.py
+++ b/tests/integration/test_worker_lifecycle.py
@@ -267,9 +267,10 @@ async def test_worker_lanes_process_allowed_job_types(db_session, monkeypatch):
     await db_session.commit()
 
     async def stop_soon():
-        while len(calls) < 2:
-            await asyncio.sleep(0.05)
-        worker_main._shutdown.set()
+        try:
+            await asyncio.wait_for(_wait_for_calls(calls, count=2), timeout=2)
+        finally:
+            worker_main._shutdown.set()
 
     await asyncio.gather(worker_main.run(), stop_soon())
 
@@ -337,3 +338,114 @@ async def test_slow_lane_drains_while_llm_lane_is_saturated(db_session, monkeypa
         ("test-llm-blocking", "done"),
         ("test-slow-fast", "done"),
     ]
+
+
+async def _wait_for_calls(calls: list[str], *, count: int) -> None:
+    while len(calls) < count:
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_worker_run_cleans_up_sibling_lanes_when_one_lane_raises(monkeypatch):
+    started_sibling = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+
+    async def fake_run_lane(lane, *, settings, session_factory, shutdown_task):
+        if lane.name == "llm":
+            await started_sibling.wait()
+            raise RuntimeError("lane exploded")
+
+        started_sibling.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+
+    class FakeSettings:
+        concurrency = 2
+        visibility_timeout_s = 30
+
+        def lane_configs(self):
+            from app.worker.config import WorkerLane
+
+            return [
+                WorkerLane(name="llm", job_types=("test-llm",), concurrency=1),
+                WorkerLane(name="slow", job_types=("test-slow",), concurrency=1),
+            ]
+
+    monkeypatch.setattr(worker_main, "WorkerSettings", FakeSettings)
+    monkeypatch.setattr(worker_main, "get_session_factory", lambda: object())
+    monkeypatch.setattr(worker_main, "_run_lane", fake_run_lane)
+
+    with pytest.raises(RuntimeError, match="lane exploded"):
+        await worker_main.run()
+
+    assert started_sibling.is_set()
+    assert sibling_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_lane_cancels_inflight_after_drain_budget(monkeypatch):
+    from app.worker.config import WorkerLane
+
+    handler_started = asyncio.Event()
+    handler_cancelled = asyncio.Event()
+    claim_count = 0
+
+    class FakeSettings:
+        visibility_timeout_s = 30
+        poll_interval_s = 60
+        drain_budget_s = 0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def commit(self):
+            return None
+
+    class FakeJob:
+        id = 1
+        job_type = "test-blocking"
+        attempts = 1
+
+    async def fake_claim_one(session, *, worker_id, visibility_timeout_s, job_types):
+        nonlocal claim_count
+        claim_count += 1
+        return FakeJob() if claim_count == 1 else None
+
+    async def fake_handle_one(job_row, session_factory, settings, *, lane):
+        handler_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            handler_cancelled.set()
+            raise
+
+    monkeypatch.setattr(worker_main, "claim_one", fake_claim_one)
+    monkeypatch.setattr(worker_main, "_handle_one", fake_handle_one)
+
+    worker_main._shutdown.clear()
+    shutdown_task = asyncio.create_task(worker_main._shutdown.wait())
+    lane_task = asyncio.create_task(
+        worker_main._run_lane(
+            WorkerLane(name="test", job_types=None, concurrency=1),
+            settings=FakeSettings(),
+            session_factory=FakeSession,
+            shutdown_task=shutdown_task,
+        )
+    )
+
+    try:
+        await handler_started.wait()
+        worker_main._shutdown.set()
+        await lane_task
+    finally:
+        worker_main._shutdown.clear()
+        await worker_main._cancel_pending([lane_task, shutdown_task])
+
+    assert handler_cancelled.is_set()

--- a/tests/integration/test_worker_lifecycle.py
+++ b/tests/integration/test_worker_lifecycle.py
@@ -225,3 +225,96 @@ async def test_mark_done_failure_releases_row_for_replay(db_session, monkeypatch
     assert row[1] is None
     assert row[2] is None
     assert row[3] is not None
+
+
+@pytest.mark.asyncio
+async def test_worker_lanes_process_allowed_job_types(db_session, monkeypatch):
+    from app.worker.handlers import HANDLERS
+
+    calls: list[str] = []
+
+    class Record:
+        max_attempts = 3
+
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def __call__(self, session, row):
+            calls.append(self.name)
+
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", "test-llm")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "1")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "test-slow")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "1")
+    monkeypatch.setitem(HANDLERS, "test-llm", Record("llm"))
+    monkeypatch.setitem(HANDLERS, "test-slow", Record("slow"))
+
+    await enqueue(db_session, job_type="test-llm", payload={})
+    await enqueue(db_session, job_type="test-slow", payload={})
+    await db_session.commit()
+
+    async def stop_soon():
+        while len(calls) < 2:
+            await asyncio.sleep(0.05)
+        worker_main._shutdown.set()
+
+    await asyncio.gather(worker_main.run(), stop_soon())
+
+    assert sorted(calls) == ["llm", "slow"]
+
+
+@pytest.mark.asyncio
+async def test_slow_lane_drains_while_llm_lane_is_saturated(db_session, monkeypatch):
+    started_llm = asyncio.Event()
+    release_llm = asyncio.Event()
+    slow_done = asyncio.Event()
+    from app.worker.handlers import HANDLERS
+
+    class SlowLlm:
+        max_attempts = 3
+
+        async def __call__(self, session, row):
+            started_llm.set()
+            await release_llm.wait()
+
+    class FastSlow:
+        max_attempts = 3
+
+        async def __call__(self, session, row):
+            slow_done.set()
+
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", "test-llm-blocking")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "1")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "test-slow-fast")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "1")
+    monkeypatch.setitem(HANDLERS, "test-llm-blocking", SlowLlm())
+    monkeypatch.setitem(HANDLERS, "test-slow-fast", FastSlow())
+
+    await enqueue(db_session, job_type="test-llm-blocking", payload={})
+    await enqueue(db_session, job_type="test-slow-fast", payload={})
+    await db_session.commit()
+
+    async def stop_after_slow_done():
+        await started_llm.wait()
+        await asyncio.wait_for(slow_done.wait(), timeout=2)
+        release_llm.set()
+        worker_main._shutdown.set()
+
+    await asyncio.gather(worker_main.run(), stop_after_slow_done())
+
+    statuses = (
+        await db_session.execute(
+            text(
+                """
+                SELECT job_type, status
+                FROM work_queue
+                WHERE job_type IN ('test-llm-blocking', 'test-slow-fast')
+                ORDER BY job_type
+                """
+            )
+        )
+    ).all()
+    assert statuses == [
+        ("test-llm-blocking", "done"),
+        ("test-slow-fast", "done"),
+    ]

--- a/tests/integration/test_worker_lifecycle.py
+++ b/tests/integration/test_worker_lifecycle.py
@@ -295,6 +295,8 @@ async def test_slow_lane_drains_while_llm_lane_is_saturated(db_session, monkeypa
         max_attempts = 3
 
         async def __call__(self, session, row):
+            await started_llm.wait()
+            assert not release_llm.is_set()
             slow_done.set()
 
     monkeypatch.setenv("WORKER_LLM_JOB_TYPES", "test-llm-blocking")

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -206,6 +206,20 @@ def test_us_location_policy_rejects_tbilisi_georgia_as_non_us_location():
     assert verdict.gap == "Position is not US-based"
 
 
+def test_us_location_policy_rejects_description_only_tbilisi_georgia():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Remote role based in Tbilisi, Georgia.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
 def test_us_location_policy_rejects_concrete_non_us_location_despite_us_text():
     job = SimpleNamespace(
         location="Paris, France",

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -248,6 +248,62 @@ def test_us_location_policy_rejects_remote_canada_us_applicants_not_eligible():
     assert verdict.gap == "Position is not US-based"
 
 
+def test_us_location_policy_rejects_non_us_role_literal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="This is a non-US role.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_non_us_candidates_literal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Non-US candidates only.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_non_us_applicants_literal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Remote role for non-US applicants.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_non_dotted_us_role_literal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="This is a non-U.S. role.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
 def test_us_location_policy_rejects_canadian_country_abbreviation():
     job = SimpleNamespace(
         location="Toronto, ON, CA",

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from app.services.remote_policy import evaluate_remote_policy
+from app.services.remote_policy import evaluate_remote_policy, evaluate_us_location_policy
 
 
 def _profile(target_locations: list[str]) -> SimpleNamespace:
@@ -147,5 +147,98 @@ def test_multi_word_target_location_matches_token_boundary_text():
     )
 
     verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_allows_explicit_us_signal():
+    job = SimpleNamespace(
+        location="Remote - United States",
+        workplace_type="remote",
+        description="Applicants must be authorized to work in the U.S.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_rejects_explicit_non_us_position():
+    job = SimpleNamespace(
+        location="Toronto, Canada",
+        workplace_type="remote",
+        description="Remote role open to candidates based in Canada.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_ambiguous_remote_position():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Work from anywhere with a distributed engineering team.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_allows_state_name_signal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Candidates may work remotely from California.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_allows_state_abbreviation_signal():
+    job = SimpleNamespace(
+        location="San Francisco, CA",
+        workplace_type="hybrid",
+        description=None,
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_allows_contextual_state_abbreviation_signal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Applicants must be based in CA.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_allows_city_state_signal():
+    job = SimpleNamespace(
+        location=None,
+        workplace_type="hybrid",
+        description="Hybrid role based in New York, NY.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
 
     assert verdict.hard_mismatch is False

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -178,6 +178,20 @@ def test_us_location_policy_rejects_explicit_non_us_position():
     assert verdict.gap == "Position is not US-based"
 
 
+def test_us_location_policy_rejects_canadian_country_abbreviation():
+    job = SimpleNamespace(
+        location="Toronto, ON, CA",
+        workplace_type="remote",
+        description="Remote role open to candidates based in Canada.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
 def test_us_location_policy_rejects_ambiguous_remote_position():
     job = SimpleNamespace(
         location="Remote",

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -178,6 +178,34 @@ def test_us_location_policy_rejects_explicit_non_us_position():
     assert verdict.gap == "Position is not US-based"
 
 
+def test_us_location_policy_rejects_remote_canada_unavailable_in_us():
+    job = SimpleNamespace(
+        location="Remote - Canada",
+        workplace_type="remote",
+        description="This position is not available in the United States.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_remote_canada_us_applicants_not_eligible():
+    job = SimpleNamespace(
+        location="Remote - Canada",
+        workplace_type="remote",
+        description="US applicants are not eligible.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
 def test_us_location_policy_rejects_canadian_country_abbreviation():
     job = SimpleNamespace(
         location="Toronto, ON, CA",

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -206,6 +206,20 @@ def test_us_location_policy_rejects_tbilisi_georgia_as_non_us_location():
     assert verdict.gap == "Position is not US-based"
 
 
+def test_us_location_policy_rejects_concrete_non_us_location_despite_us_text():
+    job = SimpleNamespace(
+        location="Paris, France",
+        workplace_type="remote",
+        description="This team supports US customers.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
 def test_us_location_policy_rejects_remote_canada_unavailable_in_us():
     job = SimpleNamespace(
         location="Remote - Canada",

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -178,6 +178,34 @@ def test_us_location_policy_rejects_explicit_non_us_position():
     assert verdict.gap == "Position is not US-based"
 
 
+def test_us_location_policy_rejects_non_us_location_despite_us_customer_text():
+    job = SimpleNamespace(
+        location="Toronto, Canada",
+        workplace_type="remote",
+        description="Remote support role helping support US customers.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_tbilisi_georgia_as_non_us_location():
+    job = SimpleNamespace(
+        location="Tbilisi, Georgia",
+        workplace_type="remote",
+        description="Remote role for a distributed support team.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
 def test_us_location_policy_rejects_remote_canada_unavailable_in_us():
     job = SimpleNamespace(
         location="Remote - Canada",

--- a/tests/unit/test_worker_config.py
+++ b/tests/unit/test_worker_config.py
@@ -24,9 +24,10 @@ def clear_worker_env(monkeypatch):
 
 
 def _clear_worker_env(monkeypatch):
-    for key in WORKER_ENV_VARS:
-        monkeypatch.delenv(key, raising=False)
-        monkeypatch.delenv(key.lower(), raising=False)
+    worker_env_names = {key.lower() for key in WORKER_ENV_VARS}
+    for key in list(os.environ):
+        if key.lower() in worker_env_names:
+            monkeypatch.delenv(key, raising=False)
 
 
 def test_worker_config_defaults():
@@ -103,3 +104,13 @@ def test_clear_worker_env_removes_lowercase_variants(monkeypatch):
 
     assert "worker_llm_job_types" not in os.environ
     assert "worker_concurrency" not in os.environ
+
+
+def test_clear_worker_env_removes_mixed_case_variants(monkeypatch):
+    monkeypatch.setenv("WoRkEr_LlM_JoB_TyPeS", "match")
+    monkeypatch.setenv("WoRkEr_CoNcUrReNcY", "99")
+
+    _clear_worker_env(monkeypatch)
+
+    assert "WoRkEr_LlM_JoB_TyPeS" not in os.environ
+    assert "WoRkEr_CoNcUrReNcY" not in os.environ

--- a/tests/unit/test_worker_config.py
+++ b/tests/unit/test_worker_config.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 WORKER_ENV_VARS = (
@@ -18,8 +20,13 @@ WORKER_ENV_VARS = (
 
 @pytest.fixture(autouse=True)
 def clear_worker_env(monkeypatch):
+    _clear_worker_env(monkeypatch)
+
+
+def _clear_worker_env(monkeypatch):
     for key in WORKER_ENV_VARS:
         monkeypatch.delenv(key, raising=False)
+        monkeypatch.delenv(key.lower(), raising=False)
 
 
 def test_worker_config_defaults():
@@ -86,3 +93,13 @@ def test_worker_settings_blank_lane_envs_fall_back_to_default(monkeypatch):
     assert settings.lane_configs() == [
         WorkerLane(name="default", job_types=None, concurrency=settings.concurrency)
     ]
+
+
+def test_clear_worker_env_removes_lowercase_variants(monkeypatch):
+    monkeypatch.setenv("worker_llm_job_types", "match")
+    monkeypatch.setenv("worker_concurrency", "99")
+
+    _clear_worker_env(monkeypatch)
+
+    assert "worker_llm_job_types" not in os.environ
+    assert "worker_concurrency" not in os.environ

--- a/tests/unit/test_worker_config.py
+++ b/tests/unit/test_worker_config.py
@@ -8,6 +8,10 @@ def test_worker_config_defaults(monkeypatch):
         "WORKER_TRANSIENT_BACKOFF_MAX_S",
         "WORKER_UNKNOWN_TYPE_BACKOFF_S",
         "WORKER_MARK_DONE_RETRY_BACKOFF_S",
+        "WORKER_LLM_JOB_TYPES",
+        "WORKER_LLM_CONCURRENCY",
+        "WORKER_SLOW_JOB_TYPES",
+        "WORKER_SLOW_CONCURRENCY",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -22,3 +26,58 @@ def test_worker_config_defaults(monkeypatch):
     assert settings.transient_backoff_max_s == 300
     assert settings.unknown_type_backoff_s == 300
     assert settings.mark_done_retry_backoff_s == 60
+    assert settings.llm_concurrency == 6
+    assert settings.slow_concurrency == 20
+
+
+def test_worker_settings_default_single_pool(monkeypatch):
+    monkeypatch.delenv("WORKER_LLM_JOB_TYPES", raising=False)
+    monkeypatch.delenv("WORKER_SLOW_JOB_TYPES", raising=False)
+
+    from app.worker.config import WorkerLane, WorkerSettings
+
+    settings = WorkerSettings()
+
+    assert settings.lanes_enabled is False
+    assert settings.lane_configs() == [
+        WorkerLane(name="default", job_types=None, concurrency=settings.concurrency)
+    ]
+
+
+def test_worker_settings_parses_lane_job_types(monkeypatch):
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", " match, generate-cover-letter,match ")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "6")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "fetch-slug, maintenance")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "20")
+
+    from app.worker.config import WorkerLane, WorkerSettings
+
+    settings = WorkerSettings()
+
+    assert settings.lanes_enabled is True
+    assert settings.lane_configs() == [
+        WorkerLane(
+            name="llm",
+            job_types=("match", "generate-cover-letter"),
+            concurrency=6,
+        ),
+        WorkerLane(
+            name="slow",
+            job_types=("fetch-slug", "maintenance"),
+            concurrency=20,
+        ),
+    ]
+
+
+def test_worker_settings_blank_lane_envs_fall_back_to_default(monkeypatch):
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", " , ")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "")
+
+    from app.worker.config import WorkerLane, WorkerSettings
+
+    settings = WorkerSettings()
+
+    assert settings.lanes_enabled is True
+    assert settings.lane_configs() == [
+        WorkerLane(name="default", job_types=None, concurrency=settings.concurrency)
+    ]

--- a/tests/unit/test_worker_config.py
+++ b/tests/unit/test_worker_config.py
@@ -1,20 +1,28 @@
-def test_worker_config_defaults(monkeypatch):
-    for key in (
-        "WORKER_CONCURRENCY",
-        "WORKER_POLL_INTERVAL_S",
-        "WORKER_VISIBILITY_TIMEOUT_S",
-        "WORKER_DRAIN_BUDGET_S",
-        "WORKER_TRANSIENT_BACKOFF_BASE_S",
-        "WORKER_TRANSIENT_BACKOFF_MAX_S",
-        "WORKER_UNKNOWN_TYPE_BACKOFF_S",
-        "WORKER_MARK_DONE_RETRY_BACKOFF_S",
-        "WORKER_LLM_JOB_TYPES",
-        "WORKER_LLM_CONCURRENCY",
-        "WORKER_SLOW_JOB_TYPES",
-        "WORKER_SLOW_CONCURRENCY",
-    ):
+import pytest
+
+WORKER_ENV_VARS = (
+    "WORKER_CONCURRENCY",
+    "WORKER_POLL_INTERVAL_S",
+    "WORKER_VISIBILITY_TIMEOUT_S",
+    "WORKER_DRAIN_BUDGET_S",
+    "WORKER_TRANSIENT_BACKOFF_BASE_S",
+    "WORKER_TRANSIENT_BACKOFF_MAX_S",
+    "WORKER_UNKNOWN_TYPE_BACKOFF_S",
+    "WORKER_MARK_DONE_RETRY_BACKOFF_S",
+    "WORKER_LLM_JOB_TYPES",
+    "WORKER_LLM_CONCURRENCY",
+    "WORKER_SLOW_JOB_TYPES",
+    "WORKER_SLOW_CONCURRENCY",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_worker_env(monkeypatch):
+    for key in WORKER_ENV_VARS:
         monkeypatch.delenv(key, raising=False)
 
+
+def test_worker_config_defaults():
     from app.worker.config import WorkerSettings
 
     settings = WorkerSettings()
@@ -30,10 +38,7 @@ def test_worker_config_defaults(monkeypatch):
     assert settings.slow_concurrency == 20
 
 
-def test_worker_settings_default_single_pool(monkeypatch):
-    monkeypatch.delenv("WORKER_LLM_JOB_TYPES", raising=False)
-    monkeypatch.delenv("WORKER_SLOW_JOB_TYPES", raising=False)
-
+def test_worker_settings_default_single_pool():
     from app.worker.config import WorkerLane, WorkerSettings
 
     settings = WorkerSettings()


### PR DESCRIPTION
Implements separate in-process worker lanes for LLM and slow jobs, plus deterministic pre-LLM match filtering for US-only positions and remote-office mismatches.

Verification:
- .venv/bin/python -m pytest tests/unit/test_remote_policy.py -q --ignore=.env.example: passed
- .venv/bin/ruff check app/ tests/: passed
- python3 -m py_compile on touched core/test files: passed
- git diff --check HEAD: passed

Known local blocker:
- tests/integration/test_handler_match.py cannot collect in this local venv because docker.credentials.constants is missing.