### PR TITLE
Reject onsite descriptions in deterministic matching

### DIFF
--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -34,6 +34,8 @@ OFFICE_ATTENDANCE_PATTERNS = (
     r"\bhybrid\s+schedule\b.{0,40}\b(?:requires?|required|must)\b",
     r"\b(?:requires?|required|must)\b.{0,40}\bhybrid\s+schedule\b",
     r"\bmust(?:\s+be)?\s+located\s+near\b",
+    r"\b(?:onsite|on site|in person)\s+(?:role|position|job|work)\b",
+    r"\b(?:role|position|job|work)\s+(?:is\s+)?(?:onsite|on site|in person)\b",
 )
 OFFICE_ATTENDANCE_GAP = "Requires recurring office attendance outside target locations"
 NON_US_POSITION_GAP = "Position is not US-based"

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -96,6 +96,21 @@ def test_remote_only_profile_allows_explicit_remote_location():
     assert verdict.hard_mismatch is False
 
 
+def test_remote_only_profile_rejects_onsite_description_despite_remote_metadata():
+    profile = _profile(target_locations=[], remote_ok=True)
+    job = SimpleNamespace(
+        location="Remote - US",
+        workplace_type="remote",
+        description="This is an onsite role for engineers embedded with customers.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is True
+    assert "office attendance" in verdict.gap
+
+
 def test_remote_pseudo_location_is_not_office_target_location():
     profile = _profile(target_locations=["Remote"], remote_ok=True)
     job = SimpleNamespace(


### PR DESCRIPTION
## Summary
- treat onsite/on-site/on site/in-person job descriptions as office-attendance requirements
- add a regression test for remote metadata overridden by onsite JD text

## Verification
- uv run --frozen pytest tests/unit/test_remote_policy.py tests/unit/test_match_service.py tests/unit/test_match_handler.py -q