### PR TITLE
Hide stale job matches

### DIFF
--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -4,7 +4,7 @@ Match service — scores jobs against a profile and creates Application rows.
 
 import time
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import structlog
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from app.agents.matching_agent import ScoreResult
 
 log = structlog.get_logger()
+DISPLAY_JOB_MAX_AGE_DAYS = 10
 
 
 async def mark_for_rescore(profile_id: uuid.UUID, session: AsyncSession) -> int:
@@ -333,10 +334,12 @@ async def list_applications(
     limit: int = 20,
     offset: int = 0,
 ) -> list[tuple[Application, Job]]:
+    posted_cutoff = datetime.now(UTC) - timedelta(days=DISPLAY_JOB_MAX_AGE_DAYS)
     q = (
         select(Application, Job)
         .join(Job, Application.job_id == Job.id)
         .where(Application.profile_id == profile_id)
+        .where((col(Job.posted_at).is_(None)) | (Job.posted_at >= posted_cutoff))
     )
     if status:
         q = q.where(Application.status == status)

--- a/tests/unit/test_match_service.py
+++ b/tests/unit/test_match_service.py
@@ -7,6 +7,7 @@ the session and build_graph so no real DB or LLM is needed.
 
 import os
 import uuid
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -131,6 +132,30 @@ def test_remote_policy_does_not_cap_matching_target_location():
 
     assert adjusted.score == 0.92
     assert adjusted.gaps == original_gaps
+
+
+@pytest.mark.asyncio
+async def test_list_applications_filters_out_jobs_older_than_10_days():
+    from app.services.match_service import list_applications
+
+    profile_id = uuid.uuid4()
+    session = AsyncMock()
+    execute_result = MagicMock()
+    execute_result.tuples.return_value.all.return_value = []
+    session.execute.return_value = execute_result
+
+    before = datetime.now(UTC)
+    await list_applications(profile_id, session)
+    after = datetime.now(UTC)
+
+    stmt = session.execute.call_args.args[0]
+    compiled = stmt.compile(compile_kwargs={"literal_binds": False})
+    sql = str(compiled)
+    cutoff = compiled.params["posted_at_1"]
+
+    assert "jobs.posted_at IS NULL" in sql
+    assert "jobs.posted_at >= " in sql
+    assert before - timedelta(days=10) <= cutoff <= after - timedelta(days=10)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- hide match-list rows when the job has a known posting date older than 10 days
- keep jobs with unknown posting dates visible
- add a focused unit regression for the display-query cutoff

## Tests
- uv run --frozen pytest tests/unit/test_match_service.py
- uv run --frozen ruff check app/services/match_service.py tests/unit/test_match_service.py