### PR TITLE
Add deterministic US-only match prefilter

### DIFF
--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -36,6 +36,204 @@ OFFICE_ATTENDANCE_PATTERNS = (
     r"\bmust(?:\s+be)?\s+located\s+near\b",
 )
 OFFICE_ATTENDANCE_GAP = "Requires recurring office attendance outside target locations"
+NON_US_POSITION_GAP = "Position is not US-based"
+
+US_STATE_NAMES = (
+    "alabama",
+    "alaska",
+    "arizona",
+    "arkansas",
+    "california",
+    "colorado",
+    "connecticut",
+    "delaware",
+    "florida",
+    "georgia",
+    "hawaii",
+    "idaho",
+    "illinois",
+    "indiana",
+    "iowa",
+    "kansas",
+    "kentucky",
+    "louisiana",
+    "maine",
+    "maryland",
+    "massachusetts",
+    "michigan",
+    "minnesota",
+    "mississippi",
+    "missouri",
+    "montana",
+    "nebraska",
+    "nevada",
+    "new hampshire",
+    "new jersey",
+    "new mexico",
+    "new york",
+    "north carolina",
+    "north dakota",
+    "ohio",
+    "oklahoma",
+    "oregon",
+    "pennsylvania",
+    "rhode island",
+    "south carolina",
+    "south dakota",
+    "tennessee",
+    "texas",
+    "utah",
+    "vermont",
+    "virginia",
+    "washington",
+    "west virginia",
+    "wisconsin",
+    "wyoming",
+)
+US_STATE_ABBREVIATIONS = (
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+    "DC",
+)
+US_STATE_ABBREVIATION_PATTERN = "|".join(US_STATE_ABBREVIATIONS)
+US_COUNTRY_PATTERNS = (
+    re.compile(r"(?<![A-Za-z0-9])united\s+states(?![A-Za-z0-9])", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z0-9])u\.s\.a?\.?(?![A-Za-z0-9])", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z0-9])usa(?![A-Za-z0-9])", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z0-9])US(?![A-Za-z0-9])"),
+)
+NON_US_LOCATION_TOKENS = (
+    "canada",
+    "united kingdom",
+    "uk",
+    "germany",
+    "tbilisi",
+    "india",
+    "europe",
+    "european union",
+)
+NON_US_LOCATION_TOKEN_PATTERN = "|".join(
+    re.escape(token) for token in sorted(NON_US_LOCATION_TOKENS, key=len, reverse=True)
+)
+CONTEXTUAL_NON_US_LOCATION_PATTERNS = (
+    re.compile(
+        rf"\b(?:based\s+in|located\s+in)\b.{{0,80}}"
+        rf"(?<![A-Za-z0-9])(?:{NON_US_LOCATION_TOKEN_PATTERN})(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b(?:remote|work(?:ing)?|hire|hiring|eligible|open)\b.{{0,40}}"
+        rf"\bfrom\b.{{0,40}}"
+        rf"(?<![A-Za-z0-9])(?:{NON_US_LOCATION_TOKEN_PATTERN})(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b(?:candidates?|applicants?|employees?|workers?)\s+from\b.{{0,40}}"
+        rf"(?<![A-Za-z0-9])(?:{NON_US_LOCATION_TOKEN_PATTERN})(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+)
+CITY_STATE_RE = re.compile(
+    rf"(?<!,\s)\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){{0,3}},\s*"
+    rf"(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
+)
+CONTEXTUAL_STATE_ABBREVIATION_RE = re.compile(
+    rf"\b(?:based\s+in|located\s+in|from|in|within|near)\s+"
+    rf"(?:{US_STATE_ABBREVIATION_PATTERN})(?![A-Za-z0-9])"
+)
+US_COUNTRY_OR_STATE_NAME_PATTERN = "|".join(
+    (
+        r"united\s+states",
+        r"u\.s\.a?\.?",
+        "usa",
+        *tuple(re.escape(state) for state in US_STATE_NAMES),
+    )
+)
+US_LOCATION_NAME_TOKEN_PATTERN = rf"(?:the\s+)?(?:{US_COUNTRY_OR_STATE_NAME_PATTERN})"
+US_LOCATION_ABBREVIATION_TOKEN_PATTERN = rf"(?:US|{US_STATE_ABBREVIATION_PATTERN})"
+EXCLUSIONARY_US_PREFIX_PATTERN = (
+    r"(?:not\s+(?:available|open|accepted|considered|allowed|permitted)"
+    r"|unavailable|excluding|excludes?|except(?:ing)?|outside(?:\s+of)?|not\s+based)"
+)
+EXCLUSIONARY_US_SUFFIX_PATTERN = (
+    r"(?:not\s+(?:eligible|accepted|considered|allowed|permitted|available)"
+    r"|ineligible|excluded|unavailable)"
+)
+EXCLUSIONARY_US_NAME_PATTERNS = (
+    re.compile(
+        rf"\b{EXCLUSIONARY_US_PREFIX_PATTERN}\b.{{0,80}}"
+        rf"(?<![A-Za-z0-9]){US_LOCATION_NAME_TOKEN_PATTERN}(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"(?<![A-Za-z0-9]){US_LOCATION_NAME_TOKEN_PATTERN}(?![A-Za-z0-9])"
+        rf".{{0,80}}\b(?:applicants?|candidates?|residents?|workers?)?\s*"
+        rf"(?:are|is)?\s*{EXCLUSIONARY_US_SUFFIX_PATTERN}\b",
+        re.IGNORECASE,
+    ),
+)
+EXCLUSIONARY_US_ABBREVIATION_PATTERNS = (
+    re.compile(r"(?<![A-Za-z0-9])non[-\s]+U\.?S\.?(?![A-Za-z0-9])", re.IGNORECASE),
+    re.compile(
+        rf"\b(?i:{EXCLUSIONARY_US_PREFIX_PATTERN})\b.{{0,80}}"
+        rf"(?<![A-Za-z0-9-]){US_LOCATION_ABBREVIATION_TOKEN_PATTERN}"
+        rf"(?![A-Za-z0-9])"
+    ),
+    re.compile(
+        rf"(?<![A-Za-z0-9-]){US_LOCATION_ABBREVIATION_TOKEN_PATTERN}"
+        rf"(?![A-Za-z0-9]).{{0,80}}"
+        rf"\b(?i:(?:applicants?|candidates?|residents?|workers?)?\s*"
+        rf"(?:are|is)?\s*{EXCLUSIONARY_US_SUFFIX_PATTERN})\b"
+    ),
+)
 REMOTE_ONLY_GAP = "remote-only profile but job is not explicitly remote"
 
 
@@ -53,14 +251,28 @@ def evaluate_remote_policy(profile: ProfileLike, job: JobLike) -> RemotePolicyVe
     return RemotePolicyVerdict(hard_mismatch=True, gap=OFFICE_ATTENDANCE_GAP)
 
 
+def evaluate_us_location_policy(job: JobLike) -> RemotePolicyVerdict:
+    if _has_overriding_non_us_location_signal(job):
+        return RemotePolicyVerdict(hard_mismatch=True, gap=NON_US_POSITION_GAP)
+
+    if _has_us_location_signal(job):
+        return RemotePolicyVerdict(hard_mismatch=False)
+
+    return RemotePolicyVerdict(hard_mismatch=True, gap=NON_US_POSITION_GAP)
+
+
 def _job_text(job: JobLike) -> str:
+    return _job_owned_text(job).lower()
+
+
+def _job_owned_text(job: JobLike) -> str:
     fields = (
         getattr(job, "location", None),
         getattr(job, "workplace_type", None),
         getattr(job, "description", None),
         getattr(job, "description_raw", None),
     )
-    return " ".join(str(field) for field in fields if field).lower()
+    return " ".join(str(field) for field in fields if field)
 
 
 def _job_description_text(job: JobLike) -> str:
@@ -86,6 +298,77 @@ def _matches_target_location(profile: ProfileLike, text: str) -> bool:
         _contains_token_phrase(normalized_text, str(location))
         for location in target_locations
         if location
+    )
+
+
+def _has_us_location_signal(job: JobLike) -> bool:
+    text = _job_owned_text(job)
+
+    if _has_exclusionary_us_location_signal(text):
+        return False
+
+    return _has_positive_us_location_signal(text)
+
+
+def _has_overriding_non_us_location_signal(job: JobLike) -> bool:
+    location = getattr(job, "location", None)
+    if not location:
+        return _has_contextual_non_us_description_location_signal(job)
+
+    location_text = str(location)
+    normalized_location = _normalize_text(location_text)
+    if any(
+        _contains_token_phrase(normalized_location, token)
+        for token in NON_US_LOCATION_TOKENS
+    ):
+        return True
+
+    if _has_positive_us_location_signal(location_text):
+        return False
+
+    return not _is_ambiguous_location_text(
+        normalized_location
+    ) or _has_contextual_non_us_description_location_signal(job)
+
+
+def _has_contextual_non_us_description_location_signal(job: JobLike) -> bool:
+    description_text = _job_description_text(job)
+    return any(
+        pattern.search(description_text) is not None
+        for pattern in CONTEXTUAL_NON_US_LOCATION_PATTERNS
+    )
+
+
+def _has_positive_us_location_signal(text: str) -> bool:
+    normalized_text = _normalize_text(text)
+    return (
+        any(pattern.search(text) is not None for pattern in US_COUNTRY_PATTERNS)
+        or any(_contains_token_phrase(normalized_text, state) for state in US_STATE_NAMES)
+        or CITY_STATE_RE.search(text) is not None
+        or CONTEXTUAL_STATE_ABBREVIATION_RE.search(text) is not None
+    )
+
+
+def _is_ambiguous_location_text(normalized_location: str) -> bool:
+    if not normalized_location:
+        return True
+    return normalized_location in {
+        "remote",
+        "remote anywhere",
+        "anywhere",
+        "worldwide",
+        "global",
+        "distributed",
+    }
+
+
+def _has_exclusionary_us_location_signal(text: str) -> bool:
+    return any(
+        pattern.search(text) is not None
+        for pattern in (
+            *EXCLUSIONARY_US_NAME_PATTERNS,
+            *EXCLUSIONARY_US_ABBREVIATION_PATTERNS,
+        )
     )
 
 

--- a/app/worker/handlers/match.py
+++ b/app/worker/handlers/match.py
@@ -5,11 +5,18 @@ from sqlmodel import select
 
 from app.config import get_settings
 from app.models.application import Application
+from app.models.job import Job
+from app.models.user_profile import UserProfile
 from app.models.work_queue import WorkQueue
+from app.services.remote_policy import evaluate_remote_policy, evaluate_us_location_policy
 from app.worker.handlers import HANDLERS, TransientError
 from app.worker.payloads import MatchPayload
 
 log = structlog.get_logger()
+
+
+def _deterministic_rejection_score(threshold: float) -> float:
+    return max(0.0, min(0.29, threshold - 0.01))
 
 
 class MatchHandler:
@@ -39,6 +46,65 @@ class MatchHandler:
             return
         if app.match_score is not None:
             await log.ainfo("worker.match.skip_replay", application_id=str(app.id))
+            return
+
+        job = await session.get(Job, app.job_id)
+        profile = await session.get(UserProfile, app.profile_id)
+        if job is None or profile is None:
+            await log.awarning(
+                "worker.match.domain_missing",
+                application_id=str(app.id),
+                job_id=str(app.job_id),
+                profile_id=str(app.profile_id),
+                job_found=job is not None,
+                profile_found=profile is not None,
+            )
+            return
+
+        verdict = evaluate_us_location_policy(job)
+        if verdict.hard_mismatch:
+            settings = get_settings()
+            gap = verdict.gap or "Deterministic match policy mismatch"
+            app.match_score = _deterministic_rejection_score(
+                settings.match_score_threshold
+            )
+            app.match_summary = "Deterministic mismatch: non-US position"
+            app.match_rationale = gap
+            app.match_strengths = []
+            app.match_gaps = [gap]
+            if app.status == "pending_review":
+                app.status = "auto_rejected"
+            session.add(app)
+            await log.ainfo(
+                "worker.match.deterministic_reject",
+                application_id=str(app.id),
+                policy="us_location",
+                score=app.match_score,
+            )
+            return
+
+        verdict = evaluate_remote_policy(profile, job)
+        if verdict.hard_mismatch:
+            settings = get_settings()
+            gap = verdict.gap or "Deterministic match policy mismatch"
+            app.match_score = _deterministic_rejection_score(
+                settings.match_score_threshold
+            )
+            app.match_summary = (
+                "Deterministic mismatch: recurring office attendance requirement"
+            )
+            app.match_rationale = gap
+            app.match_strengths = []
+            app.match_gaps = [gap]
+            if app.status == "pending_review":
+                app.status = "auto_rejected"
+            session.add(app)
+            await log.ainfo(
+                "worker.match.deterministic_reject",
+                application_id=str(app.id),
+                policy="remote_office",
+                score=app.match_score,
+            )
             return
 
         from app.agents import matching_agent

--- a/tests/integration/test_handler_match.py
+++ b/tests/integration/test_handler_match.py
@@ -15,7 +15,17 @@ from app.worker.handlers import HANDLERS
 from app.worker.handlers.match import MatchHandler
 
 
-async def _seed_application(db_session, *, match_score: float | None = None) -> Application:
+async def _seed_application(
+    db_session,
+    *,
+    match_score: float | None = None,
+    app_status: str = "pending_review",
+    profile_locations: list[str] | None = None,
+    job_location: str | None = "Remote - United States",
+    workplace_type: str | None = None,
+    description: str | None = None,
+    description_raw: str | None = None,
+) -> Application:
     user = User(id=uuid.uuid4(), email=f"match-handler-{uuid.uuid4()}@test.com")
     db_session.add(user)
     await db_session.commit()
@@ -33,6 +43,7 @@ async def _seed_application(db_session, *, match_score: float | None = None) -> 
     profile = UserProfile(
         user_id=user.id,
         target_company_ids=[company.id],
+        target_locations=profile_locations or ["San Francisco"],
         search_active=True,
     )
     db_session.add(profile)
@@ -45,6 +56,10 @@ async def _seed_application(db_session, *, match_score: float | None = None) -> 
         title="Backend Engineer",
         company_name="Airbnb",
         company_id=company.id,
+        location=job_location,
+        workplace_type=workplace_type,
+        description=description,
+        description_raw=description_raw,
         apply_url="https://example.com/job",
         is_active=True,
     )
@@ -55,6 +70,7 @@ async def _seed_application(db_session, *, match_score: float | None = None) -> 
     app = Application(
         job_id=job.id,
         profile_id=profile.id,
+        status=app_status,
         match_score=match_score,
         match_strengths=[],
         match_gaps=[],
@@ -104,6 +120,151 @@ async def test_match_handler_scores_one_application(db_session):
     assert mock_score.call_count == 1
     assert refreshed.match_score == 0.85
     assert refreshed.match_summary == "good fit"
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_visible_remote_policy_reject(db_session):
+    app = await _seed_application(
+        db_session,
+        description=(
+            "Remote role in the United States, but candidates must work "
+            "from the New York, NY office twice a week."
+        ),
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "auto_rejected"
+    assert refreshed.match_score is not None
+    assert refreshed.match_score < 0.3
+    assert refreshed.match_summary == (
+        "Deterministic mismatch: recurring office attendance requirement"
+    )
+    assert refreshed.match_rationale == (
+        "Requires recurring office attendance outside target locations"
+    )
+    assert refreshed.match_strengths == []
+    assert refreshed.match_gaps == [
+        "Requires recurring office attendance outside target locations"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_preserves_user_owned_status(db_session):
+    app = await _seed_application(
+        db_session,
+        app_status="dismissed",
+        description="Candidates must work from the New York, NY office twice a week.",
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "dismissed"
+    assert refreshed.match_score is not None
+    assert refreshed.match_gaps == [
+        "Requires recurring office attendance outside target locations"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_visible_non_us_reject(db_session):
+    app = await _seed_application(
+        db_session,
+        job_location="Toronto, Canada",
+        workplace_type="remote",
+        description="Remote role open to candidates based in Canada.",
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "auto_rejected"
+    assert refreshed.match_score is not None
+    assert refreshed.match_score < 0.3
+    assert refreshed.match_summary == "Deterministic mismatch: non-US position"
+    assert refreshed.match_rationale == "Position is not US-based"
+    assert refreshed.match_strengths == []
+    assert refreshed.match_gaps == ["Position is not US-based"]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_non_us_preserves_user_owned_status(db_session):
+    app = await _seed_application(
+        db_session,
+        app_status="applied",
+        job_location="Remote",
+        workplace_type="remote",
+        description="Work from anywhere with a distributed engineering team.",
+    )
+    app_id = app.id
+    handler = MatchHandler()
+
+    with patch("app.agents.matching_agent.score_one", AsyncMock()) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    db_session.expire_all()
+    refreshed = (
+        await db_session.execute(sa.select(Application).where(Application.id == app_id))
+    ).scalar_one()
+    assert mock_score.call_count == 0
+    assert refreshed.status == "applied"
+    assert refreshed.match_score is not None
+    assert refreshed.match_summary == "Deterministic mismatch: non-US position"
+    assert refreshed.match_gaps == ["Position is not US-based"]
+
+
+@pytest.mark.asyncio
+async def test_match_handler_prefilter_allows_target_location_match(db_session):
+    app = await _seed_application(
+        db_session,
+        profile_locations=["San Francisco"],
+        description="Candidates must work from the San Francisco, CA office twice a week.",
+    )
+    handler = MatchHandler()
+
+    with patch(
+        "app.agents.matching_agent.score_one",
+        AsyncMock(
+            return_value={
+                "score": 0.83,
+                "summary": "location-compatible hybrid fit",
+                "rationale": "Toronto target location matches",
+                "strengths": ["Python"],
+                "gaps": [],
+            }
+        ),
+    ) as mock_score:
+        await handler(db_session, _match_row(app.id))
+        await db_session.commit()
+
+    assert mock_score.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_match_handler.py
+++ b/tests/unit/test_match_handler.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.models.application import Application
+from app.models.job import Job
+from app.models.user_profile import UserProfile
 from app.models.work_queue import WorkQueue, WorkQueueStatus
 from app.worker.handlers import TransientError
 from app.worker.handlers.match import MatchHandler
@@ -37,6 +39,32 @@ def _session_for_app(app: Application) -> AsyncMock:
     execute_result = MagicMock()
     execute_result.scalar_one_or_none.return_value = app
     session.execute.return_value = execute_result
+    job = Job(
+        id=app.job_id,
+        source="test",
+        external_id=str(app.job_id),
+        title="Software Engineer",
+        company_name="Example",
+        location="Remote, United States",
+        workplace_type="remote",
+        description="Remote role open to US candidates.",
+        apply_url="https://example.test/apply",
+    )
+    profile = UserProfile(
+        id=app.profile_id,
+        user_id=uuid.uuid4(),
+        target_locations=["Remote"],
+        remote_ok=True,
+    )
+
+    async def get(model: type, id_: uuid.UUID):
+        if model is Job and id_ == app.job_id:
+            return job
+        if model is UserProfile and id_ == app.profile_id:
+            return profile
+        return None
+
+    session.get.side_effect = get
     session.add = MagicMock()
     return session
 

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from app.services.remote_policy import evaluate_remote_policy
+from app.services.remote_policy import evaluate_remote_policy, evaluate_us_location_policy
 
 
 def _profile(target_locations: list[str], remote_ok: bool = True) -> SimpleNamespace:
@@ -190,5 +190,252 @@ def test_multi_word_target_location_matches_token_boundary_text():
     )
 
     verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_allows_explicit_us_signal():
+    job = SimpleNamespace(
+        location="Remote - United States",
+        workplace_type="remote",
+        description="Applicants must be authorized to work in the U.S.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_rejects_explicit_non_us_position():
+    job = SimpleNamespace(
+        location="Toronto, Canada",
+        workplace_type="remote",
+        description="Remote role open to candidates based in Canada.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_non_us_location_despite_us_customer_text():
+    job = SimpleNamespace(
+        location="Toronto, Canada",
+        workplace_type="remote",
+        description="Remote support role helping support US customers.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_tbilisi_georgia_as_non_us_location():
+    job = SimpleNamespace(
+        location="Tbilisi, Georgia",
+        workplace_type="remote",
+        description="Remote role for a distributed support team.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_description_only_tbilisi_georgia():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Remote role based in Tbilisi, Georgia.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_concrete_non_us_location_despite_us_text():
+    job = SimpleNamespace(
+        location="Paris, France",
+        workplace_type="remote",
+        description="This team supports US customers.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_remote_canada_unavailable_in_us():
+    job = SimpleNamespace(
+        location="Remote - Canada",
+        workplace_type="remote",
+        description="This position is not available in the United States.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_remote_canada_us_applicants_not_eligible():
+    job = SimpleNamespace(
+        location="Remote - Canada",
+        workplace_type="remote",
+        description="US applicants are not eligible.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_non_us_role_literal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="This is a non-US role.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_non_us_candidates_literal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Non-US candidates only.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_non_us_applicants_literal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Remote role for non-US applicants.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_non_dotted_us_role_literal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="This is a non-U.S. role.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_canadian_country_abbreviation():
+    job = SimpleNamespace(
+        location="Toronto, ON, CA",
+        workplace_type="remote",
+        description="Remote role open to candidates based in Canada.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_rejects_ambiguous_remote_position():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Work from anywhere with a distributed engineering team.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is True
+    assert verdict.gap == "Position is not US-based"
+
+
+def test_us_location_policy_allows_state_name_signal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Candidates may work remotely from California.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_allows_state_abbreviation_signal():
+    job = SimpleNamespace(
+        location="San Francisco, CA",
+        workplace_type="hybrid",
+        description=None,
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_allows_contextual_state_abbreviation_signal():
+    job = SimpleNamespace(
+        location="Remote",
+        workplace_type="remote",
+        description="Applicants must be based in CA.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
+
+    assert verdict.hard_mismatch is False
+
+
+def test_us_location_policy_allows_city_state_signal():
+    job = SimpleNamespace(
+        location=None,
+        workplace_type="hybrid",
+        description="Hybrid role based in New York, NY.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_us_location_policy(job)
 
     assert verdict.hard_mismatch is False


### PR DESCRIPTION
## Summary
- add deterministic US-only policy evaluation before LLM matching
- reject non-US job descriptions before spending LLM match budget
- keep existing remote-only target-location guardrails intact
- update match-handler unit fixtures so deterministic prechecks receive explicit job/profile data

## Verification
- .venv/bin/ruff check tests/unit/test_match_handler.py app/worker/handlers/match.py app/services/remote_policy.py tests/unit/test_remote_policy.py
- python3 -m py_compile tests/unit/test_match_handler.py app/worker/handlers/match.py app/services/remote_policy.py tests/unit/test_remote_policy.py
- local pytest collection is blocked by stale local .venv dependency: pydantic_settings.sources.providers.secrets