### PR TITLE
Refactor sync to background-only matching

### DIFF
--- a/app/api/internal_cron.py
+++ b/app/api/internal_cron.py
@@ -6,13 +6,10 @@ from datetime import UTC, datetime
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from sqlalchemy import text
-from sqlmodel import select
 
 from app.agents.llm_safe import BudgetExhausted
 from app.config import Settings, get_settings
 from app.database import get_session_factory
-from app.models.user_profile import UserProfile
-from app.worker.payloads import FetchSlugPayload
 from app.worker.queue_service import enqueue
 
 log = structlog.get_logger()
@@ -83,61 +80,19 @@ async def _run_cron(name: str, task: Callable[[], Awaitable[dict]]) -> dict:
     status_code=status.HTTP_202_ACCEPTED,
 )
 async def cron_sync():
-    from app.services import slug_registry_service
+    from app.services import job_sync_service
 
     factory = get_session_factory()
-    enqueued: list[int] = []
-    pruned_total = 0
-    active_count = 0
     async with factory() as session:
-        active_profiles = (
-            (
-                await session.execute(
-                    select(UserProfile).where(UserProfile.search_active.is_(True))
-                )
-            )
-            .scalars()
-            .all()
-        )
-        active_count = len(active_profiles)
-        for profile in active_profiles:
-            pruned_total += await slug_registry_service.prune_invalid_for_profile(
-                profile,
-                session,
-            )
-            stale = await slug_registry_service.list_stale_for_profile(
-                profile,
-                session,
-                ttl_hours=6,
-            )
-            for provider, slug in stale:
-                row_id = await enqueue(
-                    session,
-                    job_type="fetch-slug",
-                    payload=FetchSlugPayload(provider=provider, slug=slug).model_dump(),
-                    dedupe_key=f"fetch-slug:{provider}:{slug}",
-                )
-                if row_id is not None:
-                    enqueued.append(row_id)
-            profile.last_sync_requested_at = datetime.now(UTC)
-            profile.last_sync_summary = {
-                "queued_slugs": [slug for _, slug in stale],
-                "matched_now": 0,
-                "pruned_slugs": pruned_total,
-            }
-            session.add(profile)
-        await session.commit()
+        summary = await job_sync_service.sync_active_profiles(session)
     await log.ainfo(
         "cron.sync.completed",
-        enqueued=len(enqueued),
-        pruned=pruned_total,
-        active_profiles=active_count,
+        enqueued=len(summary["enqueued"]),
+        pruned=summary["pruned"],
+        active_profiles=summary["active_profiles"],
+        profiles_enqueued=summary["profiles_enqueued"],
     )
-    return {
-        "enqueued": enqueued,
-        "pruned": pruned_total,
-        "active_profiles": active_count,
-    }
+    return summary
 
 
 @router.post(

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -11,27 +11,15 @@ log = structlog.get_logger()
 async def run_job_sync() -> dict:
     """Bulk sweep: prune invalid slugs + enqueue stale slugs for active profiles."""
     from app.database import get_session_factory
-    from app.models.user_profile import UserProfile
-    from app.services.job_sync_service import prune_and_enqueue
+    from app.services.job_sync_service import sync_active_profiles
 
     factory = get_session_factory()
-    profiles_enqueued = 0
-    slugs_enqueued = 0
-    slugs_pruned = 0
     async with factory() as session:
-        result = await session.execute(
-            select(UserProfile).where(UserProfile.search_active.is_(True))
-        )
-        for profile in result.scalars().all():
-            summary = await prune_and_enqueue(profile, session)
-            if summary["queued_slugs"]:
-                profiles_enqueued += 1
-                slugs_enqueued += len(summary["queued_slugs"])
-            slugs_pruned += len(summary["pruned_slugs"])
+        summary = await sync_active_profiles(session)
     return {
-        "profiles_enqueued": profiles_enqueued,
-        "slugs_enqueued": slugs_enqueued,
-        "slugs_pruned": slugs_pruned,
+        "profiles_enqueued": summary["profiles_enqueued"],
+        "slugs_enqueued": len(summary["enqueued"]),
+        "slugs_pruned": summary["pruned"],
     }
 
 

--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -20,7 +20,7 @@ from datetime import UTC, datetime
 import structlog
 from sqlalchemy import and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import col, select
 
 from app.models.company import Company
 from app.models.slug_fetch import SlugFetch
@@ -112,6 +112,37 @@ async def prune_and_enqueue(profile: UserProfile, session: AsyncSession) -> dict
     session.add(profile)
     await session.commit()
     return summary
+
+
+async def sync_active_profiles(session: AsyncSession) -> dict:
+    """Cron/scheduler sweep: apply the enqueue-only sync contract to active profiles."""
+    active_profiles = (
+        (
+            await session.execute(
+                select(UserProfile).where(col(UserProfile.search_active).is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    enqueued: list[str] = []
+    pruned = 0
+    profiles_enqueued = 0
+    for profile in active_profiles:
+        summary = await prune_and_enqueue(profile, session)
+        queued_slugs = list(summary["queued_slugs"])
+        if queued_slugs:
+            profiles_enqueued += 1
+            enqueued.extend(queued_slugs)
+        pruned += len(summary["pruned_slugs"])
+
+    return {
+        "enqueued": enqueued,
+        "pruned": pruned,
+        "active_profiles": len(active_profiles),
+        "profiles_enqueued": profiles_enqueued,
+    }
 
 
 async def sync_profile(profile: UserProfile, session: AsyncSession) -> dict:

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import structlog
-from sqlalchemy import text, update
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -323,62 +323,6 @@ async def score_and_match(
         duration_ms=int((time.perf_counter() - t0) * 1000),
     )
     return scored_apps
-
-
-async def score_cached(
-    profile: UserProfile,
-    session: AsyncSession,
-    *,
-    cap: int | None = None,
-) -> list[Application]:
-    """Variant of score_and_match that scores at most `cap` already-cached jobs.
-    No fetches, no slug-pool growth. Kept for explicit callers; POST /api/jobs/sync
-    relies on background workers instead."""
-    from app.config import get_settings
-
-    settings = get_settings()
-    cap = cap if cap is not None else settings.matching_jobs_per_batch
-
-    company_ids = list(profile.target_company_ids or [])
-    if not company_ids:
-        return []
-
-    excluded_result = await session.execute(
-        text("""
-            SELECT a.job_id
-            FROM applications a
-            WHERE a.profile_id = :profile_id
-              AND (
-                a.match_score IS NOT NULL
-                OR EXISTS (
-                  SELECT 1
-                  FROM work_queue w
-                  WHERE w.job_type = 'match'
-                    AND w.status IN ('pending', 'in_progress')
-                    AND w.payload->>'application_id' = a.id::text
-                )
-              )
-        """),
-        {"profile_id": profile.id},
-    )
-    excluded_ids = {row[0] for row in excluded_result.all()}
-
-    q = (
-        select(Job)
-        .where(
-            Job.is_active.is_(True),
-            Job.company_id.in_(company_ids),
-        )
-        .order_by(Job.posted_at.desc().nullslast(), Job.fetched_at.desc())
-    )
-    if excluded_ids:
-        q = q.where(Job.id.notin_(excluded_ids))
-    q = q.limit(cap)
-    jobs_result = await session.execute(q)
-    jobs = list(jobs_result.scalars().all())
-    if not jobs:
-        return []
-    return await score_and_match(profile, session, jobs=jobs)
 
 
 async def list_applications(

--- a/docs/superpowers/specs/2026-05-17-background-only-matching-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-17-background-only-matching-cleanup-design.md
@@ -1,0 +1,76 @@
+# Background-Only Matching Cleanup Design
+
+## Problem
+
+Manual sync previously had a synchronous "instant feedback" path that could score cached jobs before the worker saw them. Cron sync also carried its own duplicate stale-slug enqueue loop instead of using the same service as manual sync. Together, that created two matching entrypoints and two sync implementations:
+
+- Worker path: claims `work_queue` match rows and applies deterministic pre-LLM filters before calling the LLM.
+- Synchronous path: `sync_profile()` could call `score_cached()`, which used the batch LangGraph path and only applied location policy after LLM scoring.
+- Cron path: `/internal/cron/sync` duplicated stale-slug enqueue and profile summary logic instead of delegating to `job_sync_service`.
+
+The worker path is now the safe operational path. Leaving the old synchronous scoring API in place makes it easy for future code to bypass the pre-LLM filters and spend LLM quota on jobs that should be deterministic rejects.
+
+## Goals
+
+- Make manual sync enqueue-only.
+- Make cron sync use the same enqueue-only service contract as manual sync.
+- Remove the obsolete cached synchronous scoring helper.
+- Keep the public response shape stable for the frontend: `status`, `queued_slugs`, `matched_now`, `pruned_slugs`.
+- Keep the internal cron response structured: `enqueued`, `pruned`, `active_profiles`.
+- Preserve user-owned application states: `dismissed` and `applied` remain protected by the worker handler.
+- Keep the single-job worker scoring path as the production scoring entrypoint.
+
+## Non-Goals
+
+- Do not change queue claiming, worker lanes, or retry policy.
+- Do not change the deterministic policy rules themselves.
+- Do not remove defensive post-score policy capping from `score_one()` in this cleanup; it remains useful if a test or maintenance script calls `score_one()` directly.
+- Do not change frontend polling semantics.
+- Do not change generation reconcile or maintenance cron behavior beyond import cleanup.
+
+## Design
+
+`app/services/job_sync_service.py` becomes the single sync orchestration module. `sync_profile()` delegates only to `prune_and_enqueue()` and returns the same summary shape with `matched_now=0`. A new active-profile sweep helper in the same module owns the cron loop: select active profiles, call `prune_and_enqueue()` for each one, aggregate queued slug and pruned counts, and return the structured cron summary.
+
+`app/api/internal_cron.py` should not import `slug_registry_service`, `FetchSlugPayload`, or `enqueue` for sync. Its `/sync` endpoint gets a session, delegates to the active-profile sync helper, logs the aggregated summary, and returns it. `app/scheduler/tasks.py` should use the same helper so scheduled/background cron execution and HTTP cron execution cannot drift.
+
+`app/services/match_service.py` keeps profile formatting, application listing, and rematch enqueueing. The obsolete `score_cached()` helper is removed because no production caller should synchronously score cached jobs. The older batch `score_and_match()` path remains for now because integration tests and historical utilities still exercise it, but it should not be wired back into HTTP sync.
+
+The worker handler in `app/worker/handlers/match.py` remains the single production scoring entrypoint. It loads the `Application`, `Job`, and `UserProfile`; applies `evaluate_us_location_policy()` and `evaluate_remote_policy()` before importing/calling `matching_agent.score_one()`; and persists deterministic auto-rejects without spending LLM quota.
+
+## Data Flow
+
+1. User calls `POST /api/jobs/sync`.
+2. API calls `job_sync_service.sync_profile()`.
+3. Sync prunes invalid slugs, enqueues stale `fetch-slug` work, updates `last_sync_*`, and returns `202`.
+4. Worker drains `fetch-slug`, creates `Application` rows, and enqueues `match` work.
+5. Worker drains `match` rows through pre-LLM deterministic filters, then calls the LLM only for jobs that pass those filters.
+
+Cron flow:
+
+1. Supercronic calls `POST /internal/cron/sync`.
+2. Cron endpoint verifies `X-Cron-Secret`.
+3. Cron endpoint calls the shared active-profile sync helper.
+4. The shared helper applies the same prune/enqueue behavior as manual sync for every active profile.
+5. Worker drains all queued fetch and match rows.
+
+## Error Handling
+
+- Sync failures remain request-scoped database/API failures.
+- Cron sync failures remain cron-scoped database/API failures and keep the existing structured error logging in `_run_cron` if that wrapper is used by future endpoints.
+- Match failures remain worker-scoped transient or terminal failures.
+- If deterministic filters reject a job, the worker writes a below-threshold score, summary, rationale, and gaps, then marks `pending_review` rows `auto_rejected`.
+- Existing `dismissed` and `applied` statuses are not overwritten by deterministic rejects.
+
+## Tests
+
+- Update `test_sync_profile_returns_202_shape_and_enqueues_stale_slugs` to assert `sync_profile()` does not import or call the matching service.
+- Add cron coverage proving `/internal/cron/sync` delegates to the shared active-profile sync helper.
+- Add service coverage for the active-profile helper's aggregation contract.
+- Remove tests that directly exercise `score_cached()`.
+- Keep worker prefilter tests that assert `matching_agent.score_one()` is not called for deterministic rejects.
+- Run targeted job sync, cron, handler, and remote policy tests.
+
+## Rollout
+
+This is code-only and backward compatible at the API response level. After deploy, failed match queue rows can be safely requeued because the worker path now owns matching and applies pre-LLM filters consistently.

--- a/tests/integration/test_cron_sync_enqueues.py
+++ b/tests/integration/test_cron_sync_enqueues.py
@@ -59,8 +59,9 @@ async def test_cron_sync_enqueues_fetch_slug_work_rows(db_session):
     assert response.status_code == 202
     body = response.json()
     assert body["active_profiles"] == 1
+    assert body["profiles_enqueued"] == 1
     assert body["pruned"] == 0
-    assert len(body["enqueued"]) == 1
+    assert body["enqueued"] == ["co"]
 
     rows = (
         (

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -2,7 +2,6 @@
 
 import uuid
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlmodel import select
@@ -98,16 +97,90 @@ async def test_sync_profile_returns_202_shape_and_enqueues_stale_slugs(db_sessio
     await db_session.commit()
     await db_session.refresh(profile)
 
-    with patch(
-        "app.services.match_service.score_cached",
-        AsyncMock(return_value=[]),
-    ) as mock_score_cached:
-        result = await job_sync_service.sync_profile(profile, db_session)
+    result = await job_sync_service.sync_profile(profile, db_session)
 
     assert result["status"] == "queued"
     assert sorted(result["queued_slugs"]) == ["airbnb", "stripe"]
     assert result["matched_now"] == 0
-    mock_score_cached.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_active_profiles_uses_shared_enqueue_contract(db_session):
+    """Cron and scheduler sweeps use the same enqueue-only behavior as manual sync."""
+    from app.models.company import Company
+    from app.models.slug_fetch import SlugFetch
+    from app.models.user import User
+    from app.models.user_profile import UserProfile
+    from app.models.work_queue import WorkQueue
+
+    active_company = Company(
+        canonical_name="Active Co",
+        normalized_key=f"active-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "active-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    inactive_company = Company(
+        canonical_name="Inactive Co",
+        normalized_key=f"inactive-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "inactive-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.add_all([active_company, inactive_company])
+    await db_session.commit()
+    await db_session.refresh(active_company)
+    await db_session.refresh(inactive_company)
+
+    active_user = User(id=uuid.uuid4(), email=f"active-{uuid.uuid4()}@test.com")
+    inactive_user = User(id=uuid.uuid4(), email=f"inactive-{uuid.uuid4()}@test.com")
+    db_session.add_all([active_user, inactive_user])
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            UserProfile(
+                user_id=active_user.id,
+                email=active_user.email,
+                search_active=True,
+                target_company_ids=[active_company.id],
+            ),
+            UserProfile(
+                user_id=inactive_user.id,
+                email=inactive_user.email,
+                search_active=False,
+                target_company_ids=[inactive_company.id],
+            ),
+            SlugFetch(
+                source="greenhouse",
+                slug="active-co",
+                last_fetched_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+            SlugFetch(
+                source="greenhouse",
+                slug="inactive-co",
+                last_fetched_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    result = await job_sync_service.sync_active_profiles(db_session)
+
+    assert result == {
+        "enqueued": ["active-co"],
+        "pruned": 0,
+        "active_profiles": 1,
+        "profiles_enqueued": 1,
+    }
+    queue_rows = (
+        (
+            await db_session.execute(
+                select(WorkQueue).where(WorkQueue.job_type == "fetch-slug")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [row.dedupe_key for row in queue_rows] == ["fetch-slug:greenhouse:active-co"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_jobs_endpoint.py
+++ b/tests/integration/test_jobs_endpoint.py
@@ -1,7 +1,7 @@
 """Integration tests for POST /api/jobs/sync.
 
 The new contract returns 202 Accepted with {status: 'queued', queued_slugs, matched_now}
-instead of 200 with synchronous results. Background fetch + match catches up via cron.
+instead of 200 with synchronous results. Background fetch + match catches up via workers.
 """
 
 import pytest

--- a/tests/integration/test_match_scoring.py
+++ b/tests/integration/test_match_scoring.py
@@ -16,7 +16,6 @@ from app.models.company import Company
 from app.models.job import Job
 from app.models.user import User
 from app.models.user_profile import UserProfile
-from app.models.work_queue import WorkQueue, WorkQueueStatus
 from app.services import match_service
 from app.services.match_service import list_applications, score_and_match
 from tests.conftest import patch_llm
@@ -374,39 +373,6 @@ async def test_score_and_match_filters_by_profile_slugs(db_session):
 
 
 @pytest.mark.asyncio
-async def test_score_cached_only_uses_existing_jobs(db_session):
-    """score_cached must NOT enqueue any fetches and must respect the company filter
-    and matching_jobs_per_batch cap."""
-    airbnb_co = await _ensure_company(db_session, "airbnb")
-    user = User(id=uuid.uuid4(), email=f"cached-{uuid.uuid4()}@test.com")
-    db_session.add(user)
-    await db_session.commit()
-    profile = UserProfile(
-        user_id=user.id,
-        target_company_ids=[airbnb_co.id],
-    )
-    db_session.add(profile)
-    db_session.add(
-        Job(
-            source="greenhouse",
-            external_id="a-2",
-            title="Z",
-            company_name="Airbnb",
-            company_id=airbnb_co.id,
-            apply_url="https://z",
-            is_active=True,
-        )
-    )
-    await db_session.commit()
-
-    fake_graph = MagicMock()
-    fake_graph.ainvoke = AsyncMock(return_value={"scores": []})
-    with patch("app.agents.matching_agent.build_graph", return_value=fake_graph):
-        result = await match_service.score_cached(profile, db_session, cap=20)
-    assert isinstance(result, list)
-
-
-@pytest.mark.asyncio
 async def test_score_and_match_persists_match_score(db_session):
     """After score_and_match persists a score, match_score becomes the scored
     predicate used to avoid duplicate scoring."""
@@ -476,73 +442,6 @@ async def test_score_and_match_persists_match_score(db_session):
         await db_session.execute(sa.select(Application).where(Application.id == app.id))
     ).scalar_one()
     assert refreshed.match_score == 0.85
-
-
-@pytest.mark.asyncio
-async def test_score_cached_skips_jobs_with_active_match_work(db_session):
-    """If an Application has active match work, score_cached must not pick its
-    job again — otherwise we'd double-score and waste an LLM call."""
-    from app.models.user import User
-    from app.services.profile_service import get_or_create_profile
-
-    user = User(
-        id=uuid.uuid4(),
-        email="t@t.com",
-        is_active=True,
-        is_verified=True,
-        is_superuser=False,
-        hashed_password="",
-    )
-    db_session.add(user)
-    await db_session.commit()
-    airbnb_co = await _ensure_company(db_session, "airbnb")
-    profile = await get_or_create_profile(user.id, db_session)
-    profile.target_company_ids = [airbnb_co.id]
-    db_session.add(profile)
-    await db_session.commit()
-    await db_session.refresh(profile)
-
-    job = Job(
-        source="greenhouse",
-        external_id="r-1",
-        title="Eng",
-        company_name="Airbnb",
-        company_id=airbnb_co.id,
-        apply_url="https://x",
-        is_active=True,
-    )
-    db_session.add(job)
-    await db_session.commit()
-    await db_session.refresh(job)
-
-    app = Application(
-        job_id=job.id,
-        profile_id=profile.id,
-    )
-    db_session.add(app)
-    await db_session.commit()
-    await db_session.refresh(app)
-    db_session.add(
-        WorkQueue(
-            job_type="match",
-            payload={"application_id": str(app.id)},
-            status=WorkQueueStatus.IN_PROGRESS,
-            claimed_at=datetime.now(UTC),
-            claimed_by="worker-1",
-            attempts=1,
-            dedupe_key=f"match:{app.id}",
-        )
-    )
-    await db_session.commit()
-
-    # score_cached must skip this job (no LangGraph invocation)
-    fake_graph = MagicMock()
-    fake_graph.ainvoke = AsyncMock(return_value={"scores": []})
-    with patch("app.agents.matching_agent.build_graph", return_value=fake_graph):
-        result = await match_service.score_cached(profile, db_session, cap=20)
-
-    assert result == []
-    fake_graph.ainvoke.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_internal_cron.py
+++ b/tests/unit/test_internal_cron.py
@@ -76,7 +76,35 @@ def test_sync_correct_secret_calls_task():
     with patch("app.api.internal_cron.get_session_factory", return_value=lambda: _FakeSession()):
         resp = client.post("/internal/cron/sync", headers={"X-Cron-Secret": "real-secret"})
     assert resp.status_code == 202
-    assert resp.json() == {"enqueued": [], "pruned": 0, "active_profiles": 0}
+    assert resp.json() == {
+        "enqueued": [],
+        "pruned": 0,
+        "active_profiles": 0,
+        "profiles_enqueued": 0,
+    }
+
+
+def test_sync_correct_secret_delegates_to_shared_sync_service():
+    client = make_app(secret="real-secret")
+    summary = {
+        "enqueued": ["co"],
+        "pruned": 1,
+        "active_profiles": 2,
+        "profiles_enqueued": 1,
+    }
+    with (
+        patch("app.api.internal_cron.get_session_factory", return_value=lambda: _FakeSession()),
+        patch(
+            "app.services.job_sync_service.sync_active_profiles",
+            new=AsyncMock(return_value=summary),
+            create=True,
+        ) as mock_sync,
+    ):
+        resp = client.post("/internal/cron/sync", headers={"X-Cron-Secret": "real-secret"})
+
+    assert resp.status_code == 202
+    assert resp.json() == summary
+    mock_sync.assert_awaited_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_job_sync_service.py
+++ b/tests/unit/test_job_sync_service.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import job_sync_service
+
+
+class _ScalarResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+class _Session:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, stmt):
+        return _ScalarResult(self._rows)
+
+
+@pytest.mark.asyncio
+async def test_sync_active_profiles_aggregates_shared_enqueue_contract():
+    profiles = [SimpleNamespace(id="p1"), SimpleNamespace(id="p2")]
+    session = _Session(profiles)
+
+    with patch(
+        "app.services.job_sync_service.prune_and_enqueue",
+        new=AsyncMock(
+            side_effect=[
+                {
+                    "queued_slugs": ["airbnb", "stripe"],
+                    "matched_now": 0,
+                    "pruned_slugs": ["greenhouse:deadcorp"],
+                },
+                {
+                    "queued_slugs": [],
+                    "matched_now": 0,
+                    "pruned_slugs": [],
+                },
+            ]
+        ),
+    ) as mock_prune:
+        result = await job_sync_service.sync_active_profiles(session)
+
+    assert result == {
+        "enqueued": ["airbnb", "stripe"],
+        "pruned": 1,
+        "active_profiles": 2,
+        "profiles_enqueued": 1,
+    }
+    assert mock_prune.await_count == 2
+    mock_prune.assert_any_await(profiles[0], session)
+    mock_prune.assert_any_await(profiles[1], session)


### PR DESCRIPTION
## Summary
- document the background-only matching cleanup and cron review
- route manual, cron, and scheduler sync through shared enqueue-only sync helpers
- remove the obsolete score_cached synchronous matching helper and direct tests

## Verification
- env UV_PROJECT_ENVIRONMENT=/private/tmp/job-agent-venv UV_CACHE_DIR=/private/tmp/job-agent-uv-cache uv run pytest --ignore=.env.example tests/integration/test_job_sync.py tests/integration/test_cron_sync_enqueues.py tests/integration/test_cron_endpoints.py tests/integration/test_handler_match.py -q
- env UV_PROJECT_ENVIRONMENT=/private/tmp/job-agent-venv UV_CACHE_DIR=/private/tmp/job-agent-uv-cache uv run pytest --ignore=.env.example tests/unit/test_job_sync_service.py tests/unit/test_internal_cron.py tests/unit/test_remote_policy.py tests/unit/test_match_handler.py -q
- env UV_PROJECT_ENVIRONMENT=/private/tmp/job-agent-venv UV_CACHE_DIR=/private/tmp/job-agent-uv-cache uv run ruff check app/services/job_sync_service.py app/api/internal_cron.py app/scheduler/tasks.py app/services/match_service.py tests/unit/test_internal_cron.py tests/unit/test_job_sync_service.py tests/integration/test_job_sync.py tests/integration/test_cron_sync_enqueues.py tests/integration/test_match_scoring.py