### PR TITLE
Reject ambiguous salary backfill values

### DIFF
--- a/app/services/job_salary_backfill.py
+++ b/app/services/job_salary_backfill.py
@@ -14,7 +14,7 @@ from app.models.company import Company
 from app.models.job import Job
 from app.sources import SOURCES
 from app.sources.greenhouse_board import DEFAULT_TIMEOUT
-from app.sources.salary import extract_salary_range_from_text
+from app.sources.salary import extract_salary_range_from_text, is_plausible_salary
 
 
 @dataclass
@@ -41,8 +41,27 @@ def _candidate_query(limit: int | None = None):
     return query
 
 
+def _cleanup_candidate_query(limit: int | None = None):
+    query = (
+        select(Job)
+        .where(
+            col(Job.salary).isnot(None),
+            exists().where(Application.job_id == Job.id),
+        )
+        .order_by(Job.fetched_at.desc(), Job.id)
+    )
+    if limit is not None:
+        query = query.limit(limit)
+    return query
+
+
 async def _load_candidate_jobs(session, *, limit: int | None) -> list[Job]:
     rows = await session.execute(_candidate_query(limit))
+    return list(rows.scalars().all())
+
+
+async def _load_cleanup_candidate_jobs(session, *, limit: int | None) -> list[Job]:
+    rows = await session.execute(_cleanup_candidate_query(limit))
     return list(rows.scalars().all())
 
 
@@ -131,6 +150,32 @@ async def backfill_job_salaries(
             if apply:
                 job.salary = salary
                 session.add(job)
+
+    result.unchanged = result.scanned - result.updated
+    if apply and result.updated:
+        await session.commit()
+    else:
+        await session.rollback()
+    return result
+
+
+async def cleanup_invalid_salaries(
+    session,
+    *,
+    apply: bool = False,
+    limit: int | None = None,
+) -> SalaryBackfillResult:
+    """Null salary values that are too ambiguous to display as compensation."""
+    jobs = await _load_cleanup_candidate_jobs(session, limit=limit)
+    result = SalaryBackfillResult(scanned=len(jobs))
+
+    for job in jobs:
+        if is_plausible_salary(job.salary):
+            continue
+        result.updated += 1
+        if apply:
+            job.salary = None
+            session.add(job)
 
     result.unchanged = result.scanned - result.updated
     if apply and result.updated:

--- a/app/sources/salary.py
+++ b/app/sources/salary.py
@@ -23,6 +23,22 @@ _RANGE_RE = re.compile(
     rf"{_MONEY_RE}\s*(?:-|–|—|to)\s*{_MONEY_RE}(?:\s*(?:{'|'.join(CURRENCY_CODES)}))?",
     re.IGNORECASE,
 )
+_CURRENCY_RE = re.compile(
+    rf"(?:[$€£]|\b(?:{'|'.join(CURRENCY_CODES)})\b)",
+    re.IGNORECASE,
+)
+
+
+def has_currency_marker(value: str | None) -> bool:
+    return bool(value and _CURRENCY_RE.search(value))
+
+
+def is_plausible_salary(value: str | None) -> bool:
+    if not value or not value.strip():
+        return False
+    if not has_currency_marker(value):
+        return False
+    return bool(re.search(r"\d", value))
 
 
 def _as_decimal(value: Any) -> Decimal | None:
@@ -62,6 +78,8 @@ def format_salary_range(
     *,
     cents: bool = False,
 ) -> str | None:
+    if not currency_code:
+        return None
     low = _format_amount(min_value, currency_code, cents=cents)
     high = _format_amount(max_value, currency_code, cents=cents)
     if low is None or high is None:
@@ -83,10 +101,7 @@ def extract_salary_range_from_text(text: str | None) -> str | None:
         window_start = max(match.start() - 80, 0)
         window_end = min(match.end() + 40, len(plain))
         window = plain[window_start:window_end].lower()
-        has_currency = any(symbol in candidate for symbol in ("$", "€", "£")) or any(
-            code.lower() in candidate.lower() for code in CURRENCY_CODES
-        )
-        if has_currency or any(keyword in window for keyword in SALARY_KEYWORDS):
+        if has_currency_marker(candidate) and any(keyword in window for keyword in SALARY_KEYWORDS):
             return candidate
     return None
 
@@ -96,7 +111,7 @@ def salary_from_ashby_compensation(compensation: Any) -> str | None:
         return None
 
     summary = compensation.get("scrapeableCompensationSalarySummary")
-    if isinstance(summary, str) and summary.strip():
+    if isinstance(summary, str) and is_plausible_salary(summary):
         return summary.strip()
 
     components = list(compensation.get("summaryComponents") or [])
@@ -154,7 +169,7 @@ def salary_from_greenhouse_metadata(metadata: Any) -> str | None:
         if not any(keyword in name for keyword in SALARY_KEYWORDS):
             continue
         value = field.get("value")
-        if isinstance(value, str) and value.strip():
+        if isinstance(value, str) and is_plausible_salary(value):
             return value.strip()
         if isinstance(value, dict):
             salary = format_salary_range(

--- a/scripts/backfill_job_salaries.py
+++ b/scripts/backfill_job_salaries.py
@@ -14,10 +14,12 @@ import asyncio
 import sys
 from pathlib import Path
 
+from pydantic import ValidationError
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from app.database import get_session_factory
-from app.services.job_salary_backfill import backfill_job_salaries
+from app.services.job_salary_backfill import backfill_job_salaries, cleanup_invalid_salaries
 
 
 async def main() -> None:
@@ -28,24 +30,49 @@ async def main() -> None:
         action="store_true",
         help="Only parse stored description_raw; skip ATS refetch for structured salary data.",
     )
+    parser.add_argument(
+        "--cleanup-invalid",
+        action="store_true",
+        help="Null ambiguous existing salary values, such as 'Salary', '10-20', or '0-0'.",
+    )
     parser.add_argument("--limit", type=int, default=None, help="Maximum matched jobs to scan.")
     args = parser.parse_args()
 
-    factory = get_session_factory()
+    try:
+        factory = get_session_factory()
+    except ValidationError as exc:
+        if any(error.get("loc") == ("database_url",) for error in exc.errors()):
+            print(
+                "DATABASE_URL is required. Export it or create .env before running this script.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2) from exc
+        raise
+
     async with factory() as session:
-        result = await backfill_job_salaries(
-            session,
-            apply=args.apply,
-            fetch_structured=not args.no_refetch,
-            limit=args.limit,
-        )
+        if args.cleanup_invalid:
+            result = await cleanup_invalid_salaries(
+                session,
+                apply=args.apply,
+                limit=args.limit,
+            )
+        else:
+            result = await backfill_job_salaries(
+                session,
+                apply=args.apply,
+                fetch_structured=not args.no_refetch,
+                limit=args.limit,
+            )
 
     mode = "APPLIED" if args.apply else "DRY RUN"
+    action = "cleanup" if args.cleanup_invalid else "backfill"
     print(f"{mode}: scanned={result.scanned} updated={result.updated} unchanged={result.unchanged}")
-    print(
-        "sources: "
-        f"description={result.from_description} structured_refetch={result.from_refetch}"
-    )
+    print(f"action: {action}")
+    if not args.cleanup_invalid:
+        print(
+            "sources: "
+            f"description={result.from_description} structured_refetch={result.from_refetch}"
+        )
     if result.failed_refetches:
         print("failed_refetches:")
         for failure in result.failed_refetches:

--- a/tests/integration/test_job_salary_backfill.py
+++ b/tests/integration/test_job_salary_backfill.py
@@ -7,7 +7,7 @@ from sqlmodel import select
 from app.models.application import Application
 from app.models.company import Company
 from app.models.job import Job
-from app.services.job_salary_backfill import backfill_job_salaries
+from app.services.job_salary_backfill import backfill_job_salaries, cleanup_invalid_salaries
 from app.sources.base import JobData
 
 
@@ -76,6 +76,61 @@ async def test_backfill_job_salaries_updates_existing_matches_from_description(
     assert already_has_salary.salary == "$1"
     assert no_salary.salary is None
     assert unmatched.salary is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_job_salaries_ignores_ambiguous_non_currency_ranges(
+    db_session, seeded_user
+):
+    equity = _job(
+        external_id="job-1",
+        description_raw="<p>Compensation includes equity: 10-20 bps.</p>",
+    )
+    zero = _job(external_id="job-2", description_raw="<p>Salary range: 0–0.</p>")
+    bare_range = _job(
+        external_id="job-3",
+        description_raw="<p>The salary range is 64,800–95,300.</p>",
+    )
+    await _matched_job(db_session, seeded_user, equity)
+    await _matched_job(db_session, seeded_user, zero)
+    await _matched_job(db_session, seeded_user, bare_range)
+
+    result = await backfill_job_salaries(db_session, apply=True, fetch_structured=False)
+
+    assert result.updated == 0
+    await db_session.refresh(equity)
+    await db_session.refresh(zero)
+    await db_session.refresh(bare_range)
+    assert equity.salary is None
+    assert zero.salary is None
+    assert bare_range.salary is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_invalid_salaries_nulls_ambiguous_backfill_values(
+    db_session, seeded_user
+):
+    ambiguous = _job(salary="10-20")
+    label = _job(external_id="job-2", salary="Salary")
+    valid_usd = _job(external_id="job-3", salary="$105,400 — $155,000 USD")
+    valid_eur = _job(external_id="job-4", salary="€300,000 - €330,000")
+    await _matched_job(db_session, seeded_user, ambiguous)
+    await _matched_job(db_session, seeded_user, label)
+    await _matched_job(db_session, seeded_user, valid_usd)
+    await _matched_job(db_session, seeded_user, valid_eur)
+
+    result = await cleanup_invalid_salaries(db_session, apply=True)
+
+    assert result.scanned == 4
+    assert result.updated == 2
+    await db_session.refresh(ambiguous)
+    await db_session.refresh(label)
+    await db_session.refresh(valid_usd)
+    await db_session.refresh(valid_eur)
+    assert ambiguous.salary is None
+    assert label.salary is None
+    assert valid_usd.salary == "$105,400 — $155,000 USD"
+    assert valid_eur.salary == "€300,000 - €330,000"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sources/test_ashby_board.py
+++ b/tests/unit/sources/test_ashby_board.py
@@ -115,6 +115,27 @@ async def test_fetch_jobs_includes_ashby_compensation_salary_summary(src):
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_fetch_jobs_ignores_non_salary_compensation_summary(src):
+    posting = _posting(1)
+    posting["compensation"] = {
+        "scrapeableCompensationSalarySummary": "Salary",
+        "summaryComponents": [
+            {
+                "compensationType": "Salary",
+                "interval": "1 YEAR",
+                "minValue": 0,
+                "maxValue": 0,
+            }
+        ],
+    }
+    respx.get(f"{ASHBY_POSTINGS_BASE}/acme").respond(200, json=_payload(posting))
+    async with httpx.AsyncClient() as client:
+        jobs = await src.fetch_jobs("acme", client=client)
+    assert jobs[0].salary is None
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_fetch_jobs_extracts_salary_range_from_description(src):
     posting = _posting(1)
     posting["descriptionHtml"] = "<p>The salary range for this role is $150,000 - $190,000.</p>"


### PR DESCRIPTION
## Summary
- Require salary values to include a currency marker/code before storing them
- Ignore ambiguous compensation ranges like `10-20`, `0-0`, and placeholder `Salary` summaries
- Add `scripts/backfill_job_salaries.py --cleanup-invalid` to null ambiguous values already written by the backfill

## Production repair
Run dry-run first, then apply:

```bash
uv run python scripts/backfill_job_salaries.py --cleanup-invalid
uv run python scripts/backfill_job_salaries.py --cleanup-invalid --apply
```

This only touches `jobs.salary` for jobs that already have application rows; it does not reprocess LLM matching, enqueue match jobs, or change application scores/statuses.

## Verification
- .venv/bin/python -m pytest tests/unit/sources/test_ashby_board.py tests/unit/test_greenhouse_board_source.py tests/unit/sources/test_lever_postings.py tests/integration/test_job_salary_backfill.py
- .venv/bin/python -m ruff check app/sources/salary.py app/services/job_salary_backfill.py scripts/backfill_job_salaries.py tests/unit/sources/test_ashby_board.py tests/integration/test_job_salary_backfill.py