### PR TITLE
Include salary ranges in matched jobs

### DIFF
--- a/app/services/job_salary_backfill.py
+++ b/app/services/job_salary_backfill.py
@@ -1,0 +1,140 @@
+"""Backfill salary fields for already-matched jobs without re-scoring."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+import httpx
+from sqlalchemy import exists
+from sqlmodel import col, select
+
+from app.models.application import Application
+from app.models.company import Company
+from app.models.job import Job
+from app.sources import SOURCES
+from app.sources.greenhouse_board import DEFAULT_TIMEOUT
+from app.sources.salary import extract_salary_range_from_text
+
+
+@dataclass
+class SalaryBackfillResult:
+    scanned: int = 0
+    updated: int = 0
+    from_description: int = 0
+    from_refetch: int = 0
+    unchanged: int = 0
+    failed_refetches: list[str] = field(default_factory=list)
+
+
+def _candidate_query(limit: int | None = None):
+    query = (
+        select(Job)
+        .where(
+            col(Job.salary).is_(None),
+            exists().where(Application.job_id == Job.id),
+        )
+        .order_by(Job.fetched_at.desc(), Job.id)
+    )
+    if limit is not None:
+        query = query.limit(limit)
+    return query
+
+
+async def _load_candidate_jobs(session, *, limit: int | None) -> list[Job]:
+    rows = await session.execute(_candidate_query(limit))
+    return list(rows.scalars().all())
+
+
+async def _companies_by_id(session, jobs: Iterable[Job]) -> dict:
+    company_ids = {job.company_id for job in jobs if job.company_id is not None}
+    if not company_ids:
+        return {}
+    rows = await session.execute(select(Company).where(col(Company.id).in_(company_ids)))
+    return {company.id: company for company in rows.scalars().all()}
+
+
+async def _refetch_salary_map(groups: dict[tuple[str, str], list[Job]]) -> tuple[dict, list[str]]:
+    salary_by_key: dict[tuple[str, str], str] = {}
+    failed_refetches: list[str] = []
+
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+        for (source, slug), jobs in groups.items():
+            adapter = SOURCES.get(source)
+            if adapter is None:
+                failed_refetches.append(f"{source}:{slug}: unknown provider")
+                continue
+            try:
+                fetched_jobs = await adapter.fetch_jobs(slug, since=None, client=client)
+            except Exception as exc:  # noqa: BLE001 - report and keep the backfill moving.
+                failed_refetches.append(f"{source}:{slug}: {type(exc).__name__}: {exc}")
+                continue
+
+            wanted_external_ids = {job.external_id for job in jobs}
+            for fetched in fetched_jobs:
+                if fetched.external_id in wanted_external_ids and fetched.salary:
+                    salary_by_key[(source, fetched.external_id)] = fetched.salary
+
+    return salary_by_key, failed_refetches
+
+
+async def backfill_job_salaries(
+    session,
+    *,
+    apply: bool = False,
+    fetch_structured: bool = True,
+    limit: int | None = None,
+) -> SalaryBackfillResult:
+    """Populate Job.salary for jobs that already have Application rows.
+
+    This never calls the matching agent, clears scores, or enqueues match jobs.
+    It first extracts salary ranges from stored description_raw. If requested,
+    it then refetches each provider slug once and copies structured salary
+    values onto matching existing jobs.
+    """
+    jobs = await _load_candidate_jobs(session, limit=limit)
+    result = SalaryBackfillResult(scanned=len(jobs))
+
+    remaining: list[Job] = []
+    for job in jobs:
+        salary = extract_salary_range_from_text(job.description_raw)
+        if salary:
+            result.updated += 1
+            result.from_description += 1
+            if apply:
+                job.salary = salary
+                session.add(job)
+        else:
+            remaining.append(job)
+
+    if fetch_structured and remaining:
+        companies = await _companies_by_id(session, remaining)
+        groups: dict[tuple[str, str], list[Job]] = {}
+        for job in remaining:
+            company = companies.get(job.company_id)
+            if company is None:
+                continue
+            slug = (company.provider_slugs or {}).get(job.source)
+            if not slug:
+                continue
+            groups.setdefault((job.source, slug), []).append(job)
+
+        salary_by_key, failed_refetches = await _refetch_salary_map(groups)
+        result.failed_refetches.extend(failed_refetches)
+
+        for job in remaining:
+            salary = salary_by_key.get((job.source, job.external_id))
+            if salary is None:
+                continue
+            result.updated += 1
+            result.from_refetch += 1
+            if apply:
+                job.salary = salary
+                session.add(job)
+
+    result.unchanged = result.scanned - result.updated
+    if apply and result.updated:
+        await session.commit()
+    else:
+        await session.rollback()
+    return result

--- a/app/sources/ashby_board.py
+++ b/app/sources/ashby_board.py
@@ -21,6 +21,7 @@ from app.sources.base import (
     JobSource,
     TransientFetchError,
 )
+from app.sources.salary import extract_salary_range_from_text, salary_from_ashby_compensation
 
 ASHBY_POSTINGS_BASE = "https://api.ashbyhq.com/posting-api/job-board"
 DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
@@ -67,6 +68,11 @@ class AshbyBoardSource(JobSource):
         # field; the slug itself is canonical for the Company row, and
         # Track B will replace this lazy derivation with Company.canonical_name.
         company_name = slug.replace("-", " ").title()
+        salary = salary_from_ashby_compensation(item.get("compensation"))
+        if salary is None:
+            salary = extract_salary_range_from_text(
+                item.get("descriptionHtml") or item.get("descriptionPlain")
+            )
         return JobData(
             external_id=external_id,
             title=title,
@@ -74,7 +80,7 @@ class AshbyBoardSource(JobSource):
             location=location,
             workplace_type=workplace_type,
             description_raw=item.get("descriptionHtml") or None,
-            salary=None,
+            salary=salary,
             contract_type=contract_type,
             apply_url=apply_url,
             posted_at=posted_at,

--- a/app/sources/greenhouse_board.py
+++ b/app/sources/greenhouse_board.py
@@ -12,6 +12,11 @@ from app.sources.base import (
     JobSource,
     TransientFetchError,
 )
+from app.sources.salary import (
+    extract_salary_range_from_text,
+    salary_from_greenhouse_metadata,
+    salary_from_greenhouse_pay_ranges,
+)
 
 GREENHOUSE_BOARDS_BASE = "https://boards-api.greenhouse.io/v1/boards"
 DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
@@ -40,6 +45,11 @@ class GreenhouseBoardSource(JobSource):
                 posted_at = datetime.fromisoformat(ts.replace("Z", "+00:00"))
             except (ValueError, AttributeError):
                 pass
+        salary = (
+            salary_from_greenhouse_pay_ranges(item.get("pay_input_ranges"))
+            or salary_from_greenhouse_metadata(item.get("metadata"))
+            or extract_salary_range_from_text(item.get("content"))
+        )
         return JobData(
             external_id=str(job_id),
             title=title,
@@ -48,7 +58,7 @@ class GreenhouseBoardSource(JobSource):
             workplace_type=workplace_type,
             # raw HTML; clean_html_to_markdown runs in job_service
             description_raw=item.get("content"),
-            salary=None,
+            salary=salary,
             contract_type=None,
             apply_url=apply_url,
             posted_at=posted_at,

--- a/app/sources/lever_postings.py
+++ b/app/sources/lever_postings.py
@@ -20,6 +20,7 @@ from app.sources.base import (
     JobSource,
     TransientFetchError,
 )
+from app.sources.salary import extract_salary_range_from_text, format_salary_range
 
 LEVER_POSTINGS_BASE = "https://api.lever.co/v0/postings"
 DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
@@ -46,10 +47,18 @@ class LeverPostingsSource(JobSource):
         workplace_type = item.get("workplaceType") or None
         contract_type = categories.get("commitment") or None
         salary_obj = item.get("salaryRange") or {}
-        salary = None
-        if salary_obj.get("min") is not None and salary_obj.get("max") is not None:
-            currency = salary_obj.get("currency") or ""
-            salary = f"{currency}{salary_obj['min']}–{salary_obj['max']}"
+        salary = format_salary_range(
+            salary_obj.get("min"),
+            salary_obj.get("max"),
+            salary_obj.get("currency"),
+        )
+        if salary is None:
+            salary = extract_salary_range_from_text(
+                item.get("salaryDescriptionPlain")
+                or item.get("salaryDescription")
+                or item.get("descriptionHtml")
+                or item.get("description")
+            )
         posted_at = None
         if ts := item.get("createdAt"):
             try:

--- a/app/sources/salary.py
+++ b/app/sources/salary.py
@@ -1,0 +1,167 @@
+"""Salary extraction helpers for public ATS job payloads."""
+
+from __future__ import annotations
+
+import html as html_lib
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from bs4 import BeautifulSoup
+
+CURRENCY_SYMBOLS = {
+    "USD": "$",
+    "EUR": "€",
+    "GBP": "£",
+}
+
+SALARY_KEYWORDS = ("salary", "compensation", "pay", "base")
+CURRENCY_CODES = ("USD", "EUR", "GBP", "CAD", "AUD", "NZD")
+
+_MONEY_RE = r"(?:[$€£]\s*)?\d[\d,]*(?:\.\d+)?\s*[kKmM]?"
+_RANGE_RE = re.compile(
+    rf"{_MONEY_RE}\s*(?:-|–|—|to)\s*{_MONEY_RE}(?:\s*(?:{'|'.join(CURRENCY_CODES)}))?",
+    re.IGNORECASE,
+)
+
+
+def _as_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _format_amount(value: Any, currency_code: str | None, *, cents: bool = False) -> str | None:
+    amount = _as_decimal(value)
+    if amount is None:
+        return None
+    if cents:
+        amount = amount / Decimal(100)
+
+    if amount == amount.to_integral():
+        rendered = f"{int(amount):,}"
+    else:
+        rendered = f"{amount:,.2f}".rstrip("0").rstrip(".")
+
+    code = (currency_code or "").upper()
+    symbol = CURRENCY_SYMBOLS.get(code)
+    if symbol:
+        return f"{symbol}{rendered}"
+    if code:
+        return f"{code} {rendered}"
+    return rendered
+
+
+def format_salary_range(
+    min_value: Any,
+    max_value: Any,
+    currency_code: str | None = None,
+    *,
+    cents: bool = False,
+) -> str | None:
+    low = _format_amount(min_value, currency_code, cents=cents)
+    high = _format_amount(max_value, currency_code, cents=cents)
+    if low is None or high is None:
+        return None
+    return f"{low}–{high}"
+
+
+def extract_salary_range_from_text(text: str | None) -> str | None:
+    if not text:
+        return None
+    decoded = html_lib.unescape(text)
+    plain = BeautifulSoup(decoded, "html.parser").get_text(" ")
+    plain = re.sub(r"\s+", " ", plain).strip()
+    if not plain:
+        return None
+
+    for match in _RANGE_RE.finditer(plain):
+        candidate = match.group(0).strip(" .,;:")
+        window_start = max(match.start() - 80, 0)
+        window_end = min(match.end() + 40, len(plain))
+        window = plain[window_start:window_end].lower()
+        has_currency = any(symbol in candidate for symbol in ("$", "€", "£")) or any(
+            code.lower() in candidate.lower() for code in CURRENCY_CODES
+        )
+        if has_currency or any(keyword in window for keyword in SALARY_KEYWORDS):
+            return candidate
+    return None
+
+
+def salary_from_ashby_compensation(compensation: Any) -> str | None:
+    if not isinstance(compensation, dict):
+        return None
+
+    summary = compensation.get("scrapeableCompensationSalarySummary")
+    if isinstance(summary, str) and summary.strip():
+        return summary.strip()
+
+    components = list(compensation.get("summaryComponents") or [])
+    for tier in compensation.get("compensationTiers") or []:
+        if isinstance(tier, dict):
+            components.extend(tier.get("components") or [])
+
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        if str(component.get("compensationType") or "").lower() != "salary":
+            continue
+        salary = format_salary_range(
+            component.get("minValue"),
+            component.get("maxValue"),
+            component.get("currencyCode"),
+        )
+        if salary:
+            return salary
+    return None
+
+
+def salary_from_greenhouse_pay_ranges(pay_input_ranges: Any) -> str | None:
+    if not isinstance(pay_input_ranges, list):
+        return None
+
+    parts: list[str] = []
+    for pay_range in pay_input_ranges:
+        if not isinstance(pay_range, dict):
+            continue
+        salary = format_salary_range(
+            pay_range.get("min_cents"),
+            pay_range.get("max_cents"),
+            pay_range.get("currency_type"),
+            cents=True,
+        )
+        if salary is None:
+            continue
+        title = pay_range.get("title")
+        if isinstance(title, str) and title.strip():
+            parts.append(f"{title.strip()}: {salary}")
+        else:
+            parts.append(salary)
+    return "; ".join(parts) or None
+
+
+def salary_from_greenhouse_metadata(metadata: Any) -> str | None:
+    if not isinstance(metadata, list):
+        return None
+
+    for field in metadata:
+        if not isinstance(field, dict):
+            continue
+        name = str(field.get("name") or "").lower()
+        if not any(keyword in name for keyword in SALARY_KEYWORDS):
+            continue
+        value = field.get("value")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, dict):
+            salary = format_salary_range(
+                value.get("min_value") or value.get("min"),
+                value.get("max_value") or value.get("max"),
+                value.get("currency_type") or value.get("currency"),
+            )
+            if salary:
+                return salary
+    return None

--- a/scripts/backfill_job_salaries.py
+++ b/scripts/backfill_job_salaries.py
@@ -1,0 +1,56 @@
+"""Backfill salary fields for existing matched jobs without LLM re-scoring.
+
+Dry-run first:
+    uv run python scripts/backfill_job_salaries.py
+
+Apply:
+    uv run python scripts/backfill_job_salaries.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.database import get_session_factory
+from app.services.job_salary_backfill import backfill_job_salaries
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="Write salary values to jobs.")
+    parser.add_argument(
+        "--no-refetch",
+        action="store_true",
+        help="Only parse stored description_raw; skip ATS refetch for structured salary data.",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Maximum matched jobs to scan.")
+    args = parser.parse_args()
+
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await backfill_job_salaries(
+            session,
+            apply=args.apply,
+            fetch_structured=not args.no_refetch,
+            limit=args.limit,
+        )
+
+    mode = "APPLIED" if args.apply else "DRY RUN"
+    print(f"{mode}: scanned={result.scanned} updated={result.updated} unchanged={result.unchanged}")
+    print(
+        "sources: "
+        f"description={result.from_description} structured_refetch={result.from_refetch}"
+    )
+    if result.failed_refetches:
+        print("failed_refetches:")
+        for failure in result.failed_refetches:
+            print(f"  - {failure}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/integration/test_job_salary_backfill.py
+++ b/tests/integration/test_job_salary_backfill.py
@@ -1,0 +1,140 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from sqlmodel import select
+
+from app.models.application import Application
+from app.models.company import Company
+from app.models.job import Job
+from app.services.job_salary_backfill import backfill_job_salaries
+from app.sources.base import JobData
+
+
+def _job(
+    *,
+    source: str = "greenhouse",
+    external_id: str = "job-1",
+    description_raw: str | None = None,
+    salary: str | None = None,
+    company_id=None,
+) -> Job:
+    return Job(
+        source=source,
+        external_id=external_id,
+        title=f"Title {external_id}",
+        company_name="Acme",
+        company_id=company_id,
+        description_raw=description_raw,
+        description="",
+        salary=salary,
+        apply_url=f"https://example.test/{external_id}",
+        posted_at=datetime.now(UTC),
+    )
+
+
+async def _matched_job(db_session, seeded_user, job: Job) -> None:
+    _, profile = seeded_user
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)
+    db_session.add(Application(job_id=job.id, profile_id=profile.id, match_score=0.9))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_backfill_job_salaries_updates_existing_matches_from_description(
+    db_session, seeded_user
+):
+    job = _job(description_raw="<p>Base salary range: $150,000 - $190,000.</p>")
+    already_has_salary = _job(
+        external_id="job-2",
+        description_raw="<p>Base salary range: $120,000 - $150,000.</p>",
+        salary="$1",
+    )
+    no_salary = _job(external_id="job-3", description_raw="<p>No range here.</p>")
+    unmatched = _job(
+        external_id="job-4",
+        description_raw="<p>Base salary range: $100,000 - $120,000.</p>",
+    )
+    await _matched_job(db_session, seeded_user, job)
+    await _matched_job(db_session, seeded_user, already_has_salary)
+    await _matched_job(db_session, seeded_user, no_salary)
+    db_session.add(unmatched)
+    await db_session.commit()
+
+    result = await backfill_job_salaries(db_session, apply=True, fetch_structured=False)
+
+    assert result.scanned == 2
+    assert result.updated == 1
+    assert result.from_description == 1
+    await db_session.refresh(job)
+    await db_session.refresh(already_has_salary)
+    await db_session.refresh(no_salary)
+    await db_session.refresh(unmatched)
+    assert job.salary == "$150,000 - $190,000"
+    assert already_has_salary.salary == "$1"
+    assert no_salary.salary is None
+    assert unmatched.salary is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_job_salaries_dry_run_does_not_write(db_session, seeded_user):
+    job = _job(description_raw="<p>Compensation: $150,000 - $190,000.</p>")
+    await _matched_job(db_session, seeded_user, job)
+
+    result = await backfill_job_salaries(db_session, apply=False, fetch_structured=False)
+
+    assert result.updated == 1
+    await db_session.refresh(job)
+    assert job.salary is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_job_salaries_refetches_full_slug_for_structured_compensation(
+    db_session, seeded_user, monkeypatch
+):
+    company = Company(
+        canonical_name="Acme",
+        normalized_key=f"acme-{uuid4()}",
+        provider_slugs={"ashby": "acme"},
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.add(company)
+    await db_session.commit()
+    await db_session.refresh(company)
+
+    job = _job(
+        source="ashby",
+        external_id="https://jobs.ashbyhq.com/acme/job-1",
+        description_raw="<p>No salary in description.</p>",
+        company_id=company.id,
+    )
+    await _matched_job(db_session, seeded_user, job)
+
+    class FakeAshbySource:
+        async def fetch_jobs(self, slug, *, since=None, client=None):
+            assert slug == "acme"
+            assert since is None
+            return [
+                JobData(
+                    external_id="https://jobs.ashbyhq.com/acme/job-1",
+                    title="Title",
+                    company_name="Acme",
+                    description_raw="<p>No salary in description.</p>",
+                    salary="$150,000–$190,000",
+                    apply_url="https://jobs.ashbyhq.com/acme/job-1/application",
+                )
+            ]
+
+    import app.services.job_salary_backfill as salary_backfill
+
+    monkeypatch.setitem(salary_backfill.SOURCES, "ashby", FakeAshbySource())
+
+    result = await backfill_job_salaries(db_session, apply=True, fetch_structured=True)
+
+    assert result.scanned == 1
+    assert result.updated == 1
+    assert result.from_refetch == 1
+    refreshed = (await db_session.execute(select(Job).where(Job.id == job.id))).scalar_one()
+    assert refreshed.salary == "$150,000–$190,000"

--- a/tests/unit/sources/test_ashby_board.py
+++ b/tests/unit/sources/test_ashby_board.py
@@ -92,6 +92,40 @@ async def test_fetch_jobs_happy_path(src):
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_fetch_jobs_includes_ashby_compensation_salary_summary(src):
+    posting = _posting(1)
+    posting["compensation"] = {
+        "compensationTierSummary": "$81K - $87K • 0.5% - 1.75%",
+        "scrapeableCompensationSalarySummary": "$81K - $87K",
+        "summaryComponents": [
+            {
+                "compensationType": "Salary",
+                "interval": "1 YEAR",
+                "currencyCode": "USD",
+                "minValue": 81000,
+                "maxValue": 87000,
+            }
+        ],
+    }
+    respx.get(f"{ASHBY_POSTINGS_BASE}/acme").respond(200, json=_payload(posting))
+    async with httpx.AsyncClient() as client:
+        jobs = await src.fetch_jobs("acme", client=client)
+    assert jobs[0].salary == "$81K - $87K"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_jobs_extracts_salary_range_from_description(src):
+    posting = _posting(1)
+    posting["descriptionHtml"] = "<p>The salary range for this role is $150,000 - $190,000.</p>"
+    respx.get(f"{ASHBY_POSTINGS_BASE}/acme").respond(200, json=_payload(posting))
+    async with httpx.AsyncClient() as client:
+        jobs = await src.fetch_jobs("acme", client=client)
+    assert jobs[0].salary == "$150,000 - $190,000"
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_fetch_jobs_skips_postings_without_apply_url(src):
     bad = _posting(1)
     bad["applyUrl"] = ""

--- a/tests/unit/sources/test_lever_postings.py
+++ b/tests/unit/sources/test_lever_postings.py
@@ -97,6 +97,27 @@ async def test_fetch_jobs_single_page(src):
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_fetch_jobs_includes_salary_range(src):
+    posting = _posting(1)
+    posting["salaryRange"] = {
+        "currency": "USD",
+        "interval": "year",
+        "min": 150000,
+        "max": 190000,
+    }
+    respx.get(f"{LEVER_POSTINGS_BASE}/acme").mock(
+        side_effect=[
+            httpx.Response(200, json=[posting]),
+            httpx.Response(200, json=[]),
+        ]
+    )
+    async with httpx.AsyncClient() as client:
+        jobs = await src.fetch_jobs("acme", client=client)
+    assert jobs[0].salary == "$150,000–$190,000"
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_fetch_jobs_paginates_until_empty(src):
     page1 = [_posting(i) for i in range(100)]
     page2 = [_posting(i) for i in range(100, 150)]

--- a/tests/unit/test_greenhouse_board_source.py
+++ b/tests/unit/test_greenhouse_board_source.py
@@ -162,6 +162,66 @@ async def test_greenhouse_board_passes_through_raw_html_content():
 
 
 @pytest.mark.asyncio
+async def test_greenhouse_board_includes_pay_input_ranges():
+    source = GreenhouseBoardSource()
+
+    fixture = {
+        "jobs": [
+            {
+                "id": 4000011,
+                "title": "Backend Engineer",
+                "location": {"name": "Remote"},
+                "content": "<div>Work from anywhere</div>",
+                "absolute_url": "https://boards.greenhouse.io/stripe/jobs/4000011",
+                "updated_at": "2026-04-01T10:00:00Z",
+                "pay_input_ranges": [
+                    {
+                        "min_cents": 15000000,
+                        "max_cents": 19000000,
+                        "currency_type": "USD",
+                        "title": "US Salary Range",
+                    }
+                ],
+            }
+        ]
+    }
+
+    with respx.mock:
+        respx.get(f"{GREENHOUSE_BOARDS_BASE}/stripe/jobs").mock(
+            return_value=httpx.Response(200, json=fixture)
+        )
+        jobs = await source.fetch_jobs("stripe")
+
+    assert jobs[0].salary == "US Salary Range: $150,000–$190,000"
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_board_extracts_salary_range_from_description():
+    source = GreenhouseBoardSource()
+
+    fixture = {
+        "jobs": [
+            {
+                "id": 4000012,
+                "title": "Backend Engineer",
+                "location": {"name": "Remote"},
+                "content": "<p>Base salary range: $160,000 to $210,000 USD.</p>",
+                "absolute_url": "https://boards.greenhouse.io/stripe/jobs/4000012",
+                "updated_at": "2026-04-01T10:00:00Z",
+            }
+        ]
+    }
+
+    with respx.mock:
+        respx.get(f"{GREENHOUSE_BOARDS_BASE}/stripe/jobs").mock(
+            return_value=httpx.Response(200, json=fixture)
+        )
+        jobs = await source.fetch_jobs("stripe")
+
+    assert jobs[0].salary == "$160,000 to $210,000 USD"
+
+
+@pytest.mark.asyncio
 async def test_greenhouse_board_5xx_raises_transient():
     """5xx from Greenhouse is transient — distinguish from 404 (#47)."""
     from app.sources.base import TransientFetchError


### PR DESCRIPTION
## Summary
- Populate job.salary from Ashby compensation, Greenhouse pay ranges/metadata, and Lever salary ranges
- Add conservative description-text fallback for salary ranges embedded in public job descriptions
- Cover Ashby, Greenhouse, and Lever adapter behavior with focused unit tests

## Verification
- .venv/bin/python -m pytest tests/unit/sources/test_ashby_board.py tests/unit/test_greenhouse_board_source.py tests/unit/sources/test_lever_postings.py
- .venv/bin/python -m ruff check app/sources/salary.py app/sources/ashby_board.py app/sources/greenhouse_board.py app/sources/lever_postings.py tests/unit/sources/test_ashby_board.py tests/unit/sources/test_lever_postings.py tests/unit/test_greenhouse_board_source.py