### PR TITLE
Fix remote-only filtering for broad country hybrid matches

### DIFF
--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -31,6 +31,8 @@ OFFICE_ATTENDANCE_PATTERNS = (
     r"\bwork\s+from\b.{0,80}\b(?:office|onsite|on site)\b",
     r"\b(?:office|onsite|on site)\b.{0,80}\btwice\s+a\s+week\b",
     r"\btwice\s+a\s+week\b.{0,80}\b(?:office|onsite|on site)\b",
+    r"\bhybrid\s+(?:workplace|role|position|job|work)\b",
+    r"\b(?:workplace|role|position|job|work)\s+(?:is\s+)?hybrid\b",
     r"\bhybrid\s+schedule\b.{0,40}\b(?:requires?|required|must)\b",
     r"\b(?:requires?|required|must)\b.{0,40}\bhybrid\s+schedule\b",
     r"\bmust(?:\s+be)?\s+located\s+near\b",
@@ -402,7 +404,11 @@ def _real_target_locations(profile: ProfileLike) -> list[str]:
 
 def _is_remote_pseudo_location(location: str) -> bool:
     normalized = _normalize_text(location).strip()
-    return normalized == "remote" or normalized.startswith("remote ")
+    return (
+        normalized == "remote"
+        or normalized.startswith("remote ")
+        or normalized in {"united states", "usa", "us", "u s", "u s a"}
+    )
 
 
 def _is_explicitly_remote(job: JobLike) -> bool:

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -111,6 +111,59 @@ def test_remote_only_profile_rejects_onsite_description_despite_remote_metadata(
     assert "office attendance" in verdict.gap
 
 
+def test_remote_only_profile_rejects_hybrid_workplace_city_job_with_country_target():
+    profile = _profile(target_locations=["United States"], remote_ok=True)
+    job = SimpleNamespace(
+        location="Boston, Massachusetts, USA; New York, New York, USA",
+        workplace_type=None,
+        description=(
+            "At Datadog, we place value in our office culture - the relationships "
+            "and collaboration it builds and the creativity it brings to the table. "
+            "We operate as a hybrid workplace to ensure our Datadogs can create a "
+            "work-life harmony that best fits them."
+        ),
+        description_raw=None,
+    )
+
+    verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is True
+    assert "office attendance" in verdict.gap
+
+
+def test_country_target_does_not_allow_non_matching_office_location():
+    profile = _profile(target_locations=["United States"], remote_ok=True)
+    job = SimpleNamespace(
+        location="Remote - US",
+        workplace_type="remote",
+        description=(
+            "This United States role requires a minimum 3 days/week in the "
+            "Boston office."
+        ),
+        description_raw=None,
+    )
+
+    verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is True
+    assert "office attendance" in verdict.gap
+
+
+def test_remote_only_country_target_rejects_city_location_without_remote_evidence():
+    profile = _profile(target_locations=["United States"], remote_ok=True)
+    job = SimpleNamespace(
+        location="Boston, Massachusetts, USA; New York, New York, USA",
+        workplace_type=None,
+        description="Build enterprise systems and internal tools for sales engineers.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is True
+    assert "remote-only" in verdict.gap
+
+
 def test_remote_pseudo_location_is_not_office_target_location():
     profile = _profile(target_locations=["Remote"], remote_ok=True)
     job = SimpleNamespace(


### PR DESCRIPTION
## Summary
- reject hybrid workplace wording as deterministic office-attendance evidence
- treat broad US country targets as remote-region pseudo locations, not physical office allowlists
- add regressions for the Datadog-style false negative and city-location remote-only cases

## Tests
- env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/unit/test_remote_policy.py -q
- env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/unit/test_match_service.py tests/unit/test_match_handler.py -q
- env UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check app/services/remote_policy.py tests/unit/test_remote_policy.py

Note: integration handler tests requiring testcontainers could not run here because Docker socket access is unavailable in this sandbox.