### PR TITLE
Reduce Neon egress from sync and read paths

### DIFF
--- a/alembic/versions/d8f2c4a9b1e7_add_jobs_content_hash.py
+++ b/alembic/versions/d8f2c4a9b1e7_add_jobs_content_hash.py
@@ -1,0 +1,27 @@
+"""add jobs content hash
+
+Revision ID: d8f2c4a9b1e7
+Revises: 5a6b7c8d9e0f
+Create Date: 2026-05-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d8f2c4a9b1e7"
+down_revision: str | None = "5a6b7c8d9e0f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("content_hash", sa.String(), nullable=True))
+    op.create_index("ix_jobs_content_hash", "jobs", ["content_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_content_hash", table_name="jobs")
+    op.drop_column("jobs", "content_hash")

--- a/app/api/applications.py
+++ b/app/api/applications.py
@@ -34,28 +34,47 @@ async def list_applications(
     )
 
     result = []
-    for app, job in rows:
+    for (
+        app_id,
+        app_status,
+        generation_status,
+        match_score,
+        match_summary,
+        match_rationale,
+        match_strengths,
+        match_gaps,
+        created_at,
+        job_id,
+        title,
+        company_name,
+        location,
+        workplace_type,
+        salary,
+        contract_type,
+        apply_url,
+        posted_at,
+    ) in rows:
         result.append(
             {
-                "id": str(app.id),
-                "status": app.status,
-                "generation_status": app.generation_status,
-                "match_score": app.match_score,
-                "match_summary": app.match_summary,
-                "match_rationale": app.match_rationale,
-                "match_strengths": app.match_strengths,
-                "match_gaps": app.match_gaps,
-                "created_at": app.created_at,
+                "id": str(app_id),
+                "status": app_status,
+                "generation_status": generation_status,
+                "match_score": match_score,
+                "match_summary": match_summary,
+                "match_rationale": match_rationale,
+                "match_strengths": match_strengths,
+                "match_gaps": match_gaps,
+                "created_at": created_at,
                 "job": {
-                    "id": str(job.id),
-                    "title": job.title,
-                    "company_name": job.company_name,
-                    "location": job.location,
-                    "workplace_type": job.workplace_type,
-                    "salary": job.salary,
-                    "contract_type": job.contract_type,
-                    "apply_url": job.apply_url,
-                    "posted_at": job.posted_at,
+                    "id": str(job_id),
+                    "title": title,
+                    "company_name": company_name,
+                    "location": location,
+                    "workplace_type": workplace_type,
+                    "salary": salary,
+                    "contract_type": contract_type,
+                    "apply_url": apply_url,
+                    "posted_at": posted_at,
                 },
             }
         )
@@ -72,7 +91,22 @@ async def get_application(
     if not app or app.profile_id != profile.id:
         raise HTTPException(status_code=404, detail="Application not found")
 
-    job = await session.get(Job, app.job_id)
+    job = (
+        await session.execute(
+            select(
+                Job.id,
+                Job.title,
+                Job.company_name,
+                Job.location,
+                Job.workplace_type,
+                Job.salary,
+                Job.contract_type,
+                Job.description,
+                Job.apply_url,
+                Job.posted_at,
+            ).where(Job.id == app.job_id)
+        )
+    ).one_or_none()
     docs_result = await session.execute(
         select(GeneratedDocument).where(GeneratedDocument.application_id == app.id)
     )
@@ -91,17 +125,16 @@ async def get_application(
         "applied_at": app.applied_at,
         "created_at": app.created_at,
         "job": {
-            "id": str(job.id),
-            "title": job.title,
-            "company_name": job.company_name,
-            "location": job.location,
-            "workplace_type": job.workplace_type,
-            "salary": job.salary,
-            "contract_type": job.contract_type,
-            "description_raw": job.description_raw,
-            "description": job.description,
-            "apply_url": job.apply_url,
-            "posted_at": job.posted_at,
+            "id": str(job[0]),
+            "title": job[1],
+            "company_name": job[2],
+            "location": job[3],
+            "workplace_type": job[4],
+            "salary": job[5],
+            "contract_type": job[6],
+            "description": job[7],
+            "apply_url": job[8],
+            "posted_at": job[9],
         }
         if job
         else None,

--- a/app/config.py
+++ b/app/config.py
@@ -34,6 +34,7 @@ class Settings(BaseSettings):
     # `tick_deadline_seconds` bounds total wall time per tick.
     matching_max_per_profile_per_tick: int = 30
     matching_tick_deadline_seconds: int = 240
+    queue_depth_emit_interval_s: int = 60
 
     cors_allowed_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]
     # Absolute base URL Google sees as redirect_uri host. Cloud Run forwards HTTP to

--- a/app/main.py
+++ b/app/main.py
@@ -108,7 +108,10 @@ async def lifespan(app: FastAPI):
         from app.observability.queue_depth import _emit_queue_depth_forever
 
         depth_task = asyncio.create_task(
-            _emit_queue_depth_forever(get_session_factory()),
+            _emit_queue_depth_forever(
+                get_session_factory(),
+                interval_s=settings.queue_depth_emit_interval_s,
+            ),
             name="queue-depth-emitter",
         )
         try:

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -18,6 +18,7 @@ class Job(SQLModel, table=True):
     workplace_type: str | None = None  # remote, hybrid, onsite
     description_raw: str | None = None  # untouched source payload (HTML for greenhouse/lever/ashby)
     description: str | None = None  # canonical markdown, populated by html_cleaner at ingestion
+    content_hash: str | None = Field(default=None, index=True)
     salary: str | None = None
     contract_type: str | None = None
     apply_url: str

--- a/app/services/job_service.py
+++ b/app/services/job_service.py
@@ -1,8 +1,11 @@
 """Job CRUD and staleness logic."""
 
+import hashlib
+import json
 import uuid
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -24,6 +27,22 @@ async def _resolve_company_id(
     return result.scalar_one_or_none()
 
 
+def compute_job_content_hash(job_data: JobData) -> str:
+    payload = {
+        "title": job_data.title,
+        "company_name": job_data.company_name,
+        "location": job_data.location,
+        "workplace_type": job_data.workplace_type,
+        "description_raw": job_data.description_raw,
+        "salary": job_data.salary,
+        "contract_type": job_data.contract_type,
+        "apply_url": job_data.apply_url,
+        "posted_at": job_data.posted_at.isoformat() if job_data.posted_at else None,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
 async def upsert_job(
     job_data: JobData,
     source: str,
@@ -43,38 +62,81 @@ async def upsert_job(
     read-side gap from D4/D5. Without `slug`, company_id stays NULL on insert
     (legacy callers / tests not exercising the matcher).
     """
-    result = await session.execute(
-        select(Job).where(
-            Job.source == source,
-            Job.external_id == job_data.external_id,
+    content_hash = compute_job_content_hash(job_data)
+    existing_row = (
+        await session.execute(
+            select(
+                Job.id,
+                Job.content_hash,
+                Job.company_id,
+                Job.company_name,
+                Job.source,
+            ).where(
+                Job.source == source,
+                Job.external_id == job_data.external_id,
+            )
         )
-    )
-    existing = result.scalar_one_or_none()
+    ).one_or_none()
 
-    cleaned = clean_html_to_markdown(job_data.description_raw)
     company_id = await _resolve_company_id(source, slug, session)
 
-    if existing:
-        existing.title = job_data.title
-        existing.company_name = job_data.company_name
-        existing.description_raw = job_data.description_raw
-        existing.description = cleaned
-        existing.salary = job_data.salary
-        existing.contract_type = job_data.contract_type
-        existing.apply_url = job_data.apply_url
-        existing.location = job_data.location
-        existing.workplace_type = job_data.workplace_type
-        existing.is_active = True
-        existing.fetched_at = datetime.now(UTC)
-        # Backfill company_id on legacy rows whose canonical_name didn't match
-        # company_name at migration time. Only set, never clear — a slug-less
-        # caller must not unlink a previously-resolved Company.
-        if company_id is not None and existing.company_id != company_id:
-            existing.company_id = company_id
-        session.add(existing)
+    if existing_row is not None:
+        job_id, existing_hash, existing_company_id, existing_company_name, existing_source = (
+            existing_row
+        )
+        now = datetime.now(UTC)
+        values = {
+            "is_active": True,
+            "fetched_at": now,
+        }
+        resolved_company_id = existing_company_id
+        if company_id is not None and existing_company_id != company_id:
+            values["company_id"] = company_id
+            resolved_company_id = company_id
+
+        content_changed = existing_hash != content_hash
+        cleaned = None
+        if content_changed:
+            cleaned = clean_html_to_markdown(job_data.description_raw)
+            values.update(
+                {
+                    "title": job_data.title,
+                    "company_name": job_data.company_name,
+                    "description_raw": job_data.description_raw,
+                    "description": cleaned,
+                    "salary": job_data.salary,
+                    "contract_type": job_data.contract_type,
+                    "apply_url": job_data.apply_url,
+                    "location": job_data.location,
+                    "workplace_type": job_data.workplace_type,
+                    "posted_at": job_data.posted_at,
+                    "content_hash": content_hash,
+                }
+            )
+        await session.execute(update(Job).where(Job.id == job_id).values(**values))
         await session.commit()
-        await session.refresh(existing)
-        return existing, False
+        return (
+            Job(
+                id=job_id,
+                source=existing_source,
+                external_id=job_data.external_id,
+                title=job_data.title,
+                company_name=job_data.company_name if content_changed else existing_company_name,
+                company_id=resolved_company_id,
+                location=job_data.location,
+                workplace_type=job_data.workplace_type,
+                description_raw=job_data.description_raw if content_changed else None,
+                description=cleaned,
+                salary=job_data.salary,
+                contract_type=job_data.contract_type,
+                apply_url=job_data.apply_url,
+                posted_at=job_data.posted_at,
+                content_hash=content_hash,
+            ),
+            False,
+        )
+
+    cleaned = clean_html_to_markdown(job_data.description_raw)
 
     job = Job(
         source=source,
@@ -86,6 +148,7 @@ async def upsert_job(
         workplace_type=job_data.workplace_type,
         description_raw=job_data.description_raw,
         description=cleaned,
+        content_hash=content_hash,
         salary=job_data.salary,
         contract_type=job_data.contract_type,
         apply_url=job_data.apply_url,

--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -15,6 +15,7 @@ Two contracts here, by design (#80):
 The actual fetch and matching happen in the always-on worker.
 """
 
+import uuid
 from datetime import UTC, datetime
 
 import structlog
@@ -115,7 +116,7 @@ async def prune_and_enqueue(profile: UserProfile, session: AsyncSession) -> dict
 
 
 async def sync_active_profiles(session: AsyncSession) -> dict:
-    """Cron/scheduler sweep: apply the enqueue-only sync contract to active profiles."""
+    """Cron/scheduler sweep: enqueue distinct stale provider slugs for active profiles."""
     active_profiles = (
         (
             await session.execute(
@@ -126,20 +127,59 @@ async def sync_active_profiles(session: AsyncSession) -> dict:
         .all()
     )
 
+    pruned_by_profile: dict[uuid.UUID, list[str]] = {}
+    for profile in active_profiles:
+        pruned_by_profile[profile.id] = await _prune_invalid_provider_slugs(profile, session)
+
+    stale_by_profile = await slug_registry_service.list_stale_for_active_profiles(
+        session,
+        ttl_hours=6,
+    )
+
+    pairs_by_profile: dict[uuid.UUID, list[tuple[str, str]]] = {}
+    distinct_pairs: dict[tuple[str, str], str] = {}
+    for profile_id, provider, slug in stale_by_profile:
+        pairs_by_profile.setdefault(profile_id, []).append((provider, slug))
+        distinct_pairs.setdefault((provider, slug), slug)
+
     enqueued: list[str] = []
-    pruned = 0
+    enqueued_pairs: set[tuple[str, str]] = set()
+    for (provider, slug), display_slug in distinct_pairs.items():
+        row_id = await enqueue(
+            session,
+            job_type="fetch-slug",
+            payload=FetchSlugPayload(provider=provider, slug=slug).model_dump(),
+            dedupe_key=f"fetch-slug:{provider}:{slug}",
+        )
+        if row_id is not None:
+            enqueued.append(display_slug)
+            enqueued_pairs.add((provider, slug))
+
+    now = datetime.now(UTC)
     profiles_enqueued = 0
     for profile in active_profiles:
-        summary = await prune_and_enqueue(profile, session)
-        queued_slugs = list(summary["queued_slugs"])
-        if queued_slugs:
+        profile_slugs = [
+            slug
+            for provider, slug in pairs_by_profile.get(profile.id, [])
+            if (provider, slug) in enqueued_pairs
+        ]
+        profile.last_sync_requested_at = now
+        profile.last_sync_summary = {
+            "queued_slugs": profile_slugs,
+            "matched_now": 0,
+            "pruned_slugs": pruned_by_profile.get(profile.id, []),
+        }
+        if profile_slugs:
             profiles_enqueued += 1
-            enqueued.extend(queued_slugs)
-        pruned += len(summary["pruned_slugs"])
+        else:
+            profile.last_sync_completed_at = now
+        session.add(profile)
+
+    await session.commit()
 
     return {
         "enqueued": enqueued,
-        "pruned": pruned,
+        "pruned": sum(len(values) for values in pruned_by_profile.values()),
         "active_profiles": len(active_profiles),
         "profiles_enqueued": profiles_enqueued,
     }

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -45,6 +45,19 @@ ApplicationListRow = tuple[
     datetime | None,
 ]
 
+JobScoreRow = tuple[
+    uuid.UUID,
+    str,
+    str,
+    str,
+    str,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+]
+
 
 async def mark_for_rescore(profile_id: uuid.UUID, session: AsyncSession) -> int:
     """Clear eligible scored applications and enqueue match work for re-scoring.
@@ -218,20 +231,40 @@ async def score_and_match(
         )
         matched_ids = {row[0] for row in matched_result.all()}
 
-        candidates_q = (
-            select(Job)
-            .where(
-                Job.is_active.is_(True),
-                Job.company_id.in_(company_ids),
-            )
-            .order_by(Job.posted_at.desc().nullslast(), Job.fetched_at.desc())
+        candidates_q = build_score_candidate_query(
+            company_ids=company_ids,
+            matched_ids=matched_ids,
+            limit=settings.matching_jobs_per_batch,
         )
-        if matched_ids:
-            candidates_q = candidates_q.where(Job.id.notin_(matched_ids))
-        candidates_q = candidates_q.limit(settings.matching_jobs_per_batch)
-
-        all_jobs_result = await session.execute(candidates_q)
-        jobs = list(all_jobs_result.scalars().all())
+        candidate_rows: list[JobScoreRow] = list(
+            (await session.execute(candidates_q)).tuples().all()
+        )
+        jobs = [
+            Job(
+                id=job_id,
+                source=source,
+                external_id=external_id,
+                title=title,
+                company_name=company_name,
+                location=location,
+                workplace_type=workplace_type,
+                description=description,
+                description_raw=description_raw,
+                apply_url=apply_url,
+            )
+            for (
+                job_id,
+                source,
+                external_id,
+                title,
+                company_name,
+                location,
+                workplace_type,
+                description,
+                description_raw,
+                apply_url,
+            ) in candidate_rows
+        ]
 
     if not jobs:
         return []
@@ -406,4 +439,35 @@ def build_application_list_query(
             q = q.where(col(Application.match_score).is_not(None))
     if min_score is not None:
         q = q.where(Application.match_score >= min_score)
+    return q
+
+
+def build_score_candidate_query(
+    *,
+    company_ids: list[uuid.UUID],
+    matched_ids: set[uuid.UUID],
+    limit: int,
+):
+    q = (
+        select(
+            Job.id,
+            Job.source,
+            Job.external_id,
+            Job.title,
+            Job.company_name,
+            Job.location,
+            Job.workplace_type,
+            Job.description,
+            Job.description_raw,
+            Job.apply_url,
+        )
+        .where(
+            Job.is_active.is_(True),
+            col(Job.company_id).in_(company_ids),
+        )
+        .order_by(Job.posted_at.desc().nullslast(), Job.fetched_at.desc())
+        .limit(limit)
+    )
+    if matched_ids:
+        q = q.where(col(Job.id).notin_(matched_ids))
     return q

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -24,6 +24,27 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger()
 
+ApplicationListRow = tuple[
+    uuid.UUID,
+    str,
+    str,
+    float | None,
+    str | None,
+    str | None,
+    list[str],
+    list[str],
+    datetime,
+    uuid.UUID,
+    str,
+    str,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str,
+    datetime | None,
+]
+
 
 async def mark_for_rescore(profile_id: uuid.UUID, session: AsyncSession) -> int:
     """Clear eligible scored applications and enqueue match work for re-scoring.
@@ -332,18 +353,12 @@ async def list_applications(
     min_score: float | None = None,
     limit: int = 20,
     offset: int = 0,
-) -> list[tuple[Application, Job]]:
-    q = (
-        select(Application, Job)
-        .join(Job, Application.job_id == Job.id)
-        .where(Application.profile_id == profile_id)
+) -> list[ApplicationListRow]:
+    q = build_application_list_query(
+        profile_id,
+        status=status,
+        min_score=min_score,
     )
-    if status:
-        q = q.where(Application.status == status)
-        if status == "pending_review":
-            q = q.where(col(Application.match_score).is_not(None))
-    if min_score is not None:
-        q = q.where(Application.match_score >= min_score)
     q = q.order_by(
         Application.match_score.desc().nullslast(),
         Job.posted_at.desc().nullslast(),
@@ -353,3 +368,42 @@ async def list_applications(
     q = q.limit(limit).offset(offset)
     result = await session.execute(q)
     return list(result.tuples().all())
+
+
+def build_application_list_query(
+    profile_id: uuid.UUID,
+    *,
+    status: str | None,
+    min_score: float | None,
+):
+    q = (
+        select(
+            Application.id,
+            Application.status,
+            Application.generation_status,
+            Application.match_score,
+            Application.match_summary,
+            Application.match_rationale,
+            Application.match_strengths,
+            Application.match_gaps,
+            Application.created_at,
+            Job.id,
+            Job.title,
+            Job.company_name,
+            Job.location,
+            Job.workplace_type,
+            Job.salary,
+            Job.contract_type,
+            Job.apply_url,
+            Job.posted_at,
+        )
+        .join(Job, Application.job_id == Job.id)
+        .where(Application.profile_id == profile_id)
+    )
+    if status:
+        q = q.where(Application.status == status)
+        if status == "pending_review":
+            q = q.where(col(Application.match_score).is_not(None))
+    if min_score is not None:
+        q = q.where(Application.match_score >= min_score)
+    return q

--- a/app/services/slug_registry_service.py
+++ b/app/services/slug_registry_service.py
@@ -1,7 +1,9 @@
 """Slug-level fetch state. One row per (source, slug), shared across users."""
 
+import uuid
 from datetime import UTC, datetime, timedelta
 
+import sqlalchemy as sa
 import structlog
 from sqlalchemy import and_, or_
 from sqlalchemy.dialects.postgresql import insert
@@ -119,6 +121,52 @@ async def list_stale_for_profile(
                 pairs.append(key)
                 seen.add(key)
     return pairs
+
+
+async def list_stale_for_active_profiles(
+    session: AsyncSession,
+    *,
+    ttl_hours: int = 6,
+) -> list[tuple[uuid.UUID, str, str]]:
+    """Return stale provider slugs by active profile without per-slug lookups."""
+    result = await session.execute(
+        sa.text(
+            """
+            WITH active_companies AS (
+              SELECT id AS profile_id, unnest(target_company_ids) AS company_id
+              FROM user_profiles
+              WHERE search_active IS TRUE
+                AND target_company_ids IS NOT NULL
+            ),
+            provider_slugs AS (
+              SELECT DISTINCT
+                     ac.profile_id,
+                     kv.key::text AS source,
+                     kv.value::text AS slug
+              FROM active_companies ac
+              JOIN companies c ON c.id = ac.company_id
+              CROSS JOIN LATERAL jsonb_each_text(c.provider_slugs) AS kv(key, value)
+              WHERE c.unfollowable IS FALSE
+                AND kv.value IS NOT NULL
+                AND kv.value <> ''
+            )
+            SELECT ps.profile_id, ps.source, ps.slug
+            FROM provider_slugs ps
+            LEFT JOIN slug_fetches sf
+              ON sf.source = ps.source
+             AND sf.slug = ps.slug
+            WHERE COALESCE(sf.is_invalid, false) IS FALSE
+              AND (
+                sf.source IS NULL
+                OR sf.last_fetched_at IS NULL
+                OR sf.last_fetched_at < now() - make_interval(hours => :ttl_hours)
+              )
+            ORDER BY ps.profile_id, ps.source, ps.slug
+            """
+        ),
+        {"ttl_hours": ttl_hours},
+    )
+    return [(row[0], row[1], row[2]) for row in result.all()]
 
 
 async def prune_invalid_for_profile(profile, session: AsyncSession) -> int:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -61,8 +61,55 @@ Cron endpoints are protected by `X-Cron-Secret` and enqueue work only:
   letters.
 - `POST /internal/cron/maintenance` enqueues one daily maintenance job.
 
+### Cron Cadence
+
+The job-search API expects these production trigger cadences:
+
+| Endpoint | Cadence | Reason |
+|---|---|---|
+| `POST /internal/cron/sync` | every 6 hours | provider slug freshness TTL is 6 hours |
+| `POST /internal/cron/generation-reconcile` | every 30 minutes | repairs stuck cover-letter generation requests |
+| `POST /internal/cron/maintenance` | daily | stale-job marking and retention cleanup |
+
+Do not run `/internal/cron/sync` every 15 minutes. That cadence repeatedly scans
+active profiles, companies, and slug freshness while producing no new work
+inside the 6-hour TTL.
+
 `app.worker` owns queue claiming, lease timeouts, retries, terminal failure
 handling, and finalization.
+
+## Neon Egress Measurement
+
+Neon network transfer is data sent from Postgres through Neon's proxy to clients.
+The database can be small at rest while still exhausting transfer allowance when
+hot paths repeatedly fetch wide rows.
+
+Before a measurement window:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+SELECT pg_stat_statements_reset();
+```
+
+After at least 24 hours of representative traffic:
+
+```bash
+psql "$DATABASE_URL" -f scripts/neon_egress_diagnostics.sql
+```
+
+Interpretation:
+
+- high `rows` plus wide tables such as `jobs` means likely high transfer
+- high `calls` means polling, cron, or auth loops may dominate even with small rows
+- `pg_stat_statements` does not report exact bytes; compare rows, calls, and table stats before and after changes
+
+Expected healthy production cadence:
+
+- `/internal/cron/sync`: about 4/day
+- `/internal/cron/generation-reconcile`: about 48/day
+- `/internal/cron/maintenance`: about 1/day
+- `/api/sync/status`: only while an authenticated user has live sync/match work
+- `/api/status`: cached on the frontend, not a per-component minute loop
 
 ## Local Verification Before Merge
 

--- a/docs/superpowers/plans/2026-05-21-neon-egress-reduction.md
+++ b/docs/superpowers/plans/2026-05-21-neon-egress-reduction.md
@@ -1,0 +1,1192 @@
+# Neon Egress Reduction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce routine Neon network transfer from cron, polling, list endpoints, and repeated worker reads while preserving full raw job descriptions in storage.
+
+**Architecture:** Add measurement first, then remove wide-row reads from hot paths, make sync/upsert work set-based and change-aware, and stop frontend polling when auth is no longer valid. Keep raw provider descriptions in `jobs.description_raw`; reduce transfer by narrowing queries and response payloads, not by truncating stored data.
+
+**Tech Stack:** FastAPI, SQLModel/SQLAlchemy async sessions, Alembic, Postgres/Neon, React, TanStack Query, Vitest, pytest.
+
+---
+
+## File Structure
+
+- Create `scripts/neon_egress_diagnostics.sql`: reusable operator SQL for `pg_stat_statements` and table stats.
+- Modify `docs/DEPLOYMENT.md`: runbook for enabling/resetting stats and reading transfer signals.
+- Modify `app/services/slug_registry_service.py`: add set-based active-profile stale slug discovery.
+- Modify `app/services/job_sync_service.py`: use the set-based helper for cron sync and keep manual profile sync stable.
+- Modify `app/api/internal_cron.py`: keep `/internal/cron/sync` response shape stable.
+- Modify `app/services/match_service.py`: add a narrow application list projection.
+- Modify `app/api/applications.py`: serialize list rows from the narrow projection and remove raw descriptions from detail by default.
+- Modify `frontend/src/api/client.ts`: handle 401 globally and align application types with the new payload contract.
+- Modify `frontend/src/lib/useSyncControl.ts`: add 401 stop behavior and live-state backoff.
+- Modify `frontend/src/components/BudgetBanner.tsx`: replace unconditional interval polling with React Query caching.
+- Modify `app/models/job.py`: add nullable `content_hash`.
+- Create an Alembic migration adding `jobs.content_hash`.
+- Modify `app/services/job_service.py`: compute content hashes and skip wide updates for unchanged postings.
+- Modify `app/observability/queue_depth.py` and `app/config.py`: make queue-depth interval configurable.
+- Update tests in `tests/integration/`, `tests/unit/`, and `frontend/src/` to lock the egress-sensitive behavior.
+
+## Scope Notes
+
+The production cron schedule appears to be owned outside this repository by the Hetzner/supercronic deployment. This plan still reduces this repo's cron work by making active-profile stale discovery set-based. The external schedule must also be changed from roughly every 15 minutes to every 6 hours in the deployment repo/runbook to satisfy the spec's production acceptance criterion.
+
+## Task 1: Measurement Runbook
+
+**Files:**
+- Create: `scripts/neon_egress_diagnostics.sql`
+- Modify: `docs/DEPLOYMENT.md`
+
+- [ ] **Step 1: Add the diagnostic SQL script**
+
+Create `scripts/neon_egress_diagnostics.sql` with:
+
+```sql
+-- Neon egress diagnostics.
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/neon_egress_diagnostics.sql
+--
+-- These reports rank query candidates by rows and call frequency. They are not
+-- exact byte-level network-transfer reports.
+
+\echo 'pg_stat_statements availability'
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_extension
+  WHERE extname = 'pg_stat_statements'
+) AS pg_stat_statements_installed;
+
+\echo 'top total returned rows'
+SELECT query, calls, rows AS total_rows, rows / NULLIF(calls, 0) AS avg_rows_per_call
+FROM pg_stat_statements
+WHERE calls > 0
+ORDER BY rows DESC
+LIMIT 20;
+
+\echo 'top rows per call'
+SELECT query, calls, rows AS total_rows, rows / NULLIF(calls, 0) AS avg_rows_per_call
+FROM pg_stat_statements
+WHERE calls > 0
+ORDER BY avg_rows_per_call DESC NULLS LAST
+LIMIT 20;
+
+\echo 'most frequent queries'
+SELECT query, calls, rows AS total_rows, rows / NULLIF(calls, 0) AS avg_rows_per_call
+FROM pg_stat_statements
+WHERE calls > 0
+ORDER BY calls DESC
+LIMIT 20;
+
+\echo 'longest total execution time'
+SELECT query, calls, rows AS total_rows,
+       round(total_exec_time::numeric, 2) AS total_exec_time_ms
+FROM pg_stat_statements
+WHERE calls > 0
+ORDER BY total_exec_time DESC
+LIMIT 20;
+
+\echo 'hot table stats'
+SELECT relname,
+       n_live_tup,
+       n_dead_tup,
+       seq_scan,
+       seq_tup_read,
+       idx_scan,
+       idx_tup_fetch,
+       n_tup_ins,
+       n_tup_upd,
+       n_tup_del,
+       pg_size_pretty(pg_total_relation_size(relid)) AS total_size
+FROM pg_stat_user_tables
+ORDER BY seq_tup_read + idx_tup_fetch DESC
+LIMIT 30;
+```
+
+- [ ] **Step 2: Add the deployment runbook section**
+
+Append this section to `docs/DEPLOYMENT.md`:
+
+```markdown
+## Neon Egress Measurement
+
+Neon network transfer is data sent from Postgres through Neon's proxy to clients.
+The database can be small at rest while still exhausting transfer allowance when
+hot paths repeatedly fetch wide rows.
+
+Before a measurement window:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+SELECT pg_stat_statements_reset();
+```
+
+After at least 24 hours of representative traffic:
+
+```bash
+psql "$DATABASE_URL" -f scripts/neon_egress_diagnostics.sql
+```
+
+Interpretation:
+
+- high `rows` plus wide tables such as `jobs` means likely high transfer
+- high `calls` means polling, cron, or auth loops may dominate even with small rows
+- `pg_stat_statements` does not report exact bytes; compare rows, calls, and table stats before and after changes
+
+Expected healthy production cadence:
+
+- `/internal/cron/sync`: about 4/day
+- `/internal/cron/generation-reconcile`: about 48/day
+- `/internal/cron/maintenance`: about 1/day
+- `/api/sync/status`: only while an authenticated user has live sync/match work
+- `/api/status`: cached on the frontend, not a per-component minute loop
+```
+
+- [ ] **Step 3: Run a docs/script smoke check**
+
+Run:
+
+```bash
+test -f scripts/neon_egress_diagnostics.sql
+rg -n "Neon Egress Measurement|pg_stat_statements_reset|neon_egress_diagnostics" docs/DEPLOYMENT.md scripts/neon_egress_diagnostics.sql
+```
+
+Expected: all three search terms appear.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/DEPLOYMENT.md scripts/neon_egress_diagnostics.sql
+git commit -m "docs: add Neon egress measurement runbook"
+```
+
+## Task 2: Set-Based Cron Stale Slug Discovery
+
+**Files:**
+- Modify: `app/services/slug_registry_service.py`
+- Modify: `app/services/job_sync_service.py`
+- Modify: `tests/integration/test_job_sync.py`
+- Modify: `tests/integration/test_cron_sync_enqueues.py`
+
+- [ ] **Step 1: Add failing service coverage for shared slug dedupe**
+
+Add this test to `tests/integration/test_job_sync.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_sync_active_profiles_deduplicates_shared_provider_slugs(db_session):
+    from datetime import timedelta
+
+    from app.models.company import Company
+    from app.models.slug_fetch import SlugFetch
+    from app.models.user import User
+    from app.models.user_profile import UserProfile
+    from app.models.work_queue import WorkQueue
+
+    company = Company(
+        canonical_name="Shared Co",
+        normalized_key=f"shared-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "shared-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.add(company)
+    await db_session.commit()
+    await db_session.refresh(company)
+
+    users = [
+        User(id=uuid.uuid4(), email=f"shared-{i}-{uuid.uuid4()}@test.com")
+        for i in range(2)
+    ]
+    db_session.add_all(users)
+    await db_session.commit()
+    db_session.add_all(
+        [
+            UserProfile(
+                user_id=users[0].id,
+                email=users[0].email,
+                search_active=True,
+                target_company_ids=[company.id],
+            ),
+            UserProfile(
+                user_id=users[1].id,
+                email=users[1].email,
+                search_active=True,
+                target_company_ids=[company.id],
+            ),
+            SlugFetch(
+                source="greenhouse",
+                slug="shared-co",
+                last_fetched_at=datetime.now(UTC) - timedelta(hours=7),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    result = await job_sync_service.sync_active_profiles(db_session)
+
+    assert result["active_profiles"] == 2
+    assert result["profiles_enqueued"] == 2
+    assert result["enqueued"] == ["shared-co"]
+    rows = (
+        (
+            await db_session.execute(
+                select(WorkQueue).where(WorkQueue.job_type == "fetch-slug")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [row.dedupe_key for row in rows] == ["fetch-slug:greenhouse:shared-co"]
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_job_sync.py::test_sync_active_profiles_deduplicates_shared_provider_slugs -v
+```
+
+Expected before implementation: FAIL because the current cron sync loops profile-by-profile and reports duplicate `enqueued` values or repeats stale-slug lookup work.
+
+- [ ] **Step 3: Add set-based active-profile stale query**
+
+In `app/services/slug_registry_service.py`, add:
+
+```python
+async def list_stale_for_active_profiles(
+    session: AsyncSession,
+    *,
+    ttl_hours: int = 6,
+) -> list[tuple[str, str]]:
+    """Return distinct stale provider slugs followed by active profiles."""
+    result = await session.execute(
+        sa.text(
+            """
+            WITH active_companies AS (
+              SELECT DISTINCT unnest(target_company_ids) AS company_id
+              FROM user_profiles
+              WHERE search_active IS TRUE
+                AND target_company_ids IS NOT NULL
+            ),
+            provider_slugs AS (
+              SELECT DISTINCT
+                     kv.key::text AS source,
+                     kv.value::text AS slug
+              FROM active_companies ac
+              JOIN companies c ON c.id = ac.company_id
+              CROSS JOIN LATERAL jsonb_each_text(c.provider_slugs) AS kv(key, value)
+              WHERE c.unfollowable IS FALSE
+                AND kv.value IS NOT NULL
+                AND kv.value <> ''
+            )
+            SELECT ps.source, ps.slug
+            FROM provider_slugs ps
+            LEFT JOIN slug_fetches sf
+              ON sf.source = ps.source
+             AND sf.slug = ps.slug
+            WHERE COALESCE(sf.is_invalid, false) IS FALSE
+              AND (
+                sf.source IS NULL
+                OR sf.last_fetched_at IS NULL
+                OR sf.last_fetched_at < now() - make_interval(hours => :ttl_hours)
+              )
+            ORDER BY ps.source, ps.slug
+            """
+        ),
+        {"ttl_hours": ttl_hours},
+    )
+    return [(row[0], row[1]) for row in result.all()]
+```
+
+Also add `import sqlalchemy as sa` at the top of the file.
+
+- [ ] **Step 4: Use the set-based helper in cron sync**
+
+In `app/services/job_sync_service.py`, rewrite `sync_active_profiles()` so it:
+
+```python
+async def sync_active_profiles(session: AsyncSession) -> dict:
+    """Cron/scheduler sweep: enqueue distinct stale provider slugs for active profiles."""
+    active_profiles = (
+        (
+            await session.execute(
+                select(UserProfile).where(col(UserProfile.search_active).is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    stale = await slug_registry_service.list_stale_for_active_profiles(
+        session,
+        ttl_hours=6,
+    )
+
+    enqueued: list[str] = []
+    for provider, slug in stale:
+        row_id = await enqueue(
+            session,
+            job_type="fetch-slug",
+            payload=FetchSlugPayload(provider=provider, slug=slug).model_dump(),
+            dedupe_key=f"fetch-slug:{provider}:{slug}",
+        )
+        if row_id is not None:
+            enqueued.append(slug)
+
+    now = datetime.now(UTC)
+    profiles_enqueued = 0
+    for profile in active_profiles:
+        profile.last_sync_requested_at = now
+        profile.last_sync_summary = {
+            "queued_slugs": enqueued,
+            "matched_now": 0,
+            "pruned_slugs": [],
+        }
+        if enqueued:
+            profiles_enqueued += 1
+        else:
+            profile.last_sync_completed_at = now
+        session.add(profile)
+
+    await session.commit()
+    return {
+        "enqueued": enqueued,
+        "pruned": 0,
+        "active_profiles": len(active_profiles),
+        "profiles_enqueued": profiles_enqueued,
+    }
+```
+
+Keep `_prune_invalid_provider_slugs()` and `prune_and_enqueue()` unchanged for manual per-profile sync in this task.
+
+- [ ] **Step 5: Run targeted sync tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_job_sync.py::test_sync_active_profiles_uses_shared_enqueue_contract tests/integration/test_job_sync.py::test_sync_active_profiles_deduplicates_shared_provider_slugs tests/integration/test_cron_sync_enqueues.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/slug_registry_service.py app/services/job_sync_service.py tests/integration/test_job_sync.py tests/integration/test_cron_sync_enqueues.py
+git commit -m "refactor(sync): dedupe stale slug cron discovery"
+```
+
+## Task 3: Narrow Application List And Detail Payloads
+
+**Files:**
+- Modify: `app/services/match_service.py`
+- Modify: `app/api/applications.py`
+- Modify: `frontend/src/api/client.ts`
+- Modify: `tests/integration/test_applications_api_summary.py`
+- Modify: `tests/integration/test_jobs_endpoint.py`
+- Modify: `frontend/src/pages/ApplicationReview.test.tsx`
+- Modify: `frontend/src/components/feed/MatchCard.test.tsx`
+
+- [ ] **Step 1: Add failing backend tests for list/detail description behavior**
+
+In `tests/integration/test_applications_api_summary.py`, add tests equivalent to:
+
+```python
+@pytest.mark.asyncio
+async def test_list_applications_omits_job_descriptions(client, auth_headers, db_session, seeded_user):
+    from app.models.application import Application
+    from app.models.job import Job
+
+    _, profile = seeded_user
+    job = Job(
+        source="greenhouse",
+        external_id="wide-list-1",
+        title="Wide Row",
+        company_name="Wide Co",
+        description_raw="<p>raw wide payload</p>",
+        description="clean wide payload",
+        apply_url="https://example.com/apply",
+    )
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)
+    db_session.add(Application(job_id=job.id, profile_id=profile.id, match_score=0.9))
+    await db_session.commit()
+
+    response = await client.get("/api/applications", headers=auth_headers)
+    assert response.status_code == 200
+    body = response.json()
+    returned = next(row for row in body if row["job"]["id"] == str(job.id))
+    assert "description_raw" not in returned["job"]
+    assert "description" not in returned["job"]
+
+
+@pytest.mark.asyncio
+async def test_application_detail_omits_raw_description_by_default(
+    client, auth_headers, db_session, seeded_user
+):
+    from app.models.application import Application
+    from app.models.job import Job
+
+    _, profile = seeded_user
+    job = Job(
+        source="greenhouse",
+        external_id="detail-raw-1",
+        title="Detail Row",
+        company_name="Detail Co",
+        description_raw="<p>raw html</p>",
+        description="clean markdown",
+        apply_url="https://example.com/apply",
+    )
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)
+    app = Application(job_id=job.id, profile_id=profile.id, match_score=0.9)
+    db_session.add(app)
+    await db_session.commit()
+    await db_session.refresh(app)
+
+    response = await client.get(f"/api/applications/{app.id}", headers=auth_headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["job"]["description"] == "clean markdown"
+    assert "description_raw" not in body["job"]
+```
+
+- [ ] **Step 2: Run the failing backend tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_applications_api_summary.py::test_list_applications_omits_job_descriptions tests/integration/test_applications_api_summary.py::test_application_detail_omits_raw_description_by_default -v
+```
+
+Expected before implementation: FAIL because current responses include descriptions.
+
+- [ ] **Step 3: Add a narrow list projection**
+
+In `app/services/match_service.py`, add a typed alias near `list_applications()`:
+
+```python
+ApplicationListRow = tuple[
+    uuid.UUID,
+    str,
+    str,
+    float | None,
+    str | None,
+    str | None,
+    list[str],
+    list[str],
+    datetime,
+    uuid.UUID,
+    str,
+    str,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str,
+    datetime | None,
+]
+```
+
+Then replace `select(Application, Job)` in `list_applications()` with explicit columns:
+
+```python
+q = (
+    select(
+        Application.id,
+        Application.status,
+        Application.generation_status,
+        Application.match_score,
+        Application.match_summary,
+        Application.match_rationale,
+        Application.match_strengths,
+        Application.match_gaps,
+        Application.created_at,
+        Job.id,
+        Job.title,
+        Job.company_name,
+        Job.location,
+        Job.workplace_type,
+        Job.salary,
+        Job.contract_type,
+        Job.apply_url,
+        Job.posted_at,
+    )
+    .join(Job, Application.job_id == Job.id)
+    .where(Application.profile_id == profile_id)
+)
+```
+
+Return `list(result.tuples().all())`.
+
+- [ ] **Step 4: Update list serialization**
+
+In `app/api/applications.py`, update `list_applications()` to unpack the projected tuple and build the same card payload without `description_raw` or `description`:
+
+```python
+for (
+    app_id,
+    app_status,
+    generation_status,
+    match_score,
+    match_summary,
+    match_rationale,
+    match_strengths,
+    match_gaps,
+    created_at,
+    job_id,
+    title,
+    company_name,
+    location,
+    workplace_type,
+    salary,
+    contract_type,
+    apply_url,
+    posted_at,
+) in rows:
+    result.append(
+        {
+            "id": str(app_id),
+            "status": app_status,
+            "generation_status": generation_status,
+            "match_score": match_score,
+            "match_summary": match_summary,
+            "match_rationale": match_rationale,
+            "match_strengths": match_strengths,
+            "match_gaps": match_gaps,
+            "created_at": created_at,
+            "job": {
+                "id": str(job_id),
+                "title": title,
+                "company_name": company_name,
+                "location": location,
+                "workplace_type": workplace_type,
+                "salary": salary,
+                "contract_type": contract_type,
+                "apply_url": apply_url,
+                "posted_at": posted_at,
+            },
+        }
+    )
+```
+
+In `get_application()`, remove `"description_raw": job.description_raw` from the job object.
+
+- [ ] **Step 5: Update frontend types**
+
+In `frontend/src/api/client.ts`, change `Job` to:
+
+```ts
+export interface Job {
+  id: string
+  title: string
+  company_name: string
+  location: string | null
+  workplace_type: string | null
+  salary: string | null
+  contract_type: string | null
+  description?: string | null
+  apply_url: string
+  posted_at: string | null
+}
+```
+
+Remove `description_raw` from the public client type.
+
+- [ ] **Step 6: Update frontend fixtures**
+
+Update tests that include mock jobs to remove `description_raw`. For detail-page fixtures, keep `description`. For feed/card fixtures, omit both description fields.
+
+- [ ] **Step 7: Run targeted backend/frontend tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_applications_api_summary.py tests/integration/test_jobs_endpoint.py -v
+cd frontend && npm test -- ApplicationReview.test.tsx MatchCard.test.tsx client.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/services/match_service.py app/api/applications.py frontend/src/api/client.ts tests/integration/test_applications_api_summary.py tests/integration/test_jobs_endpoint.py frontend/src/pages/ApplicationReview.test.tsx frontend/src/components/feed/MatchCard.test.tsx
+git commit -m "refactor(applications): avoid wide job payloads"
+```
+
+## Task 4: Change-Aware Job Upserts
+
+**Files:**
+- Modify: `app/models/job.py`
+- Create: `alembic/versions/d8f2c4a9b1e7_add_jobs_content_hash.py`
+- Modify: `app/services/job_service.py`
+- Modify: `tests/integration/test_job_sync.py`
+
+- [ ] **Step 1: Add failing upsert tests**
+
+Add these tests to `tests/integration/test_job_sync.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_upsert_job_keeps_description_fields_when_payload_unchanged(db_session):
+    data = make_job_data(external_id="stable-1", title="Stable Engineer")
+    first, created = await upsert_job(data, "greenhouse", db_session)
+    assert created is True
+    first_hash = first.content_hash
+    first_description = first.description
+    first_raw = first.description_raw
+
+    second, created = await upsert_job(data, "greenhouse", db_session)
+
+    assert created is False
+    assert second.id == first.id
+    assert second.content_hash == first_hash
+    assert second.description == first_description
+    assert second.description_raw == first_raw
+
+
+@pytest.mark.asyncio
+async def test_upsert_job_changes_content_hash_when_description_changes(db_session):
+    data = make_job_data(external_id="stable-2", title="Stable Engineer")
+    first, _ = await upsert_job(data, "greenhouse", db_session)
+
+    changed = make_job_data(external_id="stable-2", title="Stable Engineer")
+    changed.description_raw = "A different role description."
+    second, created = await upsert_job(changed, "greenhouse", db_session)
+
+    assert created is False
+    assert second.id == first.id
+    assert second.content_hash != first.content_hash
+    assert second.description_raw == "A different role description."
+    assert "different role" in (second.description or "")
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_job_sync.py::test_upsert_job_keeps_description_fields_when_payload_unchanged tests/integration/test_job_sync.py::test_upsert_job_changes_content_hash_when_description_changes -v
+```
+
+Expected before implementation: FAIL because `Job` has no `content_hash`.
+
+- [ ] **Step 3: Add the model column**
+
+In `app/models/job.py`, add after `description`:
+
+```python
+    content_hash: str | None = Field(default=None, index=True)
+```
+
+- [ ] **Step 4: Add Alembic migration**
+
+Create `alembic/versions/d8f2c4a9b1e7_add_jobs_content_hash.py` with:
+
+```python
+"""add jobs content hash
+
+Revision ID: d8f2c4a9b1e7
+Revises: 5a6b7c8d9e0f
+Create Date: 2026-05-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d8f2c4a9b1e7"
+down_revision: str | None = "5a6b7c8d9e0f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("content_hash", sa.String(), nullable=True))
+    op.create_index("ix_jobs_content_hash", "jobs", ["content_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_content_hash", table_name="jobs")
+    op.drop_column("jobs", "content_hash")
+```
+
+Keep `down_revision` aligned with the current repository head shown above.
+
+- [ ] **Step 5: Add hash helper and narrow unchanged path**
+
+In `app/services/job_service.py`, add imports:
+
+```python
+import hashlib
+import json
+```
+
+Add helper:
+
+```python
+def compute_job_content_hash(job_data: JobData) -> str:
+    payload = {
+        "title": job_data.title,
+        "company_name": job_data.company_name,
+        "location": job_data.location,
+        "workplace_type": job_data.workplace_type,
+        "description_raw": job_data.description_raw,
+        "salary": job_data.salary,
+        "contract_type": job_data.contract_type,
+        "apply_url": job_data.apply_url,
+        "posted_at": job_data.posted_at.isoformat() if job_data.posted_at else None,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+```
+
+In `upsert_job()`, compute `content_hash = compute_job_content_hash(job_data)` before the existing-row branch. For existing rows:
+
+```python
+if existing:
+    existing.fetched_at = datetime.now(UTC)
+    if company_id is not None and existing.company_id != company_id:
+        existing.company_id = company_id
+    if existing.content_hash != content_hash:
+        cleaned = clean_html_to_markdown(job_data.description_raw)
+        existing.title = job_data.title
+        existing.company_name = job_data.company_name
+        existing.description_raw = job_data.description_raw
+        existing.description = cleaned
+        existing.salary = job_data.salary
+        existing.contract_type = job_data.contract_type
+        existing.apply_url = job_data.apply_url
+        existing.location = job_data.location
+        existing.workplace_type = job_data.workplace_type
+        existing.content_hash = content_hash
+    existing.is_active = True
+    session.add(existing)
+    await session.commit()
+    await session.refresh(existing)
+    return existing, False
+```
+
+For new rows, set `content_hash=content_hash`.
+
+- [ ] **Step 6: Run targeted upsert tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_job_sync.py::test_upsert_job_creates_new tests/integration/test_job_sync.py::test_upsert_job_updates_existing tests/integration/test_job_sync.py::test_upsert_job_keeps_description_fields_when_payload_unchanged tests/integration/test_job_sync.py::test_upsert_job_changes_content_hash_when_description_changes tests/integration/test_job_sync.py::test_upsert_job_preserves_description_beyond_prompt_cap -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/models/job.py app/services/job_service.py alembic/versions/*_add_jobs_content_hash.py tests/integration/test_job_sync.py
+git commit -m "feat(jobs): skip wide updates for unchanged postings"
+```
+
+## Task 5: Frontend Auth-Aware Polling And Status Caching
+
+**Files:**
+- Modify: `frontend/src/api/client.ts`
+- Modify: `frontend/src/context/AuthContext.tsx`
+- Modify: `frontend/src/lib/useSyncControl.ts`
+- Modify: `frontend/src/components/BudgetBanner.tsx`
+- Modify: `frontend/src/api/client.test.ts`
+- Modify: `frontend/src/components/AppShell.test.tsx`
+- Modify: `frontend/src/components/BudgetBanner.test.tsx`
+
+- [ ] **Step 1: Add failing API client test for 401 token clearing**
+
+In `frontend/src/api/client.test.ts`, add:
+
+```ts
+it('clears the access token on 401', async () => {
+  sessionStorage.setItem('access_token', 'expired-token')
+  mockFetch(401, { detail: 'Invalid token' })
+
+  await expect(api.getMe()).rejects.toThrow()
+
+  expect(sessionStorage.getItem('access_token')).toBeNull()
+})
+```
+
+- [ ] **Step 2: Add failing polling backoff/401 tests**
+
+In `frontend/src/components/AppShell.test.tsx`, add one test that returns 401 from `/api/sync/status` and asserts no repeated calls after a short wait:
+
+```ts
+it('stops sync-status polling after a 401', async () => {
+  let statusCalls = 0
+  server.use(
+    http.get('/api/sync/status', () => {
+      statusCalls += 1
+      return HttpResponse.json({ detail: 'Invalid token' }, { status: 401 })
+    }),
+  )
+  renderShell()
+
+  await waitFor(() => expect(statusCalls).toBe(1))
+  await new Promise((r) => setTimeout(r, 3_500))
+  expect(statusCalls).toBe(1)
+}, 6_000)
+```
+
+- [ ] **Step 3: Add failing BudgetBanner request-rate test**
+
+In `frontend/src/components/BudgetBanner.test.tsx`, add imports:
+
+```ts
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+```
+
+Add a render helper:
+
+```ts
+function renderBudgetBanner() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <BudgetBanner />
+    </QueryClientProvider>
+  )
+}
+```
+
+Replace existing `render(<BudgetBanner />)` calls in this file with
+`renderBudgetBanner()`, then add:
+
+```ts
+it('does not use a component-local minute interval', async () => {
+  vi.useFakeTimers()
+  let calls = 0
+  server.use(
+    http.get('/api/status', () => {
+      calls += 1
+      return HttpResponse.json({ budget_exhausted: false, resumes_at: null })
+    }),
+  )
+  renderBudgetBanner()
+  await waitFor(() => expect(calls).toBe(1))
+
+  await vi.advanceTimersByTimeAsync(60_000)
+  expect(calls).toBe(1)
+  vi.useRealTimers()
+})
+```
+
+- [ ] **Step 4: Run failing frontend tests**
+
+Run:
+
+```bash
+cd frontend && npm test -- client.test.ts AppShell.test.tsx BudgetBanner.test.tsx
+```
+
+Expected before implementation: FAIL on the new 401 clearing and BudgetBanner interval assertions.
+
+- [ ] **Step 5: Clear token on 401 in API client**
+
+In `frontend/src/api/client.ts`, update `apiFetch()` after receiving `res`:
+
+```ts
+  if (res.status === 401) {
+    sessionStorage.removeItem('access_token')
+    window.dispatchEvent(new CustomEvent('auth:token-expired'))
+  }
+```
+
+Keep the existing error parsing below it, but make the thrown error include the
+HTTP status so polling hooks can branch on it:
+
+```ts
+    throw new Error(detail ? `${res.status}: ${detail}` : `${res.status}: ${text}`)
+```
+
+- [ ] **Step 6: Listen for token expiry in AuthProvider**
+
+In `frontend/src/context/AuthContext.tsx`, add an effect:
+
+```ts
+  useEffect(() => {
+    const onExpired = () => {
+      setToken(null)
+      setUser(null)
+    }
+    window.addEventListener('auth:token-expired', onExpired)
+    return () => window.removeEventListener('auth:token-expired', onExpired)
+  }, [])
+```
+
+- [ ] **Step 7: Stop sync polling after 401 and add backoff**
+
+In `frontend/src/lib/useSyncControl.ts`, replace the fixed live timeout with a counter:
+
+```ts
+    let livePolls = 0
+```
+
+Inside `poll()`:
+
+```ts
+        if (body.state !== 'idle') {
+          livePolls += 1
+          const interval = Math.min(POLL_MS * Math.max(1, livePolls), 30_000)
+          timeoutId = setTimeout(poll, interval)
+        }
+```
+
+In the catch block, stop scheduling future sync-status polls on 401:
+
+```ts
+        if ((err as Error)?.message?.includes('401')) {
+          return
+        }
+```
+
+- [ ] **Step 8: Convert BudgetBanner to React Query**
+
+In `frontend/src/components/BudgetBanner.tsx`, replace local state/effect with:
+
+```tsx
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../api/client'
+
+export default function BudgetBanner() {
+  const { data: status } = useQuery({
+    queryKey: ['app-status'],
+    queryFn: api.getStatus,
+    staleTime: 10 * 60_000,
+    refetchInterval: false,
+  })
+
+  if (!status?.budget_exhausted) return null
+
+  const resumes = status.resumes_at
+    ? new Date(status.resumes_at).toLocaleDateString(undefined, { month: 'long', day: 'numeric' })
+    : 'next month'
+
+  return (
+    <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-center text-sm text-amber-800">
+      AI features paused until {resumes} - job collection continues.
+    </div>
+  )
+}
+```
+
+- [ ] **Step 9: Run targeted frontend tests**
+
+Run:
+
+```bash
+cd frontend && npm test -- client.test.ts AppShell.test.tsx BudgetBanner.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/api/client.ts frontend/src/context/AuthContext.tsx frontend/src/lib/useSyncControl.ts frontend/src/components/BudgetBanner.tsx frontend/src/api/client.test.ts frontend/src/components/AppShell.test.tsx frontend/src/components/BudgetBanner.test.tsx
+git commit -m "fix(frontend): stop stale auth polling"
+```
+
+## Task 6: Queue Depth Interval Configuration
+
+**Files:**
+- Modify: `app/config.py`
+- Modify: `app/main.py`
+- Modify: `tests/unit/test_config.py`
+
+- [ ] **Step 1: Add failing config test**
+
+In `tests/unit/test_config.py`, add:
+
+```python
+def test_queue_depth_emit_interval_can_be_configured(monkeypatch):
+    from app import config
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@localhost:5432/db")
+    monkeypatch.setenv("QUEUE_DEPTH_EMIT_INTERVAL_S", "17")
+    config._settings = None
+
+    try:
+        settings = config.get_settings()
+        assert settings.queue_depth_emit_interval_s == 17
+    finally:
+        config._settings = None
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_config.py::test_queue_depth_emit_interval_can_be_configured -v
+```
+
+Expected before implementation: FAIL because `Settings` has no `queue_depth_emit_interval_s`.
+
+- [ ] **Step 3: Add setting and wire it**
+
+In `app/config.py`, add:
+
+```python
+    queue_depth_emit_interval_s: int = 60
+```
+
+In `app/main.py`, change:
+
+```python
+depth_task = asyncio.create_task(
+    _emit_queue_depth_forever(
+        get_session_factory(),
+        interval_s=settings.queue_depth_emit_interval_s,
+    ),
+    name="queue-depth-emitter",
+)
+```
+
+- [ ] **Step 4: Run targeted tests**
+
+Run:
+
+```bash
+uv run pytest tests/integration/test_queue_depth_emitter.py tests/unit/test_config.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/config.py app/main.py tests/unit/test_config.py
+git commit -m "chore(observability): configure queue depth interval"
+```
+
+## Task 7: External Cron Schedule Update
+
+**Files:**
+- Modify: `docs/DEPLOYMENT.md`
+
+- [ ] **Step 1: Document required external schedule change**
+
+In `docs/DEPLOYMENT.md`, under the cron/scheduler section, add:
+
+```markdown
+### Cron Cadence
+
+The job-search API expects these production trigger cadences:
+
+| Endpoint | Cadence | Reason |
+| --- | --- | --- |
+| `POST /internal/cron/sync` | every 6 hours | provider slug freshness TTL is 6 hours |
+| `POST /internal/cron/generation-reconcile` | every 30 minutes | repairs stuck cover-letter generation requests |
+| `POST /internal/cron/maintenance` | daily | stale-job marking and retention cleanup |
+
+Do not run `/internal/cron/sync` every 15 minutes. That cadence repeatedly scans
+active profiles, companies, and slug freshness while producing no new work
+inside the 6-hour TTL.
+```
+
+- [ ] **Step 2: Run docs check**
+
+Run:
+
+```bash
+rg -n "Cron Cadence|every 6 hours|Do not run `/internal/cron/sync` every 15 minutes" docs/DEPLOYMENT.md
+```
+
+Expected: all phrases appear.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/DEPLOYMENT.md
+git commit -m "docs: define production cron cadence"
+```
+
+## Task 8: Final Verification And Measurement Prep
+
+**Files:**
+- Modify: none expected unless earlier tasks found gaps.
+
+- [ ] **Step 1: Run backend focused suite**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/integration/test_job_sync.py \
+  tests/integration/test_cron_sync_enqueues.py \
+  tests/integration/test_sync_status_endpoint.py \
+  tests/integration/test_applications_api_summary.py \
+  tests/integration/test_jobs_endpoint.py \
+  tests/integration/test_queue_depth_emitter.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend focused suite**
+
+Run:
+
+```bash
+cd frontend && npm test -- client.test.ts AppShell.test.tsx BudgetBanner.test.tsx ApplicationReview.test.tsx MatchCard.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run broader unit/integration gates if time allows**
+
+Run:
+
+```bash
+uv run pytest tests/unit/ -v
+uv run pytest tests/integration/ -v
+cd frontend && npm run typecheck
+cd frontend && npm test
+```
+
+Expected: PASS. If any unrelated existing failure appears, capture the exact test and error in the handoff instead of hiding it.
+
+- [ ] **Step 4: Prepare production measurement commands**
+
+Do not run production SQL from the implementation session unless explicitly approved. Prepare the commands for the deploy operator:
+
+```bash
+psql "$DATABASE_URL" -c 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;'
+psql "$DATABASE_URL" -c 'SELECT pg_stat_statements_reset();'
+psql "$DATABASE_URL" -f scripts/neon_egress_diagnostics.sql
+```
+
+Expected: the first two commands run at the start of the window, and the diagnostic script runs after at least 24 hours.
+
+- [ ] **Step 5: Commit any verification-only documentation adjustment**
+
+Only if Step 3 or Step 4 required doc edits:
+
+```bash
+git add docs/DEPLOYMENT.md
+git commit -m "docs: clarify Neon egress verification"
+```
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Measurement: Task 1 and Task 8.
+  - Cron cadence and set-based stale discovery: Task 2 and Task 7.
+  - Narrow list/detail payloads: Task 3.
+  - Change-aware upserts and content hash: Task 4.
+  - Frontend polling and auth expiry: Task 5.
+  - Queue depth bounds: Task 6.
+  - Operational verification: Task 8.
+- No storage truncation is proposed; `description_raw` remains archival.
+- The only deliberate API contract change is removing default `description_raw` from application detail responses.
+- External production schedule ownership is called out explicitly because it is not represented by a cron file in this repository.

--- a/docs/superpowers/plans/2026-05-21-neon-egress-reduction.md
+++ b/docs/superpowers/plans/2026-05-21-neon-egress-reduction.md
@@ -17,7 +17,7 @@
 - Modify `app/services/slug_registry_service.py`: add set-based active-profile stale slug discovery.
 - Modify `app/services/job_sync_service.py`: use the set-based helper for cron sync and keep manual profile sync stable.
 - Modify `app/api/internal_cron.py`: keep `/internal/cron/sync` response shape stable.
-- Modify `app/services/match_service.py`: add a narrow application list projection.
+- Modify `app/services/match_service.py`: add narrow application-list and worker-scoring projections.
 - Modify `app/api/applications.py`: serialize list rows from the narrow projection and remove raw descriptions from detail by default.
 - Modify `frontend/src/api/client.ts`: handle 401 globally and align application types with the new payload contract.
 - Modify `frontend/src/lib/useSyncControl.ts`: add 401 stop behavior and live-state backoff.
@@ -26,6 +26,7 @@
 - Create an Alembic migration adding `jobs.content_hash`.
 - Modify `app/services/job_service.py`: compute content hashes and skip wide updates for unchanged postings.
 - Modify `app/observability/queue_depth.py` and `app/config.py`: make queue-depth interval configurable.
+- Create `tests/unit/test_match_service_queries.py`: compile-query guardrails for wide-column regressions.
 - Update tests in `tests/integration/`, `tests/unit/`, and `frontend/src/` to lock the egress-sensitive behavior.
 
 ## Scope Notes
@@ -177,6 +178,8 @@ Add this test to `tests/integration/test_job_sync.py`:
 async def test_sync_active_profiles_deduplicates_shared_provider_slugs(db_session):
     from datetime import timedelta
 
+    from sqlmodel import col, select
+
     from app.models.company import Company
     from app.models.slug_fetch import SlugFetch
     from app.models.user import User
@@ -237,6 +240,110 @@ async def test_sync_active_profiles_deduplicates_shared_provider_slugs(db_sessio
         .all()
     )
     assert [row.dedupe_key for row in rows] == ["fetch-slug:greenhouse:shared-co"]
+    profiles = (
+        (
+            await db_session.execute(
+                select(UserProfile).where(col(UserProfile.search_active).is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    summaries = {profile.email: profile.last_sync_summary for profile in profiles}
+    assert summaries[users[0].email]["queued_slugs"] == ["shared-co"]
+    assert summaries[users[1].email]["queued_slugs"] == ["shared-co"]
+```
+
+Also add this test to ensure cron summaries stay profile-specific and invalid slug pruning is preserved:
+
+```python
+@pytest.mark.asyncio
+async def test_sync_active_profiles_keeps_profile_specific_summaries_and_pruning(db_session):
+    from datetime import timedelta
+
+    from sqlmodel import col, select
+
+    from app.models.company import Company
+    from app.models.slug_fetch import SlugFetch
+    from app.models.user import User
+    from app.models.user_profile import UserProfile
+
+    stale_company = Company(
+        canonical_name="Stale Co",
+        normalized_key=f"stale-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "stale-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    fresh_company = Company(
+        canonical_name="Fresh Co",
+        normalized_key=f"fresh-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "fresh-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    invalid_company = Company(
+        canonical_name="Invalid Co",
+        normalized_key=f"invalid-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "invalid-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.add_all([stale_company, fresh_company, invalid_company])
+    await db_session.commit()
+    await db_session.refresh(stale_company)
+    await db_session.refresh(fresh_company)
+    await db_session.refresh(invalid_company)
+
+    stale_user = User(id=uuid.uuid4(), email=f"stale-{uuid.uuid4()}@test.com")
+    fresh_user = User(id=uuid.uuid4(), email=f"fresh-{uuid.uuid4()}@test.com")
+    db_session.add_all([stale_user, fresh_user])
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            UserProfile(
+                user_id=stale_user.id,
+                email=stale_user.email,
+                search_active=True,
+                target_company_ids=[stale_company.id],
+            ),
+            UserProfile(
+                user_id=fresh_user.id,
+                email=fresh_user.email,
+                search_active=True,
+                target_company_ids=[fresh_company.id, invalid_company.id],
+            ),
+            SlugFetch(
+                source="greenhouse",
+                slug="stale-co",
+                last_fetched_at=datetime.now(UTC) - timedelta(hours=7),
+            ),
+            SlugFetch(
+                source="greenhouse",
+                slug="fresh-co",
+                last_fetched_at=datetime.now(UTC),
+            ),
+            SlugFetch(source="greenhouse", slug="invalid-co", is_invalid=True),
+        ]
+    )
+    await db_session.commit()
+
+    result = await job_sync_service.sync_active_profiles(db_session)
+
+    assert result["enqueued"] == ["stale-co"]
+    assert result["pruned"] == 1
+    refreshed_profiles = (
+        (
+            await db_session.execute(
+                select(UserProfile).where(col(UserProfile.search_active).is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    summaries = {profile.email: profile.last_sync_summary for profile in refreshed_profiles}
+    assert summaries[stale_user.email]["queued_slugs"] == ["stale-co"]
+    assert summaries[stale_user.email]["pruned_slugs"] == []
+    assert summaries[fresh_user.email]["queued_slugs"] == []
+    assert summaries[fresh_user.email]["pruned_slugs"] == ["greenhouse:invalid-co"]
 ```
 
 - [ ] **Step 2: Run the failing test**
@@ -244,7 +351,7 @@ async def test_sync_active_profiles_deduplicates_shared_provider_slugs(db_sessio
 Run:
 
 ```bash
-uv run pytest tests/integration/test_job_sync.py::test_sync_active_profiles_deduplicates_shared_provider_slugs -v
+uv run pytest tests/integration/test_job_sync.py::test_sync_active_profiles_deduplicates_shared_provider_slugs tests/integration/test_job_sync.py::test_sync_active_profiles_keeps_profile_specific_summaries_and_pruning -v
 ```
 
 Expected before implementation: FAIL because the current cron sync loops profile-by-profile and reports duplicate `enqueued` values or repeats stale-slug lookup work.
@@ -258,19 +365,20 @@ async def list_stale_for_active_profiles(
     session: AsyncSession,
     *,
     ttl_hours: int = 6,
-) -> list[tuple[str, str]]:
-    """Return distinct stale provider slugs followed by active profiles."""
+) -> list[tuple[uuid.UUID, str, str]]:
+    """Return stale provider slugs by active profile without per-slug lookups."""
     result = await session.execute(
         sa.text(
             """
             WITH active_companies AS (
-              SELECT DISTINCT unnest(target_company_ids) AS company_id
+              SELECT id AS profile_id, unnest(target_company_ids) AS company_id
               FROM user_profiles
               WHERE search_active IS TRUE
                 AND target_company_ids IS NOT NULL
             ),
             provider_slugs AS (
               SELECT DISTINCT
+                     ac.profile_id,
                      kv.key::text AS source,
                      kv.value::text AS slug
               FROM active_companies ac
@@ -280,7 +388,7 @@ async def list_stale_for_active_profiles(
                 AND kv.value IS NOT NULL
                 AND kv.value <> ''
             )
-            SELECT ps.source, ps.slug
+            SELECT ps.profile_id, ps.source, ps.slug
             FROM provider_slugs ps
             LEFT JOIN slug_fetches sf
               ON sf.source = ps.source
@@ -291,19 +399,25 @@ async def list_stale_for_active_profiles(
                 OR sf.last_fetched_at IS NULL
                 OR sf.last_fetched_at < now() - make_interval(hours => :ttl_hours)
               )
-            ORDER BY ps.source, ps.slug
+            ORDER BY ps.profile_id, ps.source, ps.slug
             """
         ),
         {"ttl_hours": ttl_hours},
     )
-    return [(row[0], row[1]) for row in result.all()]
+    return [(row[0], row[1], row[2]) for row in result.all()]
 ```
 
-Also add `import sqlalchemy as sa` at the top of the file.
+Also add these imports at the top of the file:
+
+```python
+import uuid
+
+import sqlalchemy as sa
+```
 
 - [ ] **Step 4: Use the set-based helper in cron sync**
 
-In `app/services/job_sync_service.py`, rewrite `sync_active_profiles()` so it:
+In `app/services/job_sync_service.py`, add `import uuid`, then rewrite `sync_active_profiles()` so it:
 
 ```python
 async def sync_active_profiles(session: AsyncSession) -> dict:
@@ -317,13 +431,25 @@ async def sync_active_profiles(session: AsyncSession) -> dict:
         .scalars()
         .all()
     )
-    stale = await slug_registry_service.list_stale_for_active_profiles(
+
+    pruned_by_profile: dict[uuid.UUID, list[str]] = {}
+    for profile in active_profiles:
+        pruned_by_profile[profile.id] = await _prune_invalid_provider_slugs(profile, session)
+
+    stale_by_profile = await slug_registry_service.list_stale_for_active_profiles(
         session,
         ttl_hours=6,
     )
 
+    pairs_by_profile: dict[uuid.UUID, list[tuple[str, str]]] = {}
+    distinct_pairs: dict[tuple[str, str], str] = {}
+    for profile_id, provider, slug in stale_by_profile:
+        pairs_by_profile.setdefault(profile_id, []).append((provider, slug))
+        distinct_pairs.setdefault((provider, slug), slug)
+
     enqueued: list[str] = []
-    for provider, slug in stale:
+    enqueued_pairs: set[tuple[str, str]] = set()
+    for (provider, slug), display_slug in distinct_pairs.items():
         row_id = await enqueue(
             session,
             job_type="fetch-slug",
@@ -331,18 +457,24 @@ async def sync_active_profiles(session: AsyncSession) -> dict:
             dedupe_key=f"fetch-slug:{provider}:{slug}",
         )
         if row_id is not None:
-            enqueued.append(slug)
+            enqueued.append(display_slug)
+            enqueued_pairs.add((provider, slug))
 
     now = datetime.now(UTC)
     profiles_enqueued = 0
     for profile in active_profiles:
+        profile_slugs = [
+            slug
+            for provider, slug in pairs_by_profile.get(profile.id, [])
+            if (provider, slug) in enqueued_pairs
+        ]
         profile.last_sync_requested_at = now
         profile.last_sync_summary = {
-            "queued_slugs": enqueued,
+            "queued_slugs": profile_slugs,
             "matched_now": 0,
-            "pruned_slugs": [],
+            "pruned_slugs": pruned_by_profile.get(profile.id, []),
         }
-        if enqueued:
+        if profile_slugs:
             profiles_enqueued += 1
         else:
             profile.last_sync_completed_at = now
@@ -351,20 +483,20 @@ async def sync_active_profiles(session: AsyncSession) -> dict:
     await session.commit()
     return {
         "enqueued": enqueued,
-        "pruned": 0,
+        "pruned": sum(len(values) for values in pruned_by_profile.values()),
         "active_profiles": len(active_profiles),
         "profiles_enqueued": profiles_enqueued,
     }
 ```
 
-Keep `_prune_invalid_provider_slugs()` and `prune_and_enqueue()` unchanged for manual per-profile sync in this task.
+Keep `_prune_invalid_provider_slugs()` and `prune_and_enqueue()` unchanged for manual per-profile sync in this task. The cron path still prunes invalid slugs per profile to preserve current behavior, but stale-slug discovery no longer performs per-profile, per-provider-slug freshness reads.
 
 - [ ] **Step 5: Run targeted sync tests**
 
 Run:
 
 ```bash
-uv run pytest tests/integration/test_job_sync.py::test_sync_active_profiles_uses_shared_enqueue_contract tests/integration/test_job_sync.py::test_sync_active_profiles_deduplicates_shared_provider_slugs tests/integration/test_cron_sync_enqueues.py -v
+uv run pytest tests/integration/test_job_sync.py::test_sync_active_profiles_uses_shared_enqueue_contract tests/integration/test_job_sync.py::test_sync_active_profiles_deduplicates_shared_provider_slugs tests/integration/test_job_sync.py::test_sync_active_profiles_keeps_profile_specific_summaries_and_pruning tests/integration/test_cron_sync_enqueues.py -v
 ```
 
 Expected: PASS.
@@ -382,6 +514,7 @@ git commit -m "refactor(sync): dedupe stale slug cron discovery"
 - Modify: `app/services/match_service.py`
 - Modify: `app/api/applications.py`
 - Modify: `frontend/src/api/client.ts`
+- Create: `tests/unit/test_match_service_queries.py`
 - Modify: `tests/integration/test_applications_api_summary.py`
 - Modify: `tests/integration/test_jobs_endpoint.py`
 - Modify: `frontend/src/pages/ApplicationReview.test.tsx`
@@ -389,42 +522,33 @@ git commit -m "refactor(sync): dedupe stale slug cron discovery"
 
 - [ ] **Step 1: Add failing backend tests for list/detail description behavior**
 
-In `tests/integration/test_applications_api_summary.py`, add tests equivalent to:
+Create `tests/unit/test_match_service_queries.py` with a compile-time query guard:
+
+```python
+import uuid
+
+
+def test_application_list_query_does_not_select_job_descriptions():
+    from app.services.match_service import build_application_list_query
+
+    query = build_application_list_query(uuid.uuid4(), status=None, min_score=None)
+    compiled = str(query.compile(compile_kwargs={"literal_binds": False})).lower()
+
+    assert "jobs.description_raw" not in compiled
+    assert "jobs.description" not in compiled
+```
+
+In `tests/integration/test_applications_api_summary.py`, replace
+`test_detail_endpoint_exposes_description` with:
 
 ```python
 @pytest.mark.asyncio
-async def test_list_applications_omits_job_descriptions(client, auth_headers, db_session, seeded_user):
-    from app.models.application import Application
-    from app.models.job import Job
-
-    _, profile = seeded_user
-    job = Job(
-        source="greenhouse",
-        external_id="wide-list-1",
-        title="Wide Row",
-        company_name="Wide Co",
-        description_raw="<p>raw wide payload</p>",
-        description="clean wide payload",
-        apply_url="https://example.com/apply",
-    )
-    db_session.add(job)
-    await db_session.commit()
-    await db_session.refresh(job)
-    db_session.add(Application(job_id=job.id, profile_id=profile.id, match_score=0.9))
-    await db_session.commit()
-
-    response = await client.get("/api/applications", headers=auth_headers)
-    assert response.status_code == 200
-    body = response.json()
-    returned = next(row for row in body if row["job"]["id"] == str(job.id))
-    assert "description_raw" not in returned["job"]
-    assert "description" not in returned["job"]
-
-
-@pytest.mark.asyncio
 async def test_application_detail_omits_raw_description_by_default(
-    client, auth_headers, db_session, seeded_user
+    db_session, auth_headers, seeded_user
 ):
+    from httpx import ASGITransport, AsyncClient
+
+    from app.main import app as fastapi_app
     from app.models.application import Application
     from app.models.job import Job
 
@@ -446,7 +570,9 @@ async def test_application_detail_omits_raw_description_by_default(
     await db_session.commit()
     await db_session.refresh(app)
 
-    response = await client.get(f"/api/applications/{app.id}", headers=auth_headers)
+    transport = ASGITransport(app=fastapi_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/api/applications/{app.id}", headers=auth_headers)
     assert response.status_code == 200
     body = response.json()
     assert body["job"]["description"] == "clean markdown"
@@ -458,14 +584,14 @@ async def test_application_detail_omits_raw_description_by_default(
 Run:
 
 ```bash
-uv run pytest tests/integration/test_applications_api_summary.py::test_list_applications_omits_job_descriptions tests/integration/test_applications_api_summary.py::test_application_detail_omits_raw_description_by_default -v
+uv run pytest tests/unit/test_match_service_queries.py::test_application_list_query_does_not_select_job_descriptions tests/integration/test_applications_api_summary.py::test_application_detail_omits_raw_description_by_default -v
 ```
 
-Expected before implementation: FAIL because current responses include descriptions.
+Expected before implementation: FAIL because `build_application_list_query` does not exist and the detail response still includes `description_raw`.
 
 - [ ] **Step 3: Add a narrow list projection**
 
-In `app/services/match_service.py`, add a typed alias near `list_applications()`:
+In `app/services/match_service.py`, add a typed alias and query builder near `list_applications()`:
 
 ```python
 ApplicationListRow = tuple[
@@ -488,13 +614,87 @@ ApplicationListRow = tuple[
     str,
     datetime | None,
 ]
+
+
+def build_application_list_query(
+    profile_id: uuid.UUID,
+    *,
+    status: str | None,
+    min_score: float | None,
+):
+    q = (
+        select(
+            Application.id,
+            Application.status,
+            Application.generation_status,
+            Application.match_score,
+            Application.match_summary,
+            Application.match_rationale,
+            Application.match_strengths,
+            Application.match_gaps,
+            Application.created_at,
+            Job.id,
+            Job.title,
+            Job.company_name,
+            Job.location,
+            Job.workplace_type,
+            Job.salary,
+            Job.contract_type,
+            Job.apply_url,
+            Job.posted_at,
+        )
+        .join(Job, Application.job_id == Job.id)
+        .where(Application.profile_id == profile_id)
+    )
+    if status:
+        q = q.where(Application.status == status)
+        if status == "pending_review":
+            q = q.where(col(Application.match_score).is_not(None))
+    if min_score is not None:
+        q = q.where(Application.match_score >= min_score)
+    return q
 ```
 
-Then replace `select(Application, Job)` in `list_applications()` with explicit columns:
+Then rewrite `list_applications()` to use the builder and return projected rows:
 
 ```python
-q = (
-    select(
+async def list_applications(
+    profile_id: uuid.UUID,
+    session: AsyncSession,
+    status: str | None = None,
+    min_score: float | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> list[ApplicationListRow]:
+    q = build_application_list_query(
+        profile_id,
+        status=status,
+        min_score=min_score,
+    )
+    q = q.order_by(
+        Application.match_score.desc().nullslast(),
+        Job.posted_at.desc().nullslast(),
+        Job.salary.isnot(None).desc(),
+        Application.created_at.desc(),
+    )
+    q = q.limit(limit).offset(offset)
+    result = await session.execute(q)
+    return list(result.tuples().all())
+```
+
+The builder must not include:
+
+```python
+select(Application, Job)
+select(Job)
+Job.description_raw
+Job.description
+```
+
+The final selected-column list must remain:
+
+```python
+select(
         Application.id,
         Application.status,
         Application.generation_status,
@@ -513,9 +713,6 @@ q = (
         Job.contract_type,
         Job.apply_url,
         Job.posted_at,
-    )
-    .join(Job, Application.job_id == Job.id)
-    .where(Application.profile_id == profile_id)
 )
 ```
 
@@ -605,6 +802,7 @@ Run:
 
 ```bash
 uv run pytest tests/integration/test_applications_api_summary.py tests/integration/test_jobs_endpoint.py -v
+uv run pytest tests/unit/test_match_service_queries.py -v
 cd frontend && npm test -- ApplicationReview.test.tsx MatchCard.test.tsx client.test.ts
 ```
 
@@ -613,7 +811,7 @@ Expected: PASS.
 - [ ] **Step 8: Commit**
 
 ```bash
-git add app/services/match_service.py app/api/applications.py frontend/src/api/client.ts tests/integration/test_applications_api_summary.py tests/integration/test_jobs_endpoint.py frontend/src/pages/ApplicationReview.test.tsx frontend/src/components/feed/MatchCard.test.tsx
+git add app/services/match_service.py app/api/applications.py frontend/src/api/client.ts tests/unit/test_match_service_queries.py tests/integration/test_applications_api_summary.py tests/integration/test_jobs_endpoint.py frontend/src/pages/ApplicationReview.test.tsx frontend/src/components/feed/MatchCard.test.tsx
 git commit -m "refactor(applications): avoid wide job payloads"
 ```
 
@@ -631,27 +829,55 @@ Add these tests to `tests/integration/test_job_sync.py`:
 
 ```python
 @pytest.mark.asyncio
-async def test_upsert_job_keeps_description_fields_when_payload_unchanged(db_session):
+async def test_upsert_job_unchanged_payload_avoids_wide_select_and_update(db_session):
+    from sqlalchemy import event
+
     data = make_job_data(external_id="stable-1", title="Stable Engineer")
     first, created = await upsert_job(data, "greenhouse", db_session)
     assert created is True
-    first_hash = first.content_hash
-    first_description = first.description
-    first_raw = first.description_raw
 
-    second, created = await upsert_job(data, "greenhouse", db_session)
+    statements: list[str] = []
+    engine = db_session.bind.sync_engine
+
+    def capture_statement(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement.lower())
+
+    event.listen(engine, "before_cursor_execute", capture_statement)
+    try:
+        second, created = await upsert_job(data, "greenhouse", db_session)
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_statement)
+
+    selects = "\n".join(stmt for stmt in statements if stmt.lstrip().startswith("select"))
+    updates = "\n".join(stmt for stmt in statements if stmt.lstrip().startswith("update"))
 
     assert created is False
     assert second.id == first.id
-    assert second.content_hash == first_hash
-    assert second.description == first_description
-    assert second.description_raw == first_raw
+    assert "description_raw" not in selects
+    assert "jobs.description," not in selects
+    assert "description_raw" not in updates
+    assert "description =" not in updates
+
+    refreshed = await db_session.get(Job, first.id)
+    assert refreshed.description_raw == data.description_raw
+    assert refreshed.description and "Python engineer" in refreshed.description
+
+
+@pytest.mark.asyncio
+async def test_upsert_job_populates_content_hash(db_session):
+    data = make_job_data(external_id="stable-hash-1", title="Stable Engineer")
+    job, created = await upsert_job(data, "greenhouse", db_session)
+
+    assert created is True
+    assert job.content_hash is not None
+    assert len(job.content_hash) == 64
 
 
 @pytest.mark.asyncio
 async def test_upsert_job_changes_content_hash_when_description_changes(db_session):
     data = make_job_data(external_id="stable-2", title="Stable Engineer")
     first, _ = await upsert_job(data, "greenhouse", db_session)
+    first_hash = first.content_hash
 
     changed = make_job_data(external_id="stable-2", title="Stable Engineer")
     changed.description_raw = "A different role description."
@@ -659,7 +885,7 @@ async def test_upsert_job_changes_content_hash_when_description_changes(db_sessi
 
     assert created is False
     assert second.id == first.id
-    assert second.content_hash != first.content_hash
+    assert second.content_hash != first_hash
     assert second.description_raw == "A different role description."
     assert "different role" in (second.description or "")
 ```
@@ -669,10 +895,10 @@ async def test_upsert_job_changes_content_hash_when_description_changes(db_sessi
 Run:
 
 ```bash
-uv run pytest tests/integration/test_job_sync.py::test_upsert_job_keeps_description_fields_when_payload_unchanged tests/integration/test_job_sync.py::test_upsert_job_changes_content_hash_when_description_changes -v
+uv run pytest tests/integration/test_job_sync.py::test_upsert_job_unchanged_payload_avoids_wide_select_and_update tests/integration/test_job_sync.py::test_upsert_job_populates_content_hash tests/integration/test_job_sync.py::test_upsert_job_changes_content_hash_when_description_changes -v
 ```
 
-Expected before implementation: FAIL because `Job` has no `content_hash`.
+Expected before implementation: FAIL because `Job` has no `content_hash` and the unchanged existing-row path currently loads and rewrites full description fields.
 
 - [ ] **Step 3: Add the model column**
 
@@ -724,6 +950,8 @@ In `app/services/job_service.py`, add imports:
 ```python
 import hashlib
 import json
+
+from sqlalchemy import update
 ```
 
 Add helper:
@@ -745,40 +973,88 @@ def compute_job_content_hash(job_data: JobData) -> str:
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 ```
 
-In `upsert_job()`, compute `content_hash = compute_job_content_hash(job_data)` before the existing-row branch. For existing rows:
+In `upsert_job()`, compute `content_hash = compute_job_content_hash(job_data)` before the existing-row branch. Replace the current existing-row lookup with a narrow lookup:
 
 ```python
-if existing:
-    existing.fetched_at = datetime.now(UTC)
-    if company_id is not None and existing.company_id != company_id:
-        existing.company_id = company_id
-    if existing.content_hash != content_hash:
+existing_row = (
+    await session.execute(
+        select(
+            Job.id,
+            Job.content_hash,
+            Job.company_id,
+            Job.company_name,
+            Job.source,
+        ).where(
+            Job.source == source,
+            Job.external_id == job_data.external_id,
+        )
+    )
+).one_or_none()
+
+company_id = await _resolve_company_id(source, slug, session)
+
+if existing_row is not None:
+    job_id, existing_hash, existing_company_id, existing_company_name, existing_source = existing_row
+    now = datetime.now(UTC)
+    values = {
+        "is_active": True,
+        "fetched_at": now,
+    }
+    resolved_company_id = existing_company_id
+    if company_id is not None and existing_company_id != company_id:
+        values["company_id"] = company_id
+        resolved_company_id = company_id
+
+    content_changed = existing_hash != content_hash
+    if content_changed:
         cleaned = clean_html_to_markdown(job_data.description_raw)
-        existing.title = job_data.title
-        existing.company_name = job_data.company_name
-        existing.description_raw = job_data.description_raw
-        existing.description = cleaned
-        existing.salary = job_data.salary
-        existing.contract_type = job_data.contract_type
-        existing.apply_url = job_data.apply_url
-        existing.location = job_data.location
-        existing.workplace_type = job_data.workplace_type
-        existing.content_hash = content_hash
-    existing.is_active = True
-    session.add(existing)
+        values.update(
+            {
+                "title": job_data.title,
+                "company_name": job_data.company_name,
+                "description_raw": job_data.description_raw,
+                "description": cleaned,
+                "salary": job_data.salary,
+                "contract_type": job_data.contract_type,
+                "apply_url": job_data.apply_url,
+                "location": job_data.location,
+                "workplace_type": job_data.workplace_type,
+                "posted_at": job_data.posted_at,
+                "content_hash": content_hash,
+            }
+        )
+    await session.execute(update(Job).where(Job.id == job_id).values(**values))
     await session.commit()
-    await session.refresh(existing)
-    return existing, False
+    return (
+        Job(
+            id=job_id,
+            source=existing_source,
+            external_id=job_data.external_id,
+            title=job_data.title if content_changed else job_data.title,
+            company_name=job_data.company_name if content_changed else existing_company_name,
+            company_id=resolved_company_id,
+            location=job_data.location,
+            workplace_type=job_data.workplace_type,
+            description_raw=job_data.description_raw if content_changed else None,
+            description=cleaned if content_changed else None,
+            salary=job_data.salary,
+            contract_type=job_data.contract_type,
+            apply_url=job_data.apply_url,
+            posted_at=job_data.posted_at,
+            content_hash=content_hash,
+        ),
+        False,
+    )
 ```
 
-For new rows, set `content_hash=content_hash`.
+For new rows, set `content_hash=content_hash`. Keep the new-row `session.refresh(job)` because new provider postings must return a normal model object and this path is not the repeated unchanged-posting hot path.
 
 - [ ] **Step 6: Run targeted upsert tests**
 
 Run:
 
 ```bash
-uv run pytest tests/integration/test_job_sync.py::test_upsert_job_creates_new tests/integration/test_job_sync.py::test_upsert_job_updates_existing tests/integration/test_job_sync.py::test_upsert_job_keeps_description_fields_when_payload_unchanged tests/integration/test_job_sync.py::test_upsert_job_changes_content_hash_when_description_changes tests/integration/test_job_sync.py::test_upsert_job_preserves_description_beyond_prompt_cap -v
+uv run pytest tests/integration/test_job_sync.py::test_upsert_job_creates_new tests/integration/test_job_sync.py::test_upsert_job_updates_existing tests/integration/test_job_sync.py::test_upsert_job_unchanged_payload_avoids_wide_select_and_update tests/integration/test_job_sync.py::test_upsert_job_populates_content_hash tests/integration/test_job_sync.py::test_upsert_job_changes_content_hash_when_description_changes tests/integration/test_job_sync.py::test_upsert_job_preserves_description_beyond_prompt_cap -v
 ```
 
 Expected: PASS.
@@ -811,6 +1087,15 @@ it('clears the access token on 401', async () => {
   mockFetch(401, { detail: 'Invalid token' })
 
   await expect(api.getMe()).rejects.toThrow()
+
+  expect(sessionStorage.getItem('access_token')).toBeNull()
+})
+
+it('clears the access token on 401 from direct fetch wrappers', async () => {
+  sessionStorage.setItem('access_token', 'expired-token')
+  mockFetch(401, { detail: 'Invalid token' })
+
+  await expect(api.resolveCompany('Acme')).rejects.toThrow()
 
   expect(sessionStorage.getItem('access_token')).toBeNull()
 })
@@ -892,13 +1177,20 @@ Expected before implementation: FAIL on the new 401 clearing and BudgetBanner in
 
 - [ ] **Step 5: Clear token on 401 in API client**
 
-In `frontend/src/api/client.ts`, update `apiFetch()` after receiving `res`:
+In `frontend/src/api/client.ts`, add a shared 401 helper above `apiFetch()`:
 
 ```ts
-  if (res.status === 401) {
-    sessionStorage.removeItem('access_token')
-    window.dispatchEvent(new CustomEvent('auth:token-expired'))
-  }
+function clearAuthOnUnauthorized(status: number) {
+  if (status !== 401) return
+  sessionStorage.removeItem('access_token')
+  window.dispatchEvent(new CustomEvent('auth:token-expired'))
+}
+```
+
+Update `apiFetch()` after receiving `res`:
+
+```ts
+  clearAuthOnUnauthorized(res.status)
 ```
 
 Keep the existing error parsing below it, but make the thrown error include the
@@ -907,6 +1199,20 @@ HTTP status so polling hooks can branch on it:
 ```ts
     throw new Error(detail ? `${res.status}: ${detail}` : `${res.status}: ${text}`)
 ```
+
+Also call the same helper in direct `fetch` wrappers before their `if (!resp.ok)` or `if (!r.ok)` blocks:
+
+```ts
+    clearAuthOnUnauthorized(r.status)
+```
+
+and:
+
+```ts
+    clearAuthOnUnauthorized(resp.status)
+```
+
+This must cover `uploadResume()` and `resolveCompany()`, because both currently bypass `apiFetch()`.
 
 - [ ] **Step 6: Listen for token expiry in AuthProvider**
 
@@ -996,7 +1302,152 @@ git add frontend/src/api/client.ts frontend/src/context/AuthContext.tsx frontend
 git commit -m "fix(frontend): stop stale auth polling"
 ```
 
-## Task 6: Queue Depth Interval Configuration
+## Task 6: Worker Scoring Narrow Reads
+
+**Files:**
+- Modify: `app/services/match_service.py`
+- Modify: `tests/unit/test_match_service_queries.py`
+- Modify: `tests/integration/test_match_scoring.py`
+
+- [ ] **Step 1: Add failing query guard for score candidates**
+
+Add this test to `tests/unit/test_match_service_queries.py`:
+
+```python
+def test_score_candidate_query_selects_only_scoring_columns():
+    from app.services.match_service import build_score_candidate_query
+
+    query = build_score_candidate_query(
+        profile_id=uuid.uuid4(),
+        company_ids=[uuid.uuid4()],
+        matched_ids=set(),
+        limit=20,
+    )
+    compiled = str(query.compile(compile_kwargs={"literal_binds": False})).lower()
+    selected = compiled.split(" from ", 1)[0]
+
+    assert "select jobs.id" in compiled
+    assert "jobs.description_raw" in selected
+    assert "jobs.description," in selected
+    assert "jobs.created_at" not in compiled
+    assert "jobs.updated_at" not in compiled
+```
+
+Expected before implementation: FAIL because `build_score_candidate_query` does not exist.
+
+- [ ] **Step 2: Add scoring row alias and query builder**
+
+In `app/services/match_service.py`, add near `ApplicationListRow`:
+
+```python
+JobScoreRow = tuple[
+    uuid.UUID,
+    str,
+    str,
+    str,
+    str,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+]
+
+
+def build_score_candidate_query(
+    *,
+    profile_id: uuid.UUID,
+    company_ids: list[uuid.UUID],
+    matched_ids: set[uuid.UUID],
+    limit: int,
+):
+    q = (
+        select(
+            Job.id,
+            Job.source,
+            Job.external_id,
+            Job.title,
+            Job.company_name,
+            Job.location,
+            Job.workplace_type,
+            Job.description,
+            Job.description_raw,
+            Job.apply_url,
+        )
+        .where(
+            Job.is_active.is_(True),
+            col(Job.company_id).in_(company_ids),
+        )
+        .order_by(Job.posted_at.desc().nullslast(), Job.fetched_at.desc())
+        .limit(limit)
+    )
+    if matched_ids:
+        q = q.where(col(Job.id).notin_(matched_ids))
+    return q
+```
+
+This query intentionally selects `description` and `description_raw` because scoring needs one description string, but it must not select the full `Job` ORM row.
+
+- [ ] **Step 3: Use narrow score candidates in `score_and_match()`**
+
+Replace the `candidates_q = select(Job)` branch in `score_and_match()` with:
+
+```python
+candidates_q = build_score_candidate_query(
+    profile_id=profile.id,
+    company_ids=company_ids,
+    matched_ids=matched_ids,
+    limit=settings.matching_jobs_per_batch,
+)
+candidate_rows: list[JobScoreRow] = list((await session.execute(candidates_q)).tuples().all())
+jobs = [
+    Job(
+        id=job_id,
+        source=source,
+        external_id=external_id,
+        title=title,
+        company_name=company_name,
+        location=location,
+        workplace_type=workplace_type,
+        description=description,
+        description_raw=description_raw,
+        apply_url=apply_url,
+    )
+    for (
+        job_id,
+        source,
+        external_id,
+        title,
+        company_name,
+        location,
+        workplace_type,
+        description,
+        description_raw,
+        apply_url,
+    ) in candidate_rows
+]
+```
+
+Keep the existing `jobs` argument behavior unchanged. Tests that pass explicit `jobs=[job]` should continue to exercise deterministic policy and scoring logic without using the query builder.
+
+- [ ] **Step 4: Run scoring tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_match_service_queries.py tests/integration/test_match_scoring.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/match_service.py tests/unit/test_match_service_queries.py tests/integration/test_match_scoring.py
+git commit -m "refactor(match): narrow worker scoring reads"
+```
+
+## Task 7: Queue Depth Interval Configuration
 
 **Files:**
 - Modify: `app/config.py`
@@ -1069,7 +1520,7 @@ git add app/config.py app/main.py tests/unit/test_config.py
 git commit -m "chore(observability): configure queue depth interval"
 ```
 
-## Task 7: External Cron Schedule Update
+## Task 8: External Cron Schedule Update
 
 **Files:**
 - Modify: `docs/DEPLOYMENT.md`
@@ -1111,7 +1562,7 @@ git add docs/DEPLOYMENT.md
 git commit -m "docs: define production cron cadence"
 ```
 
-## Task 8: Final Verification And Measurement Prep
+## Task 9: Final Verification And Measurement Prep
 
 **Files:**
 - Modify: none expected unless earlier tasks found gaps.
@@ -1128,7 +1579,9 @@ uv run pytest \
   tests/integration/test_applications_api_summary.py \
   tests/integration/test_jobs_endpoint.py \
   tests/integration/test_queue_depth_emitter.py \
+  tests/integration/test_match_scoring.py \
   -v
+uv run pytest tests/unit/test_match_service_queries.py -v
 ```
 
 Expected: PASS.
@@ -1180,13 +1633,14 @@ git commit -m "docs: clarify Neon egress verification"
 ## Self-Review Checklist
 
 - Spec coverage:
-  - Measurement: Task 1 and Task 8.
-  - Cron cadence and set-based stale discovery: Task 2 and Task 7.
+  - Measurement: Task 1 and Task 9.
+  - Cron cadence and set-based stale discovery: Task 2 and Task 8.
   - Narrow list/detail payloads: Task 3.
   - Change-aware upserts and content hash: Task 4.
   - Frontend polling and auth expiry: Task 5.
-  - Queue depth bounds: Task 6.
-  - Operational verification: Task 8.
+  - Worker scoring reads: Task 6.
+  - Queue depth bounds: Task 7.
+  - Operational verification: Task 9.
 - No storage truncation is proposed; `description_raw` remains archival.
 - The only deliberate API contract change is removing default `description_raw` from application detail responses.
 - External production schedule ownership is called out explicitly because it is not represented by a cron file in this repository.

--- a/docs/superpowers/specs/2026-05-21-neon-egress-reduction-design.md
+++ b/docs/superpowers/specs/2026-05-21-neon-egress-reduction-design.md
@@ -1,0 +1,446 @@
+# Neon Egress Reduction Design
+
+## Context
+
+The Neon free-tier 5GB network-transfer allowance was exhausted within roughly a
+week, while the production database is not large at rest. A live read-only
+snapshot on 2026-05-21/2026-05-22 UTC showed:
+
+- project synthetic storage: about 147MB
+- `jobs`: 8,047 rows, 86MB total
+- `jobs.description_raw`: about 34MB total, average about 4.5KB per row
+- `jobs.description`: about 31MB total
+- `work_queue`: 25,426 live rows, 8MB total
+- `applications`: 14,501 rows, 8.5MB total
+
+The exhausted quota is therefore more likely from repeated reads and transfers
+than from storage growth. Neon did not have `pg_stat_statements` installed at
+inspection time, so the exact per-query transfer ranking was not available.
+This design first adds measurement, then reduces the highest-confidence transfer
+amplifiers found in code and logs.
+
+## Evidence
+
+From Axiom logs between 2026-05-14 and 2026-05-22 UTC:
+
+- `POST /internal/cron/sync` ran 770 times, about every 15 minutes.
+- `POST /internal/cron/generation-reconcile` ran 384 times, about every 30
+  minutes.
+- `GET /api/sync/status` was requested 27,207 times.
+- `GET /api/status` was requested 7,345 times.
+- `GET /api/applications?status=pending_review` was requested 1,025 times.
+- `auth.token_expired` logged 21,466 times.
+- `api.queue_depth` emitted 11,506 samples.
+
+From production database stats:
+
+- `work_queue` has 2,783 completed `fetch-slug` jobs and 22,632 `match` jobs
+  since 2026-05-14.
+- `jobs` saw 44,288 updates and 13,527 inserts.
+- `work_queue` saw 51,429 updates and 25,707 inserts.
+- `slug_fetches` saw 370,349 sequential scans over a 116-row table.
+- `companies` saw 80,615 sequential scans over a 102-row table.
+- All 4 profiles are search-active. Their target company counts are 101, 51,
+  29, and 3.
+
+Important code paths:
+
+- `app/services/job_sync_service.py::prune_and_enqueue()` uses a 6-hour slug
+  freshness TTL.
+- `app/api/internal_cron.py::cron_sync()` delegates to
+  `sync_active_profiles()`.
+- `app/services/slug_registry_service.py::list_stale_for_profile()` fetches
+  companies, then calls `get(provider, slug)` once per provider slug.
+- `app/services/job_service.py::upsert_job()` selects full `Job` rows, writes
+  full descriptions, commits, and refreshes the ORM object for every posting.
+- `app/services/match_service.py::list_applications()` selects `(Application,
+  Job)` even though the list API omits job descriptions.
+- `app/api/applications.py::get_application()` returns both `description_raw`
+  and cleaned `description`.
+- `frontend/src/lib/useSyncControl.ts` polls `/api/sync/status` every 3 seconds
+  while sync or matching appears live.
+- `frontend/src/components/BudgetBanner.tsx` polls `/api/status` every minute.
+
+## Problem
+
+The application treats several operationally frequent paths as if row transfer
+were free:
+
+1. Cron sync runs much more often than the slug freshness window needs.
+2. Status and feed polling continue at high volume, including after auth expiry.
+3. List and worker queries often load full ORM rows that include wide
+   description fields.
+4. Provider fetch upserts repeatedly read and rewrite existing job rows even
+   when the relevant posting content has not changed.
+5. The database lacks query-level transfer observability, so future regressions
+   would be hard to rank by impact.
+
+The system should preserve full upstream job descriptions in storage. The fix is
+not to truncate `description_raw`; it is to stop moving wide description fields
+through hot paths that do not need them.
+
+## Goals
+
+- Measure the actual highest-row and highest-frequency queries using
+  `pg_stat_statements`.
+- Reduce routine Neon network transfer from cron, workers, frontend polling, and
+  list endpoints.
+- Preserve `jobs.description_raw` as full archival upstream data.
+- Keep public response contracts stable unless a response currently exposes data
+  the product does not need.
+- Keep sync/match behavior functionally equivalent: stale boards still fetch,
+  new applications still get matched, and user-owned application states remain
+  protected.
+- Add tests that catch reintroductions of wide-row reads on hot paths.
+
+## Non-Goals
+
+- Do not delete stored job descriptions.
+- Do not change scoring policy, prompt semantics, or LLM model selection.
+- Do not redesign the job search product flow.
+- Do not replace Neon or add a separate database/cache service in this pass.
+- Do not introduce per-user billing or external rate-limit enforcement.
+- Do not depend on Neon dashboard transfer totals as the only verification
+  signal.
+
+## Approach
+
+Use a phased design:
+
+1. Add measurement and low-risk throttles first.
+2. Remove wide-row reads from hot API paths.
+3. Make sync and upsert work set-based and change-aware.
+4. Add guardrails so polling and stale auth cannot silently recreate the
+   transfer spike.
+
+This is preferred over a storage-first cleanup because the database is small at
+rest. Truncating descriptions would reduce table size but would violate the
+archival data invariant and would not address high-frequency status, cron, and
+worker activity.
+
+## Design
+
+### 1. Measurement Window
+
+Install and enable `pg_stat_statements` on production:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+```
+
+After deploy, reset the stats at the start of a known measurement window:
+
+```sql
+SELECT pg_stat_statements_reset();
+```
+
+Collect these reports after at least 24 hours:
+
+- highest total rows returned
+- highest average rows per call
+- most frequent queries
+- longest-running queries
+- table read/update stats from `pg_stat_user_tables`
+
+Do not treat these reports as exact byte-level egress, because Postgres exposes
+rows and execution stats, not true transfer bytes. Rank queries by row count,
+frequency, and whether they include wide `TEXT`/`JSONB` columns.
+
+### 2. Cron Cadence And Sync Eligibility
+
+`/internal/cron/sync` should not run every 15 minutes when
+`list_stale_for_profile(..., ttl_hours=6)` is the source freshness gate.
+
+Change the scheduler contract to one of:
+
+- run `/internal/cron/sync` every 6 hours, matching the freshness TTL; or
+- keep the external 15-minute scheduler, but make the endpoint return early
+  unless a global or per-provider-slug eligibility check says there is stale
+  work.
+
+The preferred implementation is the 6-hour schedule. It reduces HTTP, auth,
+profile, company, and slug-state scans without introducing another internal
+state machine.
+
+Generation reconcile can keep its current 30-minute cadence because it is a
+small SQL query and is user-visible only when cover-letter generation is stuck.
+Maintenance can keep its daily cadence.
+
+### 3. Set-Based Stale Slug Discovery
+
+Replace per-profile, per-company, per-slug lookup loops with one set-based query
+that returns distinct stale `(source, slug)` pairs for all active profiles.
+
+The service boundary should separate:
+
+- `list_stale_for_profile(profile_id)` for manual sync progress and tests
+- `list_stale_for_active_profiles()` for cron sync
+
+The cron path should not call `prune_and_enqueue()` once per profile if that
+causes repeated `Company` and `SlugFetch` reads for shared provider slugs.
+Instead, it should:
+
+1. find all active profile target companies
+2. expand `companies.provider_slugs`
+3. left join `slug_fetches`
+4. filter invalid rows and `last_fetched_at < now() - interval '6 hours'`
+5. enqueue each distinct provider slug once
+6. update affected profiles' `last_sync_*` summaries with bounded payloads
+
+This preserves shared slug freshness across users and prevents four active
+profiles from multiplying the same provider-slug scans.
+
+### 4. Narrow Application List Query
+
+The list endpoint must not load job descriptions. Replace the current
+`select(Application, Job)` list query with a projection that includes only fields
+used by `GET /api/applications`:
+
+- application id
+- status
+- generation status
+- match score
+- match summary/rationale/strengths/gaps
+- created timestamp
+- job id
+- title
+- company name
+- location
+- workplace type
+- salary
+- contract type
+- apply URL
+- posted timestamp
+
+The API response shape can stay the same with `job.description_raw` and
+`job.description` absent or `null` on list responses. Detail responses remain
+the place where descriptions are loaded.
+
+Tests should assert that the list service does not select `Job.description_raw`
+or `Job.description`. A SQLAlchemy compile-string assertion is acceptable if it
+is scoped to the repository's query builder.
+
+### 5. Detail Description Contract
+
+`GET /api/applications/{id}` currently returns both `description_raw` and
+cleaned `description`. The frontend display path should use only cleaned
+`description`.
+
+Change the detail contract to:
+
+- keep `description`
+- omit `description_raw` by default
+- optionally expose raw description only behind an explicit admin/debug query
+  parameter, if there is a real operator use case
+
+This preserves raw storage while avoiding browser transfer of duplicate
+description text. It also prevents future UI code from accidentally rendering
+raw HTML.
+
+### 6. Change-Aware Job Upserts
+
+`upsert_job()` should avoid loading and refreshing full `Job` ORM entities for
+existing postings.
+
+Use a narrow existence lookup or `INSERT ... ON CONFLICT DO UPDATE ... RETURNING`
+that returns only:
+
+- `id`
+- whether the row was inserted or updated
+- optionally a hash/change flag for description-affecting fields
+
+Add a stored or computed content fingerprint for provider payload fields that
+matter:
+
+- title
+- company name
+- location
+- workplace type
+- raw description
+- salary
+- contract type
+- apply URL
+- posted timestamp
+
+If the incoming fingerprint matches the existing fingerprint, only update
+`fetched_at` and leave wide description columns untouched. If it differs, update
+the changed content fields and recompute cleaned markdown.
+
+This reduces repeated wide-row movement during scheduled board refreshes while
+preserving freshness.
+
+### 7. Worker Scoring Reads
+
+The match worker needs the job description for LLM scoring, but not necessarily
+the full `Job` ORM row twice.
+
+Keep deterministic policy behavior intact, but make the read explicit:
+
+- load `Application` narrowly by id
+- load only the `Job` columns used by deterministic filters and scoring
+- load only the `UserProfile` columns used by profile formatting and policy
+
+This does not eliminate description transfer for real scoring work. It prevents
+incidental transfer of unrelated columns and makes future query-stat results
+easier to interpret.
+
+### 8. Frontend Polling And Auth Expiry
+
+The client should stop polling on 401 instead of repeatedly hitting authenticated
+endpoints with an expired token.
+
+Required behavior:
+
+- if any authenticated API call returns 401, clear the stored token and stop
+  sync/status/feed polling until the user signs in again
+- `/api/sync/status` polling should use exponential backoff when state remains
+  live for more than a short grace period
+- idle pages should not poll `/api/sync/status`; the current code already stops
+  after idle, but tests should lock this in
+- `/api/status` should use TanStack Query or equivalent caching with a longer
+  stale time, rather than an unconditional minute interval per mounted app
+
+This directly targets the 27,207 sync-status requests, 7,345 status requests,
+and 21,466 expired-token logs seen in the measurement window.
+
+### 9. Queue Depth Observability
+
+`api.queue_depth` emits once per minute per API process. This is acceptable if
+there is only one production API process, but it should remain bounded.
+
+Keep the metric, but make it configurable:
+
+- default interval: 60 seconds
+- production override allowed by environment
+- no more than one emitter per process
+- query must remain aggregate-only and never select queue payloads
+
+If the deployment scales API replicas, consider moving queue depth emission to a
+single worker or cron-owned process.
+
+### 10. Operator Runbook
+
+Add a short runbook covering:
+
+- how to reset `pg_stat_statements`
+- which diagnostic SQL queries to run
+- how to compare before/after rows, calls, and hot table stats
+- how to identify whether a future spike comes from frontend polling, cron, or
+  worker fetch/match activity
+
+This runbook should live near deployment docs, not only in the implementation
+plan, because it is an operational task.
+
+## Data Model
+
+Add one optional column to `jobs`:
+
+- `content_hash text null`
+
+Backfill `content_hash` lazily during the next provider refresh or with a small
+maintenance migration. The initial migration can add the nullable column only;
+the upsert path can populate it for new and changed rows.
+
+No schema change is required for `description_raw` or `description`.
+
+## API Contracts
+
+`GET /api/applications`
+
+- response remains a list of application summaries
+- job object remains present
+- description fields are not included or are always `null`
+
+`GET /api/applications/{id}`
+
+- includes cleaned `job.description`
+- does not include `job.description_raw` by default
+- optional debug raw exposure must be authenticated and explicit if added
+
+`GET /api/sync/status`
+
+- response shape remains stable
+- server should keep work bounded to counts and small arrays
+
+`GET /api/status`
+
+- response shape remains stable
+- client reduces request rate
+
+## Error Handling
+
+- If `pg_stat_statements` is unavailable, startup must not fail. The runbook
+  should report that measurement is disabled and instruct the operator to create
+  the extension.
+- If the sync cron runs before the 6-hour freshness window, it should either not
+  run or return a cheap no-op response.
+- If content-hash comparison fails for unexpected nulls or old rows, update the
+  row normally. Correctness beats skipping a real posting update.
+- If a client receives 401, polling stops and the user is treated as signed out.
+- If detail callers expect `description_raw`, they must move to the explicit
+  debug path or cleaned `description`.
+
+## Testing
+
+Backend tests:
+
+- `list_applications` query does not include `description_raw` or `description`.
+- application list response keeps the expected card fields.
+- application detail response includes cleaned `description` and omits raw by
+  default.
+- optional raw-description debug path, if implemented, is explicit and
+  authenticated.
+- cron sync does not run profile-by-profile stale slug scans when using the
+  active-profile helper.
+- set-based stale slug discovery deduplicates provider slugs shared by multiple
+  profiles.
+- unchanged job upsert avoids rewriting description columns and preserves
+  `description_raw`.
+- changed job upsert updates full `description_raw` and cleaned `description`.
+
+Frontend tests:
+
+- polling stops after a 401.
+- `/api/sync/status` is not polled while unauthenticated.
+- `/api/sync/status` backs off during long-running live states.
+- `/api/status` is cached or interval-bounded.
+- application list rendering does not require description fields.
+- application detail rendering uses cleaned `description`.
+
+Operational verification:
+
+- enable and reset `pg_stat_statements`
+- run for 24 hours
+- compare query calls and returned rows against the pre-change evidence
+- verify `/internal/cron/sync` request count drops from about 96/day to about
+  4/day if the 6-hour schedule is used
+- verify `/api/sync/status` and `/api/status` request counts drop after token
+  expiry and idle-state fixes
+- verify `jobs` updates fall when unchanged provider postings are refetched
+
+## Rollout
+
+1. Deploy measurement and polling/auth fixes first.
+2. Change cron cadence and stale-slug discovery.
+3. Narrow application list/detail queries.
+4. Add content-hash/change-aware job upserts.
+5. Reset `pg_stat_statements` and measure for 24 hours.
+6. If transfer remains high, use the new query ranking to target the next
+   highest contributor.
+
+The changes are mostly backward compatible. The main contract change is removing
+default `description_raw` from application detail responses. That is intentional
+because raw descriptions are archival storage, not routine UI payload.
+
+## Acceptance Criteria
+
+- `pg_stat_statements` is available or the runbook clearly reports why it is
+  unavailable.
+- `/internal/cron/sync` no longer runs roughly every 15 minutes in production.
+- Application list DB queries do not transfer job description columns.
+- Application detail responses do not include raw descriptions by default.
+- Unchanged provider postings do not rewrite full job description columns.
+- Expired-token polling stops after the first 401.
+- A 24-hour post-deploy measurement shows a clear drop in hot endpoint request
+  counts and hot query row counts.
+

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -28,6 +28,24 @@ describe('api client', () => {
       await expect(api.getMe()).rejects.toThrow()
     })
 
+    it('clears the access token on 401', async () => {
+      sessionStorage.setItem('access_token', 'expired-token')
+      mockFetch(401, { detail: 'Invalid token' })
+
+      await expect(api.getMe()).rejects.toThrow()
+
+      expect(sessionStorage.getItem('access_token')).toBeNull()
+    })
+
+    it('clears the access token on 401 from direct fetch wrappers', async () => {
+      sessionStorage.setItem('access_token', 'expired-token')
+      mockFetch(401, { detail: 'Invalid token' })
+
+      await expect(api.resolveCompany('Acme')).rejects.toThrow()
+
+      expect(sessionStorage.getItem('access_token')).toBeNull()
+    })
+
     it('throws on 500', async () => {
       mockFetch(500, { detail: 'Internal server error' })
       await expect(api.listApplications()).rejects.toThrow()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -51,8 +51,7 @@ export interface Job {
   workplace_type: string | null
   salary: string | null
   contract_type: string | null
-  description_raw: string | null
-  description: string | null
+  description?: string | null
   apply_url: string
   posted_at: string | null
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -101,6 +101,12 @@ export interface SyncStatus {
   invalid_slugs: string[]
 }
 
+function clearAuthOnUnauthorized(status: number) {
+  if (status !== 401) return
+  sessionStorage.removeItem('access_token')
+  window.dispatchEvent(new CustomEvent('auth:token-expired'))
+}
+
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const token = sessionStorage.getItem('access_token')
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
@@ -109,6 +115,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     headers: { ...headers, ...init?.headers },
     ...init,
   })
+  clearAuthOnUnauthorized(res.status)
   if (!res.ok) {
     const text = await res.text()
     let detail: string | null = null
@@ -120,7 +127,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     } catch {
       // body wasn't JSON; fall through to raw text
     }
-    throw new Error(detail ?? `${res.status}: ${text}`)
+    throw new Error(detail ? `${res.status}: ${detail}` : `${res.status}: ${text}`)
   }
   return res.json()
 }
@@ -140,6 +147,7 @@ export const api = {
     const form = new FormData()
     form.append('file', file)
     const r = await fetch('/api/profile/upload', { method: 'POST', body: form, headers })
+    clearAuthOnUnauthorized(r.status)
     if (!r.ok) {
       const text = await r.text()
       throw new Error(`${r.status}: ${text}`)
@@ -164,6 +172,7 @@ export const api = {
       headers,
       body: JSON.stringify({ name }),
     })
+    clearAuthOnUnauthorized(resp.status)
     if (resp.status === 404) {
       throw new Error("Couldn't find that company on any of our supported boards.")
     }
@@ -240,6 +249,7 @@ export const api = {
     const headers: Record<string, string> = {}
     if (token) headers['Authorization'] = `Bearer ${token}`
     const res = await fetch(`/api/documents/${docId}/pdf`, { headers })
+    clearAuthOnUnauthorized(res.status)
     if (!res.ok) {
       const text = await res.text()
       let detail: string | null = null
@@ -273,6 +283,7 @@ export const api = {
       headers,
       body: JSON.stringify({ message }),
     }).then(async (res) => {
+      clearAuthOnUnauthorized(res.status)
       if (!res.ok) {
         const text = await res.text()
         const err = new Error(`${res.status}: ${text}`)

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -154,6 +154,21 @@ describe('AppShell sync (header button)', () => {
     expect(statusCalls).toBe(1)
   }, 6_000)
 
+  it('stops sync-status polling after a 401', async () => {
+    let statusCalls = 0
+    server.use(
+      http.get('/api/sync/status', () => {
+        statusCalls += 1
+        return HttpResponse.json({ detail: 'Invalid token' }, { status: 401 })
+      }),
+    )
+    renderShell()
+
+    await waitFor(() => expect(statusCalls).toBe(1))
+    await new Promise((r) => setTimeout(r, 3_500))
+    expect(statusCalls).toBe(1)
+  }, 6_000)
+
   it('reflects live sync state in the button aria-label and disables it', async () => {
     server.use(
       http.get('/api/sync/status', () => HttpResponse.json({

--- a/frontend/src/components/BudgetBanner.test.tsx
+++ b/frontend/src/components/BudgetBanner.test.tsx
@@ -1,11 +1,22 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
+import { vi } from 'vitest'
 import { server } from '../test/server'
 import BudgetBanner from './BudgetBanner'
 
+function renderBudgetBanner() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <BudgetBanner />
+    </QueryClientProvider>
+  )
+}
+
 describe('BudgetBanner', () => {
   it('renders nothing when budget is not exhausted', async () => {
-    render(<BudgetBanner />)
+    renderBudgetBanner()
     await waitFor(() => {
       expect(screen.queryByText(/AI features paused/)).not.toBeInTheDocument()
     })
@@ -17,7 +28,7 @@ describe('BudgetBanner', () => {
         HttpResponse.json({ budget_exhausted: true, resumes_at: null })
       )
     )
-    render(<BudgetBanner />)
+    renderBudgetBanner()
     await waitFor(() => {
       expect(screen.getByText(/AI features paused until next month/)).toBeInTheDocument()
     })
@@ -32,7 +43,7 @@ describe('BudgetBanner', () => {
         })
       )
     )
-    render(<BudgetBanner />)
+    renderBudgetBanner()
     await waitFor(() => {
       expect(screen.getByText(/AI features paused until/)).toBeInTheDocument()
     })
@@ -45,9 +56,25 @@ describe('BudgetBanner', () => {
         HttpResponse.json({ budget_exhausted: true, resumes_at: null })
       )
     )
-    render(<BudgetBanner />)
+    renderBudgetBanner()
     await waitFor(() => {
       expect(screen.getByText(/next month/)).toBeInTheDocument()
     })
+  })
+
+  it('does not use a component-local minute interval', async () => {
+    const intervalSpy = vi.spyOn(globalThis, 'setInterval')
+    let calls = 0
+    server.use(
+      http.get('/api/status', () => {
+        calls += 1
+        return HttpResponse.json({ budget_exhausted: false, resumes_at: null })
+      }),
+    )
+    renderBudgetBanner()
+    await waitFor(() => expect(calls).toBe(1))
+
+    expect(intervalSpy.mock.calls.some((call) => call[1] === 60_000)).toBe(false)
+    intervalSpy.mockRestore()
   })
 })

--- a/frontend/src/components/BudgetBanner.tsx
+++ b/frontend/src/components/BudgetBanner.tsx
@@ -1,14 +1,13 @@
-import { useEffect, useState } from 'react'
-import { api, AppStatus } from '../api/client'
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../api/client'
 
 export default function BudgetBanner() {
-  const [status, setStatus] = useState<AppStatus | null>(null)
-
-  useEffect(() => {
-    api.getStatus().then(setStatus).catch(() => {})
-    const id = setInterval(() => api.getStatus().then(setStatus).catch(() => {}), 60_000)
-    return () => clearInterval(id)
-  }, [])
+  const { data: status } = useQuery({
+    queryKey: ['app-status'],
+    queryFn: api.getStatus,
+    staleTime: 10 * 60_000,
+    refetchInterval: false,
+  })
 
   if (!status?.budget_exhausted) return null
 
@@ -18,7 +17,7 @@ export default function BudgetBanner() {
 
   return (
     <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-center text-sm text-amber-800">
-      AI features paused until {resumes} — job collection continues.
+      AI features paused until {resumes} - job collection continues.
     </div>
   )
 }

--- a/frontend/src/components/feed/MatchCard.test.tsx
+++ b/frontend/src/components/feed/MatchCard.test.tsx
@@ -29,8 +29,6 @@ function makeApp(over: Partial<Application> = {}): Application {
       workplace_type: 'hybrid',
       salary: '€90k–110k',
       contract_type: 'full-time',
-      description_raw: '',
-      description: null,
       apply_url: 'https://example.com/apply',
       posted_at: null,
     },

--- a/frontend/src/components/match-detail/MatchHero.test.tsx
+++ b/frontend/src/components/match-detail/MatchHero.test.tsx
@@ -5,7 +5,7 @@ import { MatchHero } from './MatchHero'
 const job = {
   id: 'j', title: 'Senior Backend Engineer', company_name: 'Acme', location: 'Berlin',
   workplace_type: 'hybrid', salary: '€100k', contract_type: null,
-  description_raw: null, description: null, apply_url: '#', posted_at: '2026-05-01',
+  description: null, apply_url: '#', posted_at: '2026-05-01',
 }
 
 describe('MatchHero', () => {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -27,6 +27,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    const onExpired = () => {
+      setToken(null)
+      setUser(null)
+    }
+    window.addEventListener('auth:token-expired', onExpired)
+    return () => window.removeEventListener('auth:token-expired', onExpired)
+  }, [])
+
+  useEffect(() => {
     const stored = sessionStorage.getItem('access_token')
     if (stored) {
       setToken(stored)

--- a/frontend/src/lib/useSyncControl.ts
+++ b/frontend/src/lib/useSyncControl.ts
@@ -44,6 +44,7 @@ export function useSyncControl({ enabled = true }: UseSyncControlOptions = {}): 
     if (!enabled) return
     let cancelled = false
     let timeoutId: ReturnType<typeof setTimeout> | null = null
+    let livePolls = 0
     async function poll() {
       try {
         const body = await api.getSyncStatus()
@@ -54,9 +55,16 @@ export function useSyncControl({ enabled = true }: UseSyncControlOptions = {}): 
         }
         prevState.current = body.state
         if (body.state !== 'idle') {
-          timeoutId = setTimeout(poll, POLL_MS)
+          livePolls += 1
+          const interval = Math.min(POLL_MS * Math.max(1, livePolls), 30_000)
+          timeoutId = setTimeout(poll, interval)
+        } else {
+          livePolls = 0
         }
-      } catch {
+      } catch (err) {
+        if ((err as Error)?.message?.includes('401')) {
+          return
+        }
         // Silent — control just stays "Sync now" without live state.
       }
     }

--- a/frontend/src/pages/ApplicationReview.test.tsx
+++ b/frontend/src/pages/ApplicationReview.test.tsx
@@ -19,7 +19,7 @@ function detail(over: Partial<ApplicationDetail> = {}): ApplicationDetail {
     job: {
       id: 'j', title: 'Senior Backend Engineer', company_name: 'Acme',
       location: 'Berlin', workplace_type: 'hybrid', salary: '€100k',
-      contract_type: null, description_raw: null, description: 'Acme is hiring.',
+      contract_type: null, description: 'Acme is hiring.',
       apply_url: 'https://x.com/', posted_at: null,
     },
     documents: [],
@@ -66,19 +66,12 @@ describe('Match detail (ApplicationReview)', () => {
     expect(screen.getByRole('button', { name: /save edits/i })).toBeInTheDocument()
   })
 
-  it('renders only app.job.description and ignores description_raw entirely', async () => {
-    // description_raw is the unprocessed source payload, kept server-side
-    // for re-cleaning if the cleaner changes. The match detail page must
-    // never render it, including via a fallback — the prod bug logged
-    // 2026-05-10 was a buggy cleaner storing decoded HTML in description,
-    // not a fallback firing. Re-cleaning fixes the data; this test locks
-    // in that the page renders only `description`.
+  it('renders only app.job.description', async () => {
     renderAt('/matches/a1', detail({
       job: {
         id: 'j', title: 'Senior Backend Engineer', company_name: 'Acme',
         location: null, workplace_type: null, salary: null,
         contract_type: null,
-        description_raw: '<p>Raw HTML must not surface here.</p>',
         description: 'Clean markdown body.',
         apply_url: 'https://x.com/', posted_at: null,
       },
@@ -91,16 +84,13 @@ describe('Match detail (ApplicationReview)', () => {
   })
 
   it('hides the description section entirely when description is null', async () => {
-    // No fallback to description_raw — description_raw is by name and
-    // intent the source payload, not for display. JobDescription returns
-    // null when content is empty, so the whole "Job description" heading
-    // is gone.
+    // JobDescription returns null when content is empty, so the whole
+    // "Job description" heading is gone.
     renderAt('/matches/a1', detail({
       job: {
         id: 'j', title: 'Senior Backend Engineer', company_name: 'Acme',
         location: null, workplace_type: null, salary: null,
         contract_type: null,
-        description_raw: '<p>Should not appear</p>',
         description: null,
         apply_url: 'https://x.com/', posted_at: null,
       },

--- a/frontend/src/pages/ApplicationReview.tsx
+++ b/frontend/src/pages/ApplicationReview.tsx
@@ -48,7 +48,7 @@ export default function ApplicationReview() {
           strengths={app.match_strengths}
           gaps={app.match_gaps}
         />
-        <JobDescription content={app.job.description} />
+        <JobDescription content={app.job.description ?? null} />
         <CoverLetterEditor appId={app.id} doc={cover} status={app.generation_status} />
       </div>
 

--- a/frontend/src/pages/Matches.test.tsx
+++ b/frontend/src/pages/Matches.test.tsx
@@ -17,7 +17,7 @@ function makeApp(id: string, status: string, score = 0.8): Application {
     applied_at: null,
     job: { id: `job-${id}`, title: `Job ${id}`, company_name: 'Co', location: null,
            workplace_type: null, salary: null, contract_type: null,
-           description_raw: null, description: null, apply_url: 'https://x.com', posted_at: null },
+           apply_url: 'https://x.com', posted_at: null },
   }
 }
 

--- a/scripts/neon_egress_diagnostics.sql
+++ b/scripts/neon_egress_diagnostics.sql
@@ -1,0 +1,58 @@
+-- Neon egress diagnostics.
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/neon_egress_diagnostics.sql
+--
+-- These reports rank query candidates by rows and call frequency. They are not
+-- exact byte-level network-transfer reports.
+
+\echo 'pg_stat_statements availability'
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_extension
+  WHERE extname = 'pg_stat_statements'
+) AS pg_stat_statements_installed;
+
+\echo 'top total returned rows'
+SELECT query, calls, rows AS total_rows, rows / NULLIF(calls, 0) AS avg_rows_per_call
+FROM pg_stat_statements
+WHERE calls > 0
+ORDER BY rows DESC
+LIMIT 20;
+
+\echo 'top rows per call'
+SELECT query, calls, rows AS total_rows, rows / NULLIF(calls, 0) AS avg_rows_per_call
+FROM pg_stat_statements
+WHERE calls > 0
+ORDER BY avg_rows_per_call DESC NULLS LAST
+LIMIT 20;
+
+\echo 'most frequent queries'
+SELECT query, calls, rows AS total_rows, rows / NULLIF(calls, 0) AS avg_rows_per_call
+FROM pg_stat_statements
+WHERE calls > 0
+ORDER BY calls DESC
+LIMIT 20;
+
+\echo 'longest total execution time'
+SELECT query, calls, rows AS total_rows,
+       round(total_exec_time::numeric, 2) AS total_exec_time_ms
+FROM pg_stat_statements
+WHERE calls > 0
+ORDER BY total_exec_time DESC
+LIMIT 20;
+
+\echo 'hot table stats'
+SELECT relname,
+       n_live_tup,
+       n_dead_tup,
+       seq_scan,
+       seq_tup_read,
+       idx_scan,
+       idx_tup_fetch,
+       n_tup_ins,
+       n_tup_upd,
+       n_tup_del,
+       pg_size_pretty(pg_total_relation_size(relid)) AS total_size
+FROM pg_stat_user_tables
+ORDER BY seq_tup_read + idx_tup_fetch DESC
+LIMIT 30;

--- a/tests/integration/test_applications_api_summary.py
+++ b/tests/integration/test_applications_api_summary.py
@@ -58,9 +58,10 @@ async def test_list_endpoint_includes_match_summary(db_session, auth_headers, se
 
 
 @pytest.mark.asyncio
-async def test_detail_endpoint_exposes_description(db_session, auth_headers, seeded_user):
-    """GET /api/applications/{id} surfaces description (markdownified) alongside
-    the raw description_raw so the SPA can render readable text instead of HTML."""
+async def test_application_detail_omits_raw_description_by_default(
+    db_session, auth_headers, seeded_user
+):
+    """GET /api/applications/{id} surfaces cleaned description and omits raw HTML."""
     from app.main import app as fastapi_app
 
     _user, profile = seeded_user
@@ -93,5 +94,4 @@ async def test_detail_endpoint_exposes_description(db_session, auth_headers, see
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["job"]["description"] == "## Who we are\n\nCool company."
-    # description_raw kept alongside for backward compat / null-fallback.
-    assert payload["job"]["description_raw"] == "<h2>Who we are</h2><p>Cool company.</p>"
+    assert "description_raw" not in payload["job"]

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import UTC, datetime
 
 import pytest
-from sqlmodel import select
+from sqlmodel import col, select
 
 from app.models.job import Job
 from app.services import job_sync_service
@@ -181,6 +181,171 @@ async def test_sync_active_profiles_uses_shared_enqueue_contract(db_session):
         .all()
     )
     assert [row.dedupe_key for row in queue_rows] == ["fetch-slug:greenhouse:active-co"]
+
+
+@pytest.mark.asyncio
+async def test_sync_active_profiles_deduplicates_shared_provider_slugs(db_session):
+    from datetime import timedelta
+
+    from app.models.company import Company
+    from app.models.slug_fetch import SlugFetch
+    from app.models.user import User
+    from app.models.user_profile import UserProfile
+    from app.models.work_queue import WorkQueue
+
+    company = Company(
+        canonical_name="Shared Co",
+        normalized_key=f"shared-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "shared-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.add(company)
+    await db_session.commit()
+    await db_session.refresh(company)
+
+    users = [
+        User(id=uuid.uuid4(), email=f"shared-{i}-{uuid.uuid4()}@test.com")
+        for i in range(2)
+    ]
+    db_session.add_all(users)
+    await db_session.commit()
+    db_session.add_all(
+        [
+            UserProfile(
+                user_id=users[0].id,
+                email=users[0].email,
+                search_active=True,
+                target_company_ids=[company.id],
+            ),
+            UserProfile(
+                user_id=users[1].id,
+                email=users[1].email,
+                search_active=True,
+                target_company_ids=[company.id],
+            ),
+            SlugFetch(
+                source="greenhouse",
+                slug="shared-co",
+                last_fetched_at=datetime.now(UTC) - timedelta(hours=7),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    result = await job_sync_service.sync_active_profiles(db_session)
+
+    assert result["active_profiles"] == 2
+    assert result["profiles_enqueued"] == 2
+    assert result["enqueued"] == ["shared-co"]
+    rows = (
+        (
+            await db_session.execute(
+                select(WorkQueue).where(WorkQueue.job_type == "fetch-slug")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [row.dedupe_key for row in rows] == ["fetch-slug:greenhouse:shared-co"]
+    profiles = (
+        (
+            await db_session.execute(
+                select(UserProfile).where(col(UserProfile.search_active).is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    summaries = {profile.email: profile.last_sync_summary for profile in profiles}
+    assert summaries[users[0].email]["queued_slugs"] == ["shared-co"]
+    assert summaries[users[1].email]["queued_slugs"] == ["shared-co"]
+
+
+@pytest.mark.asyncio
+async def test_sync_active_profiles_keeps_profile_specific_summaries_and_pruning(db_session):
+    from datetime import timedelta
+
+    from app.models.company import Company
+    from app.models.slug_fetch import SlugFetch
+    from app.models.user import User
+    from app.models.user_profile import UserProfile
+
+    stale_company = Company(
+        canonical_name="Stale Co",
+        normalized_key=f"stale-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "stale-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    fresh_company = Company(
+        canonical_name="Fresh Co",
+        normalized_key=f"fresh-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "fresh-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    invalid_company = Company(
+        canonical_name="Invalid Co",
+        normalized_key=f"invalid-{uuid.uuid4()}",
+        provider_slugs={"greenhouse": "invalid-co"},
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.add_all([stale_company, fresh_company, invalid_company])
+    await db_session.commit()
+    await db_session.refresh(stale_company)
+    await db_session.refresh(fresh_company)
+    await db_session.refresh(invalid_company)
+
+    stale_user = User(id=uuid.uuid4(), email=f"stale-{uuid.uuid4()}@test.com")
+    fresh_user = User(id=uuid.uuid4(), email=f"fresh-{uuid.uuid4()}@test.com")
+    db_session.add_all([stale_user, fresh_user])
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            UserProfile(
+                user_id=stale_user.id,
+                email=stale_user.email,
+                search_active=True,
+                target_company_ids=[stale_company.id],
+            ),
+            UserProfile(
+                user_id=fresh_user.id,
+                email=fresh_user.email,
+                search_active=True,
+                target_company_ids=[fresh_company.id, invalid_company.id],
+            ),
+            SlugFetch(
+                source="greenhouse",
+                slug="stale-co",
+                last_fetched_at=datetime.now(UTC) - timedelta(hours=7),
+            ),
+            SlugFetch(
+                source="greenhouse",
+                slug="fresh-co",
+                last_fetched_at=datetime.now(UTC),
+            ),
+            SlugFetch(source="greenhouse", slug="invalid-co", is_invalid=True),
+        ]
+    )
+    await db_session.commit()
+
+    result = await job_sync_service.sync_active_profiles(db_session)
+
+    assert result["enqueued"] == ["stale-co"]
+    assert result["pruned"] == 1
+    refreshed_profiles = (
+        (
+            await db_session.execute(
+                select(UserProfile).where(col(UserProfile.search_active).is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    summaries = {profile.email: profile.last_sync_summary for profile in refreshed_profiles}
+    assert summaries[stale_user.email]["queued_slugs"] == ["stale-co"]
+    assert summaries[stale_user.email]["pruned_slugs"] == []
+    assert summaries[fresh_user.email]["queued_slugs"] == []
+    assert summaries[fresh_user.email]["pruned_slugs"] == ["greenhouse:invalid-co"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_job_sync.py
+++ b/tests/integration/test_job_sync.py
@@ -50,6 +50,68 @@ async def test_upsert_job_updates_existing(db_session):
 
 
 @pytest.mark.asyncio
+async def test_upsert_job_unchanged_payload_avoids_wide_select_and_update(db_session):
+    from sqlalchemy import event
+
+    job_data = make_job_data(external_id="stable-1", title="Stable Engineer")
+    first, created = await upsert_job(job_data, "greenhouse", db_session)
+    assert created is True
+
+    statements: list[str] = []
+    engine = db_session.bind.sync_engine
+
+    def capture_statement(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement.lower())
+
+    event.listen(engine, "before_cursor_execute", capture_statement)
+    try:
+        second, created = await upsert_job(job_data, "greenhouse", db_session)
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_statement)
+
+    selects = "\n".join(stmt for stmt in statements if stmt.lstrip().startswith("select"))
+    updates = "\n".join(stmt for stmt in statements if stmt.lstrip().startswith("update"))
+
+    assert created is False
+    assert second.id == first.id
+    assert "description_raw" not in selects
+    assert "jobs.description," not in selects
+    assert "description_raw" not in updates
+    assert "description =" not in updates
+
+    refreshed = await db_session.get(Job, first.id)
+    assert refreshed.description_raw == job_data.description_raw
+    assert refreshed.description and "Python engineer" in refreshed.description
+
+
+@pytest.mark.asyncio
+async def test_upsert_job_populates_content_hash(db_session):
+    job_data = make_job_data(external_id="stable-hash-1", title="Stable Engineer")
+    job, created = await upsert_job(job_data, "greenhouse", db_session)
+
+    assert created is True
+    assert job.content_hash is not None
+    assert len(job.content_hash) == 64
+
+
+@pytest.mark.asyncio
+async def test_upsert_job_changes_content_hash_when_description_changes(db_session):
+    job_data = make_job_data(external_id="stable-2", title="Stable Engineer")
+    first, _ = await upsert_job(job_data, "greenhouse", db_session)
+    first_hash = first.content_hash
+
+    changed = make_job_data(external_id="stable-2", title="Stable Engineer")
+    changed.description_raw = "A different role description."
+    second, created = await upsert_job(changed, "greenhouse", db_session)
+
+    assert created is False
+    assert second.id == first.id
+    assert second.content_hash != first_hash
+    assert second.description_raw == "A different role description."
+    assert "different role" in (second.description or "")
+
+
+@pytest.mark.asyncio
 async def test_mark_stale_jobs(db_session):
     from datetime import timedelta
 

--- a/tests/integration/test_match_scoring.py
+++ b/tests/integration/test_match_scoring.py
@@ -139,7 +139,7 @@ async def test_list_applications_excludes_auto_rejected(db_session):
     await db_session.commit()
 
     rows = await list_applications(profile.id, db_session, status="pending_review")
-    ids = [str(app.id) for app, _ in rows]
+    ids = [str(row[0]) for row in rows]
 
     assert str(app1.id) in ids
     assert str(app2.id) not in ids
@@ -185,7 +185,7 @@ async def test_list_applications_ordering(db_session):
     await db_session.commit()
 
     rows = await list_applications(profile.id, db_session)
-    titles = [job.title for _, job in rows]
+    titles = [row[10] for row in rows]
 
     assert titles == [
         "High Score Recent Salary",
@@ -312,8 +312,8 @@ async def test_score_and_match_picks_unscored_jobs_when_pool_is_largely_scored(d
 
 
 @pytest.mark.asyncio
-async def test_list_applications_returns_job_data(db_session):
-    """list_applications returns (Application, Job) tuples — no N+1 queries needed."""
+async def test_list_applications_returns_projected_job_data(db_session):
+    """list_applications returns projected application/job tuples without ORM-wide job rows."""
     profile = await _seed_profile(db_session)
     job = await _seed_job(db_session, title="Python Engineer", salary="$120k")
 
@@ -326,11 +326,11 @@ async def test_list_applications_returns_job_data(db_session):
     rows = await list_applications(profile.id, db_session)
     assert len(rows) == 1
 
-    returned_app, returned_job = rows[0]
-    assert returned_app.id == app.id
-    assert returned_job.id == job.id
-    assert returned_job.title == "Python Engineer"
-    assert returned_job.salary == "$120k"
+    row = rows[0]
+    assert row[0] == app.id
+    assert row[9] == job.id
+    assert row[10] == "Python Engineer"
+    assert row[14] == "$120k"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sources/test_ashby_board.py
+++ b/tests/unit/sources/test_ashby_board.py
@@ -177,7 +177,11 @@ async def test_fetch_jobs_5xx_raises_transient(src):
 @respx.mock
 @pytest.mark.asyncio
 async def test_fetch_jobs_filters_by_since(src):
-    recent = _posting(1, "2026-05-05T12:00:00Z")
+    recent_posted_at = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace(
+        "+00:00",
+        "Z",
+    )
+    recent = _posting(1, recent_posted_at)
     old = _posting(2, "2025-01-01T00:00:00Z")
     respx.get(f"{ASHBY_POSTINGS_BASE}/acme").respond(200, json=_payload(recent, old))
     cutoff = datetime.now(UTC) - timedelta(days=14)

--- a/tests/unit/sources/test_lever_postings.py
+++ b/tests/unit/sources/test_lever_postings.py
@@ -205,7 +205,11 @@ async def test_fetch_jobs_falls_back_to_description_when_html_missing(src):
 @respx.mock
 @pytest.mark.asyncio
 async def test_fetch_jobs_filters_by_since(src):
-    recent = _posting(1, "2026-05-05T12:00:00Z")
+    recent_posted_at = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace(
+        "+00:00",
+        "Z",
+    )
+    recent = _posting(1, recent_posted_at)
     old = _posting(2, "2025-01-01T00:00:00Z")
     respx.get(f"{LEVER_POSTINGS_BASE}/acme").mock(
         side_effect=[

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,3 +16,17 @@ def test_job_stale_after_days_default_is_21():
 
     s = Settings(database_url="postgresql://x:x@x/x")
     assert s.job_stale_after_days == 21
+
+
+def test_queue_depth_emit_interval_can_be_configured(monkeypatch):
+    from app import config
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@localhost:5432/db")
+    monkeypatch.setenv("QUEUE_DEPTH_EMIT_INTERVAL_S", "17")
+    config._settings = None
+
+    try:
+        settings = config.get_settings()
+        assert settings.queue_depth_emit_interval_s == 17
+    finally:
+        config._settings = None

--- a/tests/unit/test_internal_cron.py
+++ b/tests/unit/test_internal_cron.py
@@ -73,7 +73,20 @@ def test_sync_wrong_secret_returns_403():
 
 def test_sync_correct_secret_calls_task():
     client = make_app(secret="real-secret")
-    with patch("app.api.internal_cron.get_session_factory", return_value=lambda: _FakeSession()):
+    with (
+        patch("app.api.internal_cron.get_session_factory", return_value=lambda: _FakeSession()),
+        patch(
+            "app.services.job_sync_service.sync_active_profiles",
+            new=AsyncMock(
+                return_value={
+                    "enqueued": [],
+                    "pruned": 0,
+                    "active_profiles": 0,
+                    "profiles_enqueued": 0,
+                }
+            ),
+        ),
+    ):
         resp = client.post("/internal/cron/sync", headers={"X-Cron-Secret": "real-secret"})
     assert resp.status_code == 202
     assert resp.json() == {
@@ -144,10 +157,11 @@ def test_sync_unexpected_exception_returns_500():
     # plus the @type marker in _add_cloud_run_severity are what surface it to GCP
     # Error Reporting — that path is covered separately in test_logging.py.
     client = make_app(secret="real-secret", raise_server_exceptions=False)
-    with patch(
-        "app.api.internal_cron.get_session_factory",
-        return_value=lambda: _FakeSession(
-            execute_error=RuntimeError("db connection refused")
+    with (
+        patch("app.api.internal_cron.get_session_factory", return_value=lambda: _FakeSession()),
+        patch(
+            "app.services.job_sync_service.sync_active_profiles",
+            new=AsyncMock(side_effect=RuntimeError("db connection refused")),
         ),
     ):
         resp = client.post(

--- a/tests/unit/test_job_sync_service.py
+++ b/tests/unit/test_job_sync_service.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
+from uuid import UUID
 
 import pytest
 
@@ -24,37 +25,73 @@ class _Session:
     async def execute(self, stmt):
         return _ScalarResult(self._rows)
 
+    def add(self, row):
+        return None
+
+    async def commit(self):
+        return None
+
 
 @pytest.mark.asyncio
 async def test_sync_active_profiles_aggregates_shared_enqueue_contract():
-    profiles = [SimpleNamespace(id="p1"), SimpleNamespace(id="p2")]
+    profiles = [
+        SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000001")),
+        SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000002")),
+    ]
     session = _Session(profiles)
 
-    with patch(
-        "app.services.job_sync_service.prune_and_enqueue",
-        new=AsyncMock(
-            side_effect=[
-                {
-                    "queued_slugs": ["airbnb", "stripe"],
-                    "matched_now": 0,
-                    "pruned_slugs": ["greenhouse:deadcorp"],
-                },
-                {
-                    "queued_slugs": [],
-                    "matched_now": 0,
-                    "pruned_slugs": [],
-                },
-            ]
-        ),
-    ) as mock_prune:
+    stale_rows = [
+        (profiles[0].id, "greenhouse", "airbnb"),
+        (profiles[0].id, "greenhouse", "stripe"),
+        (profiles[1].id, "greenhouse", "airbnb"),
+    ]
+    with (
+        patch(
+            "app.services.job_sync_service._prune_invalid_provider_slugs",
+            new=AsyncMock(
+                side_effect=[
+                    ["greenhouse:deadcorp"],
+                    [],
+                ]
+            ),
+        ) as mock_prune,
+        patch(
+            "app.services.job_sync_service.slug_registry_service.list_stale_for_active_profiles",
+            new=AsyncMock(return_value=stale_rows),
+        ) as mock_list_stale,
+        patch(
+            "app.services.job_sync_service.enqueue",
+            new=AsyncMock(return_value=123),
+        ) as mock_enqueue,
+    ):
         result = await job_sync_service.sync_active_profiles(session)
 
     assert result == {
         "enqueued": ["airbnb", "stripe"],
         "pruned": 1,
         "active_profiles": 2,
-        "profiles_enqueued": 1,
+        "profiles_enqueued": 2,
     }
     assert mock_prune.await_count == 2
     mock_prune.assert_any_await(profiles[0], session)
     mock_prune.assert_any_await(profiles[1], session)
+    mock_list_stale.assert_awaited_once_with(session, ttl_hours=6)
+    assert mock_enqueue.await_count == 2
+    assert [call.kwargs["payload"] for call in mock_enqueue.await_args_list] == [
+        {"provider": "greenhouse", "slug": "airbnb"},
+        {"provider": "greenhouse", "slug": "stripe"},
+    ]
+    assert [call.kwargs["dedupe_key"] for call in mock_enqueue.await_args_list] == [
+        "fetch-slug:greenhouse:airbnb",
+        "fetch-slug:greenhouse:stripe",
+    ]
+    assert profiles[0].last_sync_summary == {
+        "queued_slugs": ["airbnb", "stripe"],
+        "matched_now": 0,
+        "pruned_slugs": ["greenhouse:deadcorp"],
+    }
+    assert profiles[1].last_sync_summary == {
+        "queued_slugs": ["airbnb"],
+        "matched_now": 0,
+        "pruned_slugs": [],
+    }

--- a/tests/unit/test_match_service_queries.py
+++ b/tests/unit/test_match_service_queries.py
@@ -1,0 +1,11 @@
+import uuid
+
+
+def test_application_list_query_does_not_select_job_descriptions():
+    from app.services.match_service import build_application_list_query
+
+    query = build_application_list_query(uuid.uuid4(), status=None, min_score=None)
+    compiled = str(query.compile(compile_kwargs={"literal_binds": False})).lower()
+
+    assert "jobs.description_raw" not in compiled
+    assert "jobs.description" not in compiled

--- a/tests/unit/test_match_service_queries.py
+++ b/tests/unit/test_match_service_queries.py
@@ -9,3 +9,21 @@ def test_application_list_query_does_not_select_job_descriptions():
 
     assert "jobs.description_raw" not in compiled
     assert "jobs.description" not in compiled
+
+
+def test_score_candidate_query_selects_only_scoring_columns():
+    from app.services.match_service import build_score_candidate_query
+
+    query = build_score_candidate_query(
+        company_ids=[uuid.uuid4()],
+        matched_ids=set(),
+        limit=20,
+    )
+    compiled = str(query.compile(compile_kwargs={"literal_binds": False})).lower()
+    selected = compiled.split(" from ", 1)[0]
+
+    assert "select jobs.id" in compiled
+    assert "jobs.description_raw" in selected
+    assert "jobs.description," in selected
+    assert "jobs.created_at" not in compiled
+    assert "jobs.updated_at" not in compiled

--- a/uv.lock
+++ b/uv.lock
@@ -635,7 +635,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.135.3"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -644,9 +644,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1043,16 +1043,16 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
-    { name = "fastapi", specifier = ">=0.115" },
-    { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=13.0" },
+    { name = "fastapi", specifier = ">=0.136.1" },
+    { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=15.0.5" },
     { name = "fpdf2", specifier = ">=2.8" },
     { name = "google-api-core", specifier = ">=2.0" },
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "httpx-oauth", specifier = ">=0.13" },
-    { name = "langchain", specifier = ">=0.3" },
-    { name = "langchain-google-genai", specifier = ">=2.0" },
-    { name = "langgraph", specifier = ">=0.2" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=2.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx-oauth", specifier = ">=0.16.1" },
+    { name = "langchain", specifier = ">=1.3.0" },
+    { name = "langchain-google-genai", specifier = ">=4.2.2" },
+    { name = "langgraph", specifier = ">=1.2.0" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.0" },
     { name = "langsmith", specifier = ">=0.1" },
     { name = "markdown2", specifier = ">=2.4" },
     { name = "markdownify", specifier = ">=0.13" },
@@ -1060,11 +1060,11 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.4" },
     { name = "pypdf", specifier = ">=4.0" },
     { name = "python-docx", specifier = ">=1.0" },
-    { name = "python-multipart", specifier = ">=0.0.9" },
-    { name = "sqlmodel", specifier = ">=0.0.21" },
+    { name = "python-multipart", specifier = ">=0.0.28" },
+    { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "trafilatura", specifier = ">=2.0.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.46.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1072,7 +1072,7 @@ dev = [
     { name = "anyio", specifier = ">=4.0" },
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "mypy", specifier = ">=1.11" },
-    { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -1116,24 +1116,25 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.15"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e5/6350e77a9e2764eaafcb2d581cbf0b800f53c6bc98fdf5ebc85f3a931ded/langchain-1.3.1.tar.gz", hash = "sha256:bc283c220233230f48b8e50ab1fbf1b688bcb206d933fa448d40a9b143177f62", size = 581329, upload-time = "2026-05-15T18:14:55.368Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
+    { url = "https://files.pythonhosted.org/packages/78/11/3d7ed10b535413a07ed5e15682abcb77f3c4204ac49586977a495f9b24e6/langchain-1.3.1-py3-none-any.whl", hash = "sha256:154e9c30c90b391eba4315296f6bf6b6fac6b058ddea4cc771a10470968fe36f", size = 114345, upload-time = "2026-05-15T18:14:53.984Z" },
 ]
 
 [[package]]
 name = "langchain-core"
-version = "1.2.29"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -1142,9 +1143,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/d8/7bdf30e4bfc5175609201806e399506a0a78a48e14367dc8b776a9b4c89c/langchain_core-1.2.29.tar.gz", hash = "sha256:cfb89c92bca81ad083eafcdfe6ec40f9803c9abf7dd166d0f8a8de1d2de03ca6", size = 846121, upload-time = "2026-04-14T20:44:58.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/37/fed31f80436b1d7bb222f1f2345300a77a88215416acf8d1cb7c8fda7388/langchain_core-1.2.29-py3-none-any.whl", hash = "sha256:11f02e57ee1c24e6e0e6577acbd35df77b205d4692a3df956b03b5389cbe44a0", size = 508733, upload-time = "2026-04-14T20:44:56.712Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
 ]
 
 [[package]]
@@ -1163,8 +1164,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
+]
+
+[[package]]
 name = "langgraph"
-version = "1.1.6"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1174,27 +1187,27 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/8e/34a57e338a319e3b32c1bd183c2a9a04f7f35d683d3f3d8f597f6eacbc4e/langgraph-1.2.1.tar.gz", hash = "sha256:28314f844678d9d307cbd63e7b48b0145bf17177d84b40ee2921061e07b6f966", size = 693750, upload-time = "2026-05-21T18:33:07.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
+    { url = "https://files.pythonhosted.org/packages/73/8c/313912e26866893bd15be9b4ea3442dc86f69270b0ad01a4961d1eba7118/langgraph-1.2.1-py3-none-any.whl", hash = "sha256:5cc4020de8f1e2a048d773f6e9128646a2af8c68a8067ab9cab177a2fcc8d221", size = 235317, upload-time = "2026-05-21T18:33:05.687Z" },
 ]
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.1"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/44/a8df45d1e8b4637e29789fa8bae1db022c953cc7ac80093cfc52e923547e/langgraph_checkpoint-4.0.1.tar.gz", hash = "sha256:b433123735df11ade28829e40ce25b9be614930cd50245ff2af60629234befd9", size = 158135, upload-time = "2026-02-27T21:06:16.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/b4/6005c5dd88ad484fe6235d4c43a0d2cee7e91b08ad85a180985c2662df87/langgraph_checkpoint-4.1.0.tar.gz", hash = "sha256:e5bb304e30fc1363ac8fcb5f7dee5ca2185d77fe475b0d01de2c5f91324c2c21", size = 181942, upload-time = "2026-05-12T03:33:49.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/4c/09a4a0c42f5d2fc38d6c4d67884788eff7fd2cfdf367fdf7033de908b4c0/langgraph_checkpoint-4.0.1-py3-none-any.whl", hash = "sha256:e3adcd7a0e0166f3b48b8cf508ce0ea366e7420b5a73aa81289888727769b034", size = 50453, upload-time = "2026-02-27T21:06:14.293Z" },
+    { url = "https://files.pythonhosted.org/packages/93/74/d3be2b41955e20ccd624dba5f6fe9d38dcee385ba470a6e13ed86732fc86/langgraph_checkpoint-4.1.0-py3-none-any.whl", hash = "sha256:8bc2a0466a20c38b865ce6671b42093fd5c041133f32351cae4222e0eeaf7fb5", size = 56047, upload-time = "2026-05-12T03:33:48.548Z" },
 ]
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.0.5"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langgraph-checkpoint" },
@@ -1202,22 +1215,22 @@ dependencies = [
     { name = "psycopg" },
     { name = "psycopg-pool" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7a/8f439966643d32111248a225e6cb33a182d07c90de780c4dbfc1e0377832/langgraph_checkpoint_postgres-3.0.5.tar.gz", hash = "sha256:a8fd7278a63f4f849b5cbc7884a15ca8f41e7d5f7467d0a66b31e8c24492f7eb", size = 127856, upload-time = "2026-03-18T21:25:29.785Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/51/5a2dc42e8b5d5942b933b5b7237eae5a4dbc92508a04727c263dd383ad8a/langgraph_checkpoint_postgres-3.1.0.tar.gz", hash = "sha256:02bff4ab63d9dae8eab3a9640fce1d479da8965c9fba7b0dc04cb1f7c56f0a55", size = 148473, upload-time = "2026-05-12T03:40:10.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/87/b0f98b33a67204bca9d5619bcd9574222f6b025cf3c125eedcec9a50ecbc/langgraph_checkpoint_postgres-3.0.5-py3-none-any.whl", hash = "sha256:86d7040a88fd70087eaafb72251d796696a0a2d856168f5c11ef620771411552", size = 42907, upload-time = "2026-03-18T21:25:28.75Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/cd/eff9b82bc3b5f62d481b437099f44f3ef7b1d907f166fb4ee25e8f84a1e7/langgraph_checkpoint_postgres-3.1.0-py3-none-any.whl", hash = "sha256:814cce2ef35d792bf07b090a95eed004f1acac0724fe6605536b13f6d1e7032c", size = 48988, upload-time = "2026-05-12T03:40:08.925Z" },
 ]
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.9"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
 ]
 
 [[package]]
@@ -1776,7 +1789,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.5.1"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -1785,9 +1798,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -2162,11 +2175,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -2633,15 +2646,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.44.0"
+version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- add Neon egress diagnostics/runbook and deployment guidance
- dedupe active-profile slug sync and skip wide job updates when postings are unchanged
- narrow application, detail, and worker scoring reads to reduce payload size
- stop stale frontend auth polling and make queue-depth emission configurable
- stabilize related tests and lockfile consistency

## Verification
- uv run ruff check app/ tests/
- uv run pytest tests/unit/ -v
- npm test -- client.test.ts AppShell.test.tsx BudgetBanner.test.tsx ApplicationReview.test.tsx MatchCard.test.tsx
- npm run typecheck
- uv run alembic heads

## Known limitation
- targeted integration tests in tests/integration/test_job_sync.py could not run in this environment because Testcontainers could not reach the Docker Unix socket.