### PR TITLE
Fix Mistral catalog provider

### DIFF
--- a/app/data/catalog/companies.yaml
+++ b/app/data/catalog/companies.yaml
@@ -198,7 +198,7 @@ companies:
     tags: [ai, dev-tools, b2b, early-stage]
   - canonical_name: Mistral AI
     providers:
-      ashby: mistral
+      lever: mistral
     tags: [ai, b2b, late-stage]
   - canonical_name: Perplexity
     providers:

--- a/tests/unit/sources/test_ashby_board.py
+++ b/tests/unit/sources/test_ashby_board.py
@@ -177,7 +177,8 @@ async def test_fetch_jobs_5xx_raises_transient(src):
 @respx.mock
 @pytest.mark.asyncio
 async def test_fetch_jobs_filters_by_since(src):
-    recent = _posting(1, "2026-05-05T12:00:00Z")
+    recent_iso = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    recent = _posting(1, recent_iso)
     old = _posting(2, "2025-01-01T00:00:00Z")
     respx.get(f"{ASHBY_POSTINGS_BASE}/acme").respond(200, json=_payload(recent, old))
     cutoff = datetime.now(UTC) - timedelta(days=14)

--- a/tests/unit/sources/test_lever_postings.py
+++ b/tests/unit/sources/test_lever_postings.py
@@ -205,7 +205,8 @@ async def test_fetch_jobs_falls_back_to_description_when_html_missing(src):
 @respx.mock
 @pytest.mark.asyncio
 async def test_fetch_jobs_filters_by_since(src):
-    recent = _posting(1, "2026-05-05T12:00:00Z")
+    recent_iso = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    recent = _posting(1, recent_iso)
     old = _posting(2, "2025-01-01T00:00:00Z")
     respx.get(f"{LEVER_POSTINGS_BASE}/acme").mock(
         side_effect=[


### PR DESCRIPTION
## Summary
- update Mistral AI catalog entry from stale Ashby slug to live Lever slug
- make provider since-filter unit tests use runtime-relative recent timestamps instead of a fixed date that went stale

## Verification
- curl confirmed Ashby posting API for mistral returns 404
- curl confirmed Lever postings API for mistral returns 200 with postings
- uv run pytest tests/integration/test_catalog_live.py --catalog-live -q -k Mistral -> 1 passed, 99 deselected
- uv run pytest tests/integration/test_catalog_live.py --catalog-live -q -> 100 passed
- uv run pytest tests/unit/sources/test_ashby_board.py::test_fetch_jobs_filters_by_since tests/unit/sources/test_lever_postings.py::test_fetch_jobs_filters_by_since -q -> 2 passed
- uv run pytest tests/unit/ -v --cov=app --cov-report=term --cov-fail-under=39 -> 238 passed