### PR TITLE
Fix remote policy not-remote override

### DIFF
--- a/app/services/remote_policy.py
+++ b/app/services/remote_policy.py
@@ -410,6 +410,8 @@ def _is_explicitly_remote(job: JobLike) -> bool:
     workplace_type = _normalize_text(str(getattr(job, "workplace_type", None) or ""))
     description = _normalize_text(_job_description_text(job))
 
+    if _description_rejects_remote_work(description):
+        return False
     if _contains_token_phrase(workplace_type, "remote"):
         return True
     if _contains_token_phrase(location, "remote"):
@@ -417,15 +419,19 @@ def _is_explicitly_remote(job: JobLike) -> bool:
     return _description_has_remote_work_evidence(description)
 
 
-def _description_has_remote_work_evidence(normalized_text: str) -> bool:
-    if not normalized_text:
-        return False
+def _description_rejects_remote_work(normalized_text: str) -> bool:
     negative_patterns = (
-        r"\b(?:not|non|no)\s+remote\b",
+        r"\b(?:not|non|no)\s+(?:a\s+)?remote\b",
         r"\bremote\s+(?:work\s+)?(?:not|unavailable|unsupported)\b",
         r"\bdoes\s+not\s+(?:allow|support|offer)\s+remote\b",
     )
-    if any(re.search(pattern, normalized_text) is not None for pattern in negative_patterns):
+    return any(re.search(pattern, normalized_text) is not None for pattern in negative_patterns)
+
+
+def _description_has_remote_work_evidence(normalized_text: str) -> bool:
+    if not normalized_text:
+        return False
+    if _description_rejects_remote_work(normalized_text):
         return False
     positive_patterns = (
         r"\bremote\s+(?:role|position|job|work|employee|employees|team)\b",

--- a/tests/unit/test_remote_policy.py
+++ b/tests/unit/test_remote_policy.py
@@ -96,6 +96,21 @@ def test_remote_only_profile_allows_explicit_remote_location():
     assert verdict.hard_mismatch is False
 
 
+def test_remote_only_profile_rejects_not_remote_description_despite_remote_metadata():
+    profile = _profile(target_locations=[], remote_ok=True)
+    job = SimpleNamespace(
+        location="Remote - US",
+        workplace_type="remote",
+        description="This role is not a remote position.",
+        description_raw=None,
+    )
+
+    verdict = evaluate_remote_policy(profile, job)
+
+    assert verdict.hard_mismatch is True
+    assert "remote-only" in verdict.gap
+
+
 def test_remote_only_profile_rejects_onsite_description_despite_remote_metadata():
     profile = _profile(target_locations=[], remote_ok=True)
     job = SimpleNamespace(


### PR DESCRIPTION
## Summary
- Treat explicit not-remote job description language as stronger than provider remote metadata
- Add a regression test for remote-only profiles when metadata says remote but the JD says not remote

## Test Plan
- .venv/bin/pytest tests/unit/test_remote_policy.py tests/unit/test_match_service.py tests/unit/test_match_handler.py -q
- .venv/bin/ruff check app/services/remote_policy.py tests/unit/test_remote_policy.py