### PR TITLE
Split worker queues into LLM and slow lanes

### DIFF
--- a/app/worker/config.py
+++ b/app/worker/config.py
@@ -1,11 +1,24 @@
 """Worker-process configuration. Spec § Concurrency knobs."""
+from dataclasses import dataclass
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+@dataclass(frozen=True)
+class WorkerLane:
+    name: str
+    job_types: tuple[str, ...] | None
+    concurrency: int
 
 
 class WorkerSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="WORKER_")
 
     concurrency: int = 4
+    llm_job_types: str | None = None
+    llm_concurrency: int = 6
+    slow_job_types: str | None = None
+    slow_concurrency: int = 20
     poll_interval_s: int = 3
     visibility_timeout_s: int = 600
     drain_budget_s: int = 80
@@ -13,3 +26,54 @@ class WorkerSettings(BaseSettings):
     transient_backoff_max_s: int = 300
     unknown_type_backoff_s: int = 300
     mark_done_retry_backoff_s: int = 60
+
+    @property
+    def lanes_enabled(self) -> bool:
+        return self.llm_job_types is not None or self.slow_job_types is not None
+
+    def lane_configs(self) -> list[WorkerLane]:
+        lanes: list[WorkerLane] = []
+        if self.lanes_enabled:
+            llm_types = self._parse_job_types(self.llm_job_types)
+            slow_types = self._parse_job_types(self.slow_job_types)
+            if llm_types:
+                lanes.append(
+                    WorkerLane(
+                        name="llm",
+                        job_types=llm_types,
+                        concurrency=self.llm_concurrency,
+                    )
+                )
+            if slow_types:
+                lanes.append(
+                    WorkerLane(
+                        name="slow",
+                        job_types=slow_types,
+                        concurrency=self.slow_concurrency,
+                    )
+                )
+            if lanes:
+                return lanes
+
+        return [
+            WorkerLane(
+                name="default",
+                job_types=None,
+                concurrency=self.concurrency,
+            )
+        ]
+
+    @staticmethod
+    def _parse_job_types(value: str | None) -> tuple[str, ...]:
+        if value is None:
+            return ()
+
+        job_types = []
+        seen = set()
+        for item in value.split(","):
+            job_type = item.strip()
+            if not job_type or job_type in seen:
+                continue
+            job_types.append(job_type)
+            seen.add(job_type)
+        return tuple(job_types)

--- a/app/worker/main.py
+++ b/app/worker/main.py
@@ -11,7 +11,7 @@ import uuid
 import structlog
 
 from app.database import get_session_factory
-from app.worker.config import WorkerSettings
+from app.worker.config import WorkerLane, WorkerSettings
 from app.worker.handlers import (  # noqa: F401
     HANDLERS,
     TransientError,
@@ -78,7 +78,21 @@ async def _release_for_retry(session_factory, job_row, seconds: int) -> None:
         await session.commit()
 
 
-async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> None:
+async def _cancel_pending(tasks: set[asyncio.Task] | list[asyncio.Task]) -> None:
+    pending = [task for task in tasks if not task.done()]
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def _handle_one(
+    job_row,
+    session_factory,
+    settings: WorkerSettings,
+    *,
+    lane: str,
+) -> None:
     handler = HANDLERS.get(job_row.job_type)
     if handler is None:
         async with session_factory() as session:
@@ -91,6 +105,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
             await session.commit()
         await log.awarning(
             "worker.unknown_job_type",
+            lane=lane,
             job_id=job_row.id,
             job_type=job_row.job_type,
         )
@@ -107,6 +122,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         except Exception:
             await log.aexception(
                 "worker.terminal_failure_hook_retry",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
             )
@@ -121,6 +137,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         else:
             await log.aerror(
                 "worker.handler_max_attempts",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
                 attempts=job_row.attempts,
@@ -145,6 +162,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
             await session.commit()
         await log.awarning(
             "worker.transient_failure",
+            lane=lane,
             job_id=job_row.id,
             job_type=job_row.job_type,
             error=str(exc),
@@ -157,6 +175,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         except Exception:
             await log.aexception(
                 "worker.terminal_failure_hook_retry",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
             )
@@ -171,6 +190,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         else:
             await log.aexception(
                 "worker.job_failed",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
             )
@@ -185,6 +205,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
     except Exception:
         await log.aexception(
             "worker.mark_done_failed",
+            lane=lane,
             job_id=job_row.id,
             job_type=job_row.job_type,
         )
@@ -197,6 +218,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         except Exception:
             await log.aexception(
                 "worker.mark_done_release_failed",
+                lane=lane,
                 job_id=job_row.id,
                 job_type=job_row.job_type,
             )
@@ -204,6 +226,7 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
     else:
         await log.ainfo(
             "worker.job_done",
+            lane=lane,
             job_id=job_row.id,
             job_type=job_row.job_type,
             worker_id=_worker_id,
@@ -211,8 +234,92 @@ async def _handle_one(job_row, session_factory, settings: WorkerSettings) -> Non
         )
 
 
+async def _run_lane(
+    lane: WorkerLane,
+    *,
+    settings: WorkerSettings,
+    session_factory,
+    shutdown_task: asyncio.Task,
+) -> None:
+    inflight: set[asyncio.Task] = set()
+    cancelled = False
+
+    try:
+        while not _shutdown.is_set():
+            if len(inflight) >= lane.concurrency:
+                await asyncio.wait(
+                    inflight | {shutdown_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                continue
+
+            async with session_factory() as session:
+                job = await claim_one(
+                    session,
+                    worker_id=_worker_id,
+                    visibility_timeout_s=settings.visibility_timeout_s,
+                    job_types=lane.job_types,
+                )
+                await session.commit()
+
+            if job is None:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(shutdown_task),
+                        timeout=settings.poll_interval_s,
+                    )
+                except TimeoutError:
+                    pass
+                continue
+
+            await log.ainfo(
+                "worker.job_start",
+                lane=lane.name,
+                job_id=job.id,
+                job_type=job.job_type,
+                attempts=job.attempts,
+                worker_id=_worker_id,
+            )
+            task = asyncio.create_task(
+                _handle_one(job, session_factory, settings, lane=lane.name)
+            )
+            inflight.add(task)
+            task.add_done_callback(inflight.discard)
+    except asyncio.CancelledError:
+        cancelled = True
+        raise
+    finally:
+        await log.ainfo(
+            "worker.shutdown_drain_start",
+            lane=lane.name,
+            inflight=len(inflight),
+            drain_budget_s=settings.drain_budget_s,
+        )
+        if cancelled:
+            await _cancel_pending(inflight)
+        elif inflight:
+            _, pending = await asyncio.wait(
+                inflight,
+                timeout=settings.drain_budget_s,
+            )
+            if pending:
+                await log.awarning(
+                    "worker.shutdown_drain_timeout",
+                    lane=lane.name,
+                    pending=len(pending),
+                    drain_budget_s=settings.drain_budget_s,
+                )
+                await _cancel_pending(list(pending))
+        await log.ainfo(
+            "worker.shutdown_drain_done",
+            lane=lane.name,
+            inflight=sum(1 for task in inflight if not task.done()),
+        )
+
+
 async def run() -> None:
     settings = WorkerSettings()
+    lanes = settings.lane_configs()
     _shutdown.clear()
     try:
         loop = asyncio.get_running_loop()
@@ -221,7 +328,6 @@ async def run() -> None:
     except (NotImplementedError, RuntimeError, ValueError):
         pass
 
-    inflight: set[asyncio.Task] = set()
     shutdown_task = asyncio.create_task(_shutdown.wait(), name="shutdown-waiter")
     factory = get_session_factory()
 
@@ -229,51 +335,38 @@ async def run() -> None:
         "worker.started",
         worker_id=_worker_id,
         concurrency=settings.concurrency,
+        lanes=[
+            {
+                "name": lane.name,
+                "concurrency": lane.concurrency,
+                "job_types": lane.job_types,
+            }
+            for lane in lanes
+        ],
         visibility_timeout_s=settings.visibility_timeout_s,
     )
 
-    while not _shutdown.is_set():
-        if len(inflight) >= settings.concurrency:
-            await asyncio.wait(
-                inflight | {shutdown_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            continue
-
-        async with factory() as session:
-            job = await claim_one(
-                session,
-                worker_id=_worker_id,
-                visibility_timeout_s=settings.visibility_timeout_s,
-            )
-            await session.commit()
-
-        if job is None:
-            try:
-                await asyncio.wait_for(
-                    asyncio.shield(shutdown_task),
-                    timeout=settings.poll_interval_s,
-                )
-            except TimeoutError:
-                pass
-            continue
-
-        await log.ainfo(
-            "worker.job_start",
-            job_id=job.id,
-            job_type=job.job_type,
-            attempts=job.attempts,
-            worker_id=_worker_id,
+    lane_tasks = [
+        asyncio.create_task(
+            _run_lane(
+                lane,
+                settings=settings,
+                session_factory=factory,
+                shutdown_task=shutdown_task,
+            ),
+            name=f"worker-lane-{lane.name}",
         )
-        task = asyncio.create_task(_handle_one(job, factory, settings))
-        inflight.add(task)
-        task.add_done_callback(inflight.discard)
-
-    await log.ainfo(
-        "worker.shutdown_drain_start",
-        inflight=len(inflight),
-        drain_budget_s=settings.drain_budget_s,
-    )
-    if inflight:
-        await asyncio.wait(inflight, timeout=settings.drain_budget_s)
-    await log.ainfo("worker.shutdown_drain_done", inflight=len(inflight))
+        for lane in lanes
+    ]
+    try:
+        await asyncio.gather(*lane_tasks)
+    except asyncio.CancelledError:
+        _shutdown.set()
+        await _cancel_pending(lane_tasks)
+        raise
+    except Exception:
+        _shutdown.set()
+        await _cancel_pending(lane_tasks)
+        raise
+    finally:
+        await _cancel_pending([shutdown_task])

--- a/app/worker/queue_service.py
+++ b/app/worker/queue_service.py
@@ -90,15 +90,28 @@ async def claim_one(
     *,
     worker_id: str,
     visibility_timeout_s: int,
+    job_types: list[str] | tuple[str, ...] | None = None,
 ) -> WorkQueue | None:
     """Atomically claim the next pending or stale non-self in-progress row."""
+    params: dict[str, Any] = {"timeout": visibility_timeout_s, "worker_id": worker_id}
+    job_type_filter = ""
+    if job_types is not None:
+        allowed_job_types = [
+            normalized for job_type in job_types if (normalized := job_type.strip())
+        ]
+        if not allowed_job_types:
+            return None
+        params["job_types"] = allowed_job_types
+        job_type_filter = "AND job_type = ANY(CAST(:job_types AS text[]))"
+
     result = await session.execute(
         text(
-            """
+            f"""
             WITH claimed AS (
               SELECT id
               FROM work_queue
               WHERE (not_before IS NULL OR not_before <= now())
+                {job_type_filter}
                 AND (
                   status = 'pending'
                   OR (
@@ -134,7 +147,7 @@ async def claim_one(
                       work_queue.dedupe_key
             """
         ),
-        {"timeout": visibility_timeout_s, "worker_id": worker_id},
+        params,
     )
     row = result.first()
     if row is None:

--- a/tests/integration/test_queue_service.py
+++ b/tests/integration/test_queue_service.py
@@ -306,3 +306,124 @@ async def test_release_with_backoff_raises_stale_lease_for_wrong_worker(db_sessi
     ).scalar_one()
     assert row.status == WorkQueueStatus.IN_PROGRESS
     assert row.claimed_by == "w1"
+
+
+@pytest.mark.asyncio
+async def test_claim_one_filters_to_allowed_job_types(db_session):
+    fetch_id = await enqueue(db_session, job_type="fetch-slug", payload={"order": "old"})
+    match_id = await enqueue(db_session, job_type="match", payload={"order": "new"})
+    await db_session.execute(
+        text("UPDATE work_queue SET enqueued_at = now() - interval '1 hour' WHERE id = :id"),
+        {"id": fetch_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match", "generate-cover-letter"],
+    )
+    await db_session.commit()
+
+    assert claimed is not None
+    assert claimed.id == match_id
+    assert claimed.job_type == "match"
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_preserves_not_before(db_session):
+    row_id = await enqueue(db_session, job_type="match", payload={})
+    await db_session.execute(
+        text(
+            "UPDATE work_queue SET not_before = now() + interval '5 minutes' "
+            "WHERE id = :id"
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match"],
+    )
+
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_treats_whitespace_as_blank(db_session):
+    await enqueue(db_session, job_type="match", payload={})
+    await enqueue(db_session, job_type=" ", payload={})
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=[" ", ""],
+    )
+
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_reclaims_matching_stale_row(db_session):
+    row_id = await enqueue(db_session, job_type="match", payload={})
+    await db_session.execute(
+        text(
+            """
+            UPDATE work_queue
+            SET status='in_progress',
+                claimed_at = now() - interval '700 seconds',
+                claimed_by = 'dead-worker',
+                attempts = 1
+            WHERE id = :id
+            """
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match"],
+    )
+    await db_session.commit()
+
+    assert claimed is not None
+    assert claimed.id == row_id
+    assert claimed.claimed_by == "llm-worker"
+    assert claimed.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_claim_one_job_type_filter_ignores_other_stale_rows(db_session):
+    row_id = await enqueue(db_session, job_type="fetch-slug", payload={})
+    await db_session.execute(
+        text(
+            """
+            UPDATE work_queue
+            SET status='in_progress',
+                claimed_at = now() - interval '700 seconds',
+                claimed_by = 'dead-worker',
+                attempts = 1
+            WHERE id = :id
+            """
+        ),
+        {"id": row_id},
+    )
+    await db_session.commit()
+
+    claimed = await claim_one(
+        db_session,
+        worker_id="llm-worker",
+        visibility_timeout_s=600,
+        job_types=["match", "generate-cover-letter"],
+    )
+
+    assert claimed is None

--- a/tests/integration/test_worker_lifecycle.py
+++ b/tests/integration/test_worker_lifecycle.py
@@ -225,3 +225,227 @@ async def test_mark_done_failure_releases_row_for_replay(db_session, monkeypatch
     assert row[1] is None
     assert row[2] is None
     assert row[3] is not None
+
+
+@pytest.mark.asyncio
+async def test_worker_lanes_process_allowed_job_types(db_session, monkeypatch):
+    from app.worker.handlers import HANDLERS
+
+    calls: list[str] = []
+    started_lanes: list[str] = []
+    original_run_lane = worker_main._run_lane
+
+    class Record:
+        max_attempts = 3
+
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def __call__(self, session, row):
+            calls.append(self.name)
+
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", "test-llm")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "1")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "test-slow")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "1")
+    monkeypatch.setitem(HANDLERS, "test-llm", Record("llm"))
+    monkeypatch.setitem(HANDLERS, "test-slow", Record("slow"))
+
+    async def recording_run_lane(lane, *, settings, session_factory, shutdown_task):
+        started_lanes.append(lane.name)
+        await original_run_lane(
+            lane,
+            settings=settings,
+            session_factory=session_factory,
+            shutdown_task=shutdown_task,
+        )
+
+    monkeypatch.setattr(worker_main, "_run_lane", recording_run_lane)
+
+    await enqueue(db_session, job_type="test-llm", payload={})
+    await enqueue(db_session, job_type="test-slow", payload={})
+    await db_session.commit()
+
+    async def stop_soon():
+        try:
+            await asyncio.wait_for(_wait_for_calls(calls, count=2), timeout=2)
+        finally:
+            worker_main._shutdown.set()
+
+    await asyncio.gather(worker_main.run(), stop_soon())
+
+    assert sorted(started_lanes) == ["llm", "slow"]
+    assert sorted(calls) == ["llm", "slow"]
+
+
+@pytest.mark.asyncio
+async def test_slow_lane_drains_while_llm_lane_is_saturated(db_session, monkeypatch):
+    started_llm = asyncio.Event()
+    release_llm = asyncio.Event()
+    slow_done = asyncio.Event()
+    from app.worker.handlers import HANDLERS
+
+    class SlowLlm:
+        max_attempts = 3
+
+        async def __call__(self, session, row):
+            started_llm.set()
+            await release_llm.wait()
+
+    class FastSlow:
+        max_attempts = 3
+
+        async def __call__(self, session, row):
+            await started_llm.wait()
+            assert not release_llm.is_set()
+            slow_done.set()
+
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", "test-llm-blocking")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "1")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "test-slow-fast")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "1")
+    monkeypatch.setitem(HANDLERS, "test-llm-blocking", SlowLlm())
+    monkeypatch.setitem(HANDLERS, "test-slow-fast", FastSlow())
+
+    await enqueue(db_session, job_type="test-llm-blocking", payload={})
+    await enqueue(db_session, job_type="test-slow-fast", payload={})
+    await db_session.commit()
+
+    async def stop_after_slow_done():
+        try:
+            await started_llm.wait()
+            await asyncio.wait_for(slow_done.wait(), timeout=2)
+            assert not release_llm.is_set()
+        finally:
+            release_llm.set()
+            worker_main._shutdown.set()
+
+    await asyncio.gather(worker_main.run(), stop_after_slow_done())
+
+    statuses = (
+        await db_session.execute(
+            text(
+                """
+                SELECT job_type, status
+                FROM work_queue
+                WHERE job_type IN ('test-llm-blocking', 'test-slow-fast')
+                ORDER BY job_type
+                """
+            )
+        )
+    ).all()
+    assert statuses == [
+        ("test-llm-blocking", "done"),
+        ("test-slow-fast", "done"),
+    ]
+
+
+async def _wait_for_calls(calls: list[str], *, count: int) -> None:
+    while len(calls) < count:
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_worker_run_cleans_up_sibling_lanes_when_one_lane_raises(monkeypatch):
+    started_sibling = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+
+    async def fake_run_lane(lane, *, settings, session_factory, shutdown_task):
+        if lane.name == "llm":
+            await started_sibling.wait()
+            raise RuntimeError("lane exploded")
+
+        started_sibling.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+
+    class FakeSettings:
+        concurrency = 2
+        visibility_timeout_s = 30
+
+        def lane_configs(self):
+            from app.worker.config import WorkerLane
+
+            return [
+                WorkerLane(name="llm", job_types=("test-llm",), concurrency=1),
+                WorkerLane(name="slow", job_types=("test-slow",), concurrency=1),
+            ]
+
+    monkeypatch.setattr(worker_main, "WorkerSettings", FakeSettings)
+    monkeypatch.setattr(worker_main, "get_session_factory", lambda: object())
+    monkeypatch.setattr(worker_main, "_run_lane", fake_run_lane)
+
+    with pytest.raises(RuntimeError, match="lane exploded"):
+        await asyncio.wait_for(worker_main.run(), timeout=2)
+
+    assert started_sibling.is_set()
+    assert sibling_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_lane_cancels_inflight_after_drain_budget(monkeypatch):
+    from app.worker.config import WorkerLane
+
+    handler_started = asyncio.Event()
+    handler_cancelled = asyncio.Event()
+    claim_count = 0
+
+    class FakeSettings:
+        visibility_timeout_s = 30
+        poll_interval_s = 60
+        drain_budget_s = 0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def commit(self):
+            return None
+
+    class FakeJob:
+        id = 1
+        job_type = "test-blocking"
+        attempts = 1
+
+    async def fake_claim_one(session, *, worker_id, visibility_timeout_s, job_types):
+        nonlocal claim_count
+        claim_count += 1
+        return FakeJob() if claim_count == 1 else None
+
+    async def fake_handle_one(job_row, session_factory, settings, *, lane):
+        handler_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            handler_cancelled.set()
+            raise
+
+    monkeypatch.setattr(worker_main, "claim_one", fake_claim_one)
+    monkeypatch.setattr(worker_main, "_handle_one", fake_handle_one)
+
+    worker_main._shutdown.clear()
+    shutdown_task = asyncio.create_task(worker_main._shutdown.wait())
+    lane_task = asyncio.create_task(
+        worker_main._run_lane(
+            WorkerLane(name="test", job_types=None, concurrency=1),
+            settings=FakeSettings(),
+            session_factory=FakeSession,
+            shutdown_task=shutdown_task,
+        )
+    )
+
+    try:
+        await asyncio.wait_for(handler_started.wait(), timeout=2)
+        worker_main._shutdown.set()
+        await lane_task
+    finally:
+        worker_main._shutdown.clear()
+        await worker_main._cancel_pending([lane_task, shutdown_task])
+
+    assert handler_cancelled.is_set()

--- a/tests/unit/test_worker_config.py
+++ b/tests/unit/test_worker_config.py
@@ -1,16 +1,36 @@
-def test_worker_config_defaults(monkeypatch):
-    for key in (
-        "WORKER_CONCURRENCY",
-        "WORKER_POLL_INTERVAL_S",
-        "WORKER_VISIBILITY_TIMEOUT_S",
-        "WORKER_DRAIN_BUDGET_S",
-        "WORKER_TRANSIENT_BACKOFF_BASE_S",
-        "WORKER_TRANSIENT_BACKOFF_MAX_S",
-        "WORKER_UNKNOWN_TYPE_BACKOFF_S",
-        "WORKER_MARK_DONE_RETRY_BACKOFF_S",
-    ):
-        monkeypatch.delenv(key, raising=False)
+import os
 
+import pytest
+
+WORKER_ENV_VARS = (
+    "WORKER_CONCURRENCY",
+    "WORKER_POLL_INTERVAL_S",
+    "WORKER_VISIBILITY_TIMEOUT_S",
+    "WORKER_DRAIN_BUDGET_S",
+    "WORKER_TRANSIENT_BACKOFF_BASE_S",
+    "WORKER_TRANSIENT_BACKOFF_MAX_S",
+    "WORKER_UNKNOWN_TYPE_BACKOFF_S",
+    "WORKER_MARK_DONE_RETRY_BACKOFF_S",
+    "WORKER_LLM_JOB_TYPES",
+    "WORKER_LLM_CONCURRENCY",
+    "WORKER_SLOW_JOB_TYPES",
+    "WORKER_SLOW_CONCURRENCY",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_worker_env(monkeypatch):
+    _clear_worker_env(monkeypatch)
+
+
+def _clear_worker_env(monkeypatch):
+    worker_env_names = {key.lower() for key in WORKER_ENV_VARS}
+    for key in list(os.environ):
+        if key.lower() in worker_env_names:
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_worker_config_defaults():
     from app.worker.config import WorkerSettings
 
     settings = WorkerSettings()
@@ -22,3 +42,75 @@ def test_worker_config_defaults(monkeypatch):
     assert settings.transient_backoff_max_s == 300
     assert settings.unknown_type_backoff_s == 300
     assert settings.mark_done_retry_backoff_s == 60
+    assert settings.llm_concurrency == 6
+    assert settings.slow_concurrency == 20
+
+
+def test_worker_settings_default_single_pool():
+    from app.worker.config import WorkerLane, WorkerSettings
+
+    settings = WorkerSettings()
+
+    assert settings.lanes_enabled is False
+    assert settings.lane_configs() == [
+        WorkerLane(name="default", job_types=None, concurrency=settings.concurrency)
+    ]
+
+
+def test_worker_settings_parses_lane_job_types(monkeypatch):
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", " match, generate-cover-letter,match ")
+    monkeypatch.setenv("WORKER_LLM_CONCURRENCY", "6")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "fetch-slug, maintenance")
+    monkeypatch.setenv("WORKER_SLOW_CONCURRENCY", "20")
+
+    from app.worker.config import WorkerLane, WorkerSettings
+
+    settings = WorkerSettings()
+
+    assert settings.lanes_enabled is True
+    assert settings.lane_configs() == [
+        WorkerLane(
+            name="llm",
+            job_types=("match", "generate-cover-letter"),
+            concurrency=6,
+        ),
+        WorkerLane(
+            name="slow",
+            job_types=("fetch-slug", "maintenance"),
+            concurrency=20,
+        ),
+    ]
+
+
+def test_worker_settings_blank_lane_envs_fall_back_to_default(monkeypatch):
+    monkeypatch.setenv("WORKER_LLM_JOB_TYPES", " , ")
+    monkeypatch.setenv("WORKER_SLOW_JOB_TYPES", "")
+
+    from app.worker.config import WorkerLane, WorkerSettings
+
+    settings = WorkerSettings()
+
+    assert settings.lanes_enabled is True
+    assert settings.lane_configs() == [
+        WorkerLane(name="default", job_types=None, concurrency=settings.concurrency)
+    ]
+
+
+def test_clear_worker_env_removes_lowercase_variants(monkeypatch):
+    monkeypatch.setenv("worker_llm_job_types", "match")
+    monkeypatch.setenv("worker_concurrency", "99")
+
+    _clear_worker_env(monkeypatch)
+
+    assert "worker_llm_job_types" not in os.environ
+    assert "worker_concurrency" not in os.environ
+
+
+def test_clear_worker_env_removes_mixed_case_variants(monkeypatch):
+    monkeypatch.setenv("WoRkEr_LlM_JoB_TyPeS", "match")
+    monkeypatch.setenv("WoRkEr_CoNcUrReNcY", "99")
+
+    _clear_worker_env(monkeypatch)
+
+    assert "WoRkEr_LlM_JoB_TyPeS" not in os.environ
+    assert "WoRkEr_CoNcUrReNcY" not in os.environ


### PR DESCRIPTION
## Summary
- add explicit worker lane configuration for LLM jobs and slow non-LLM jobs
- route queue claims by allowed job types so match/cover-letter work is separate from fetch/maintenance work
- run one worker process with multiple in-process lane workers and set slow-lane concurrency to 20

## Verification
- .venv/bin/ruff check app/services/remote_policy.py tests/unit/test_remote_policy.py app/worker/queue_service.py tests/integration/test_queue_service.py
- python3 -m py_compile app/worker/config.py app/worker/main.py app/worker/queue_service.py tests/unit/test_worker_config.py tests/integration/test_worker_lifecycle.py tests/integration/test_queue_service.py