### PR TITLE
fix(sync): rely on workers for matching

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -34,8 +34,8 @@ async def trigger_sync(
     session: AsyncSession = Depends(get_db),
     settings: Settings = Depends(get_settings),
 ):
-    """Manual user-initiated sync: enqueues stale slugs + scores cached jobs.
-    Returns 202 immediately. Background fetch + match catches up via cron."""
+    """Manual user-initiated sync: enqueues stale slugs.
+    Returns 202 immediately. Background fetch + match catches up via workers."""
     if settings.environment == "production":
         await check_daily_quota(profile.user_id, "manual_sync", MANUAL_SYNC_DAILY_LIMIT, session)
     result = await job_sync_service.sync_profile(profile, session)

--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -9,10 +9,8 @@ Two contracts here, by design (#80):
 
   sync_profile(profile, session)
     User-triggered HTTP path (POST /api/jobs/sync). Calls prune_and_enqueue
-    then synchronously scores up to `matching_jobs_per_batch` already-cached
-    jobs for instant UI feedback. Cron MUST NOT call this — Cloud Run's 300s
-    wall + N-profile fan-out blew up the synchronous scoring path (#70 /
-    commit 191df6a regression / fixed by #71).
+    only. Matching is handled by the always-on worker so the deterministic
+    pre-LLM filters are applied consistently.
 
 The actual fetch and matching happen in the always-on worker.
 """
@@ -24,11 +22,10 @@ from sqlalchemy import and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from app.config import get_settings
 from app.models.company import Company
 from app.models.slug_fetch import SlugFetch
 from app.models.user_profile import UserProfile
-from app.services import match_service, slug_registry_service
+from app.services import slug_registry_service
 from app.worker.payloads import FetchSlugPayload
 from app.worker.queue_service import enqueue
 
@@ -118,20 +115,11 @@ async def prune_and_enqueue(profile: UserProfile, session: AsyncSession) -> dict
 
 
 async def sync_profile(profile: UserProfile, session: AsyncSession) -> dict:
-    """User-triggered HTTP path: prune + enqueue, then synchronously LLM-score
-    up to N cached jobs for instant UI feedback. Cron MUST NOT call this — see
-    module docstring."""
-    settings = get_settings()
-    summary = await prune_and_enqueue(profile, session)
-    matched = await match_service.score_cached(
-        profile, session, cap=settings.matching_jobs_per_batch
-    )
-    if matched:
-        summary["matched_now"] = len(matched)
-        profile.last_sync_summary = summary
-        session.add(profile)
-        await session.commit()
+    """User-triggered HTTP path: prune + enqueue only.
 
+    The worker drains fetch and match work after the 202 response.
+    """
+    summary = await prune_and_enqueue(profile, session)
     await log.ainfo(
         "sync.queued",
         profile_id=str(profile.id),

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -332,7 +332,8 @@ async def score_cached(
     cap: int | None = None,
 ) -> list[Application]:
     """Variant of score_and_match that scores at most `cap` already-cached jobs.
-    No fetches, no slug-pool growth. Used by the instant-feedback path of POST /api/jobs/sync."""
+    No fetches, no slug-pool growth. Kept for explicit callers; POST /api/jobs/sync
+    relies on background workers instead."""
     from app.config import get_settings
 
     settings = get_settings()

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,8 +48,7 @@ infra repo procedures.
 The public API avoids long-running LLM/fetch work:
 
 - `POST /api/jobs/sync` returns `202`, prunes invalid followed companies,
-  enqueues stale provider slugs, and synchronously scores only cached jobs for
-  quick UI feedback.
+  and enqueues stale provider slugs. Fetching and matching run in workers.
 - `POST /api/applications/{id}/cover-letter` returns `202`, flips the
   application to `pending`, and enqueues `generate-cover-letter`.
 - Clients poll `GET /api/applications/{id}/cover-letter/status` while the

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlmodel import select
@@ -70,8 +71,7 @@ async def test_mark_stale_jobs(db_session):
 
 @pytest.mark.asyncio
 async def test_sync_profile_returns_202_shape_and_enqueues_stale_slugs(db_session):
-    """The new contract: sync_profile is enqueue-only + score-cached, returns
-    {status:'queued', queued_slugs:[...], matched_now:int}, never blocks on fetch."""
+    """sync_profile enqueues work and never performs synchronous scoring."""
     from app.models.company import Company
     from app.models.user import User
     from app.services.profile_service import get_or_create_profile
@@ -98,11 +98,16 @@ async def test_sync_profile_returns_202_shape_and_enqueues_stale_slugs(db_sessio
     await db_session.commit()
     await db_session.refresh(profile)
 
-    result = await job_sync_service.sync_profile(profile, db_session)
+    with patch(
+        "app.services.match_service.score_cached",
+        AsyncMock(return_value=[]),
+    ) as mock_score_cached:
+        result = await job_sync_service.sync_profile(profile, db_session)
 
     assert result["status"] == "queued"
     assert sorted(result["queued_slugs"]) == ["airbnb", "stripe"]
-    assert result["matched_now"] == 0  # no cached jobs yet
+    assert result["matched_now"] == 0
+    mock_score_cached.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stop POST /api/jobs/sync from synchronously scoring cached jobs
- keep sync responses enqueue-only with matched_now=0 while workers handle fetch/match processing
- update docs and add a regression assertion that sync_profile does not call score_cached

## Verification
- uv run pytest tests/integration/test_job_sync.py tests/integration/test_jobs_endpoint.py tests/integration/test_sync_status_endpoint.py tests/integration/test_handler_match.py::test_match_handler_prefilter_visible_remote_policy_reject tests/integration/test_handler_match.py::test_match_handler_prefilter_visible_non_us_reject -q
- uv run ruff check app/services/job_sync_service.py app/services/match_service.py app/api/jobs.py tests/integration/test_job_sync.py