### PR TITLE
[codex] Wire Gemini batch match canary

### DIFF
--- a/app/services/batch_match_provider.py
+++ b/app/services/batch_match_provider.py
@@ -80,5 +80,7 @@ def get_batch_match_provider() -> BatchMatchProvider:
     ):
         return FakeBatchMatchProvider(ready=False)
     if settings.batch_match_provider == "gemini":
-        raise ValueError("gemini batch match provider is not implemented")
+        from app.services.gemini_batch_match_provider import GeminiBatchMatchProvider
+
+        return GeminiBatchMatchProvider()
     raise ValueError(f"unknown batch match provider: {settings.batch_match_provider}")

--- a/app/services/gemini_batch_match_provider.py
+++ b/app/services/gemini_batch_match_provider.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
+import asyncio
 import json
+from typing import Any
+
+from google import genai
 
 from app.agents.matching_agent import SCORING_SYSTEM_PROMPT
-from app.services.batch_match_provider import ProviderBatchOutput, ProviderBatchStatus
+from app.config import get_settings
+from app.services.batch_match_provider import (
+    ProviderBatchOutput,
+    ProviderBatchStatus,
+    ProviderJobResult,
+    ProviderRequestResult,
+)
+
+_TERMINAL_FAILED_STATES = {
+    "JOB_STATE_FAILED",
+    "JOB_STATE_CANCELLED",
+    "JOB_STATE_EXPIRED",
+    "JOB_STATE_PARTIALLY_SUCCEEDED",
+}
 
 
 def build_gemini_batch_request(request_key: str, profile_text: str, jobs: list[dict]) -> dict:
@@ -15,14 +32,212 @@ def build_gemini_batch_request(request_key: str, profile_text: str, jobs: list[d
 
 
 class GeminiBatchMatchProvider:
+    def __init__(self, *, client: Any | None = None, model: str | None = None) -> None:
+        if client is not None and model is not None:
+            self.client = client
+            self.model = model
+            return
+
+        settings = get_settings()
+        self.model = model or settings.llm_matching_model
+        if client is not None:
+            self.client = client
+            return
+        api_key = settings.google_api_key.get_secret_value()
+        if not api_key:
+            raise ValueError("google_api_key must be set for gemini batch matching")
+        self.client = genai.Client(api_key=api_key)
+
     async def submit(self, *, requests: list[dict], display_name: str) -> str:
-        raise RuntimeError("Gemini batch submit API wiring is required before use")
+        inline_requests = [_inline_request(request) for request in requests]
+        batch_job = await asyncio.to_thread(
+            self.client.batches.create,
+            model=self.model,
+            src=inline_requests,
+            config={"display_name": display_name},
+        )
+        provider_batch_id = getattr(batch_job, "name", None)
+        if not provider_batch_id:
+            raise RuntimeError("Gemini batch create did not return a job name")
+        return str(provider_batch_id)
 
     async def poll(self, *, provider_batch_id: str) -> ProviderBatchStatus:
-        raise RuntimeError("Gemini batch poll API wiring is required before use")
+        batch_job = await asyncio.to_thread(
+            self.client.batches.get,
+            name=provider_batch_id,
+        )
+        state = _state_name(getattr(batch_job, "state", None))
+        if state == "JOB_STATE_SUCCEEDED":
+            return ProviderBatchStatus(ready=True)
+        if state in _TERMINAL_FAILED_STATES:
+            return ProviderBatchStatus(
+                ready=True,
+                failed=True,
+                error=_error_message(getattr(batch_job, "error", None)) or state,
+            )
+        return ProviderBatchStatus(ready=False)
 
     async def fetch_output(self, *, provider_batch_id: str) -> ProviderBatchOutput:
-        raise RuntimeError("Gemini batch output API wiring is required before use")
+        batch_job = await asyncio.to_thread(
+            self.client.batches.get,
+            name=provider_batch_id,
+        )
+        responses = getattr(getattr(batch_job, "dest", None), "inlined_responses", None)
+        if responses is None and isinstance(getattr(batch_job, "dest", None), dict):
+            responses = batch_job.dest.get("inlined_responses") or batch_job.dest.get(
+                "inlinedResponses"
+            )
+        if responses is None:
+            raise RuntimeError("Gemini batch output did not include inline responses")
+        return ProviderBatchOutput(
+            requests=[_request_result_from_inline_response(response) for response in responses]
+        )
+
+
+def _inline_request(request: dict) -> dict:
+    payload = build_gemini_batch_request(
+        request_key=str(request["request_key"]),
+        profile_text=str(request.get("profile_text") or ""),
+        jobs=list(request.get("jobs") or []),
+    )
+    return {
+        **payload["request"],
+        "metadata": {"request_key": payload["key"]},
+    }
+
+
+def _request_result_from_inline_response(response: Any) -> ProviderRequestResult:
+    request_key = _metadata_request_key(response)
+    provider_error = _error_message(_attr_or_key(response, "error"))
+    if provider_error:
+        return ProviderRequestResult(request_key=request_key, results=[], error=provider_error)
+
+    text = _response_text(_attr_or_key(response, "response"))
+    if text is None:
+        return ProviderRequestResult(
+            request_key=request_key,
+            results=[],
+            error="provider returned no response text",
+        )
+    try:
+        payload = json.loads(_strip_json_markdown(text))
+    except json.JSONDecodeError:
+        return ProviderRequestResult(
+            request_key=request_key,
+            results=[],
+            error="provider returned invalid JSON",
+        )
+    raw_results = payload.get("results") if isinstance(payload, dict) else None
+    if not isinstance(raw_results, list):
+        return ProviderRequestResult(
+            request_key=request_key,
+            results=[],
+            error="provider returned JSON without results",
+        )
+    return ProviderRequestResult(
+        request_key=request_key,
+        results=[_job_result(raw_result) for raw_result in raw_results],
+    )
+
+
+def _metadata_request_key(response: Any) -> str:
+    metadata = _attr_or_key(response, "metadata") or {}
+    if isinstance(metadata, dict):
+        return str(metadata.get("request_key") or metadata.get("key") or "")
+    request_key = getattr(metadata, "request_key", None) or getattr(metadata, "key", None)
+    return str(request_key or "")
+
+
+def _response_text(response: Any) -> str | None:
+    parsed = _attr_or_key(response, "parsed")
+    if isinstance(parsed, dict):
+        return json.dumps(parsed)
+    direct_text = _attr_or_key(response, "text")
+    if isinstance(direct_text, str) and direct_text.strip():
+        return direct_text
+    candidates = _attr_or_key(response, "candidates") or []
+    for candidate in candidates:
+        content = _attr_or_key(candidate, "content")
+        for part in _attr_or_key(content, "parts") or []:
+            text = _attr_or_key(part, "text")
+            if isinstance(text, str) and text.strip():
+                return text
+    return None
+
+
+def _strip_json_markdown(text: str) -> str:
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = stripped.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def _job_result(raw: Any) -> ProviderJobResult:
+    if not isinstance(raw, dict):
+        return ProviderJobResult(
+            application_id="",
+            score=None,
+            summary="",
+            rationale="",
+            strengths=[],
+            gaps=[],
+            error="provider returned non-object result",
+        )
+    return ProviderJobResult(
+        application_id=str(raw.get("application_id") or ""),
+        score=_score(raw.get("score")),
+        summary=str(raw.get("summary") or ""),
+        rationale=str(raw.get("rationale") or ""),
+        strengths=_string_list(raw.get("strengths")),
+        gaps=_string_list(raw.get("gaps")),
+        error=str(raw["error"]) if raw.get("error") else None,
+    )
+
+
+def _score(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _state_name(state: Any) -> str:
+    if hasattr(state, "value"):
+        return str(state.value)
+    if hasattr(state, "name"):
+        return str(state.name)
+    return str(state or "")
+
+
+def _error_message(error: Any) -> str | None:
+    if error is None:
+        return None
+    if isinstance(error, dict):
+        message = error.get("message") or error.get("error")
+        return str(message) if message else str(error)
+    message = getattr(error, "message", None)
+    return str(message) if message else str(error)
+
+
+def _attr_or_key(value: Any, key: str) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value.get(key)
+    return getattr(value, key, None)
 
 
 def _build_prompt(*, profile_text: str, jobs: list[dict]) -> str:

--- a/docs/runbooks/batch-match-canary.md
+++ b/docs/runbooks/batch-match-canary.md
@@ -1,0 +1,44 @@
+# Batch Match Canary
+
+Use this when validating the real Gemini Batch provider for one profile before turning on automatic batch-match enqueueing.
+
+## Prerequisites
+
+Deploy the app with the provider wired but automatic enqueueing disabled:
+
+```sh
+BATCH_MATCH_PROVIDER=gemini
+BATCH_MATCH_DRY_RUN=false
+BATCH_MATCH_ENABLED=false
+GOOGLE_API_KEY=<configured secret>
+```
+
+The worker must be running with `batch-match` enabled in its slow job types. Leave `BATCH_MATCH_ENABLED=false` during the canary so normal job ingestion does not enqueue batch work for every affected profile.
+
+## Enqueue One Profile
+
+After the canary user has logged in and the account has unscored applications, enqueue exactly one batch-match job:
+
+```sh
+uv run python scripts/enqueue_batch_match_canary.py --email canary@example.com
+```
+
+If you already know the profile id:
+
+```sh
+uv run python scripts/enqueue_batch_match_canary.py --profile-id <user_profiles.id>
+```
+
+The helper writes one `work_queue` row with `job_type=batch-match`, payload `{"profile_id": "..."}`, and dedupe key `batch-match:<profile_id>`. Re-running it resets the pending row for the same profile instead of creating duplicates.
+
+## Evidence To Capture
+
+Record these before enabling automatic enqueueing:
+
+- `work_queue`: the canary row is claimed and finishes or requeues as expected.
+- `llm_match_batches`: one batch is created for the profile, has provider `gemini`, has a non-empty `provider_batch_id`, and reaches `done`.
+- `llm_match_batch_items`: submitted items transition to `imported` or a clear retryable/terminal failure.
+- `applications`: expected rows receive `match_score`, summary, rationale, strengths, and gaps.
+- Logs: submit, poll, import, and any provider errors are understandable and include the provider batch id.
+
+Only turn on `BATCH_MATCH_ENABLED=true` after the canary proves submit, poll, output parsing, import, and retry behavior on the deployed worker.

--- a/scripts/enqueue_batch_match_canary.py
+++ b/scripts/enqueue_batch_match_canary.py
@@ -1,0 +1,68 @@
+"""Enqueue one manual batch-match canary job for a user profile."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlmodel import select
+
+from app.database import get_session_factory
+from app.models.user import User
+from app.models.user_profile import UserProfile
+from app.worker.queue_service import enqueue
+
+
+async def enqueue_batch_match_canary(session, *, profile_id: uuid.UUID) -> int | None:
+    row_id = await enqueue(
+        session,
+        job_type="batch-match",
+        payload={"profile_id": str(profile_id)},
+        dedupe_key=f"batch-match:{profile_id}",
+        on_conflict="upsert_reset_not_before",
+    )
+    await session.commit()
+    return row_id
+
+
+async def lookup_profile_id_by_email(session, *, email: str) -> uuid.UUID:
+    result = await session.execute(
+        select(UserProfile.id)
+        .join(User, UserProfile.user_id == User.id)
+        .where(User.email == email)
+        .limit(1)
+    )
+    profile_id = result.scalar_one_or_none()
+    if profile_id is None:
+        raise SystemExit(f"No profile found for user email {email!r}")
+    return profile_id
+
+
+async def main(*, profile_id_arg: str | None, email: str | None) -> None:
+    factory = get_session_factory()
+    async with factory() as session:
+        profile_id = (
+            uuid.UUID(profile_id_arg)
+            if profile_id_arg is not None
+            else await lookup_profile_id_by_email(session, email=email or "")
+        )
+        row_id = await enqueue_batch_match_canary(session, profile_id=profile_id)
+    print(f"enqueued batch-match row_id={row_id} profile_id={profile_id}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--profile-id", dest="profile_id_arg", help="User profile UUID")
+    target.add_argument("--email", help="Account email to resolve to user_profiles.id")
+    return parser
+
+
+if __name__ == "__main__":
+    args = _parser().parse_args()
+    asyncio.run(main(profile_id_arg=args.profile_id_arg, email=args.email))

--- a/tests/unit/test_batch_match_provider.py
+++ b/tests/unit/test_batch_match_provider.py
@@ -86,20 +86,20 @@ def test_get_batch_match_provider_rejects_unknown_provider(monkeypatch):
         _reset_settings()
 
 
-def test_get_batch_match_provider_rejects_gemini_until_api_is_wired(monkeypatch):
+def test_get_batch_match_provider_returns_gemini_when_configured(monkeypatch):
     from app.services.batch_match_provider import get_batch_match_provider
+    from app.services.gemini_batch_match_provider import GeminiBatchMatchProvider
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost:5432/db")
     monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
     monkeypatch.setenv("BATCH_MATCH_PROVIDER", "gemini")
     monkeypatch.setenv("BATCH_MATCH_DRY_RUN", "false")
     _reset_settings()
 
     try:
-        with pytest.raises(
-            ValueError,
-            match="gemini batch match provider is not implemented",
-        ):
-            get_batch_match_provider()
+        provider = get_batch_match_provider()
     finally:
         _reset_settings()
+
+    assert isinstance(provider, GeminiBatchMatchProvider)

--- a/tests/unit/test_enqueue_batch_match_canary.py
+++ b/tests/unit/test_enqueue_batch_match_canary.py
@@ -1,0 +1,42 @@
+import uuid
+
+import pytest
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.committed = False
+
+    async def commit(self) -> None:
+        self.committed = True
+
+
+@pytest.mark.asyncio
+async def test_enqueue_batch_match_canary_uses_batch_payload_and_dedupe(monkeypatch):
+    from scripts import enqueue_batch_match_canary as script
+
+    calls = []
+
+    async def fake_enqueue(session, **kwargs):
+        calls.append((session, kwargs))
+        return 123
+
+    monkeypatch.setattr(script, "enqueue", fake_enqueue)
+    session = _FakeSession()
+    profile_id = uuid.uuid4()
+
+    row_id = await script.enqueue_batch_match_canary(session, profile_id=profile_id)
+
+    assert row_id == 123
+    assert session.committed is True
+    assert calls == [
+        (
+            session,
+            {
+                "job_type": "batch-match",
+                "payload": {"profile_id": str(profile_id)},
+                "dedupe_key": f"batch-match:{profile_id}",
+                "on_conflict": "upsert_reset_not_before",
+            },
+        )
+    ]

--- a/tests/unit/test_gemini_batch_match_provider.py
+++ b/tests/unit/test_gemini_batch_match_provider.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -66,15 +68,179 @@ def test_build_gemini_batch_request_prompt_contains_profile_and_application_ids(
     assert "exactly one result per application_id" in prompt
 
 
+class _FakeBatchesClient:
+    def __init__(self, *, create_job=None, get_jobs=None) -> None:
+        self.create_job = create_job or SimpleNamespace(name="batches/provider-123")
+        self.get_jobs = list(get_jobs or [])
+        self.created_calls = []
+        self.get_calls = []
+
+    def create(self, *, model, src, config=None):
+        self.created_calls.append({"model": model, "src": src, "config": config})
+        return self.create_job
+
+    def get(self, *, name):
+        self.get_calls.append(name)
+        return self.get_jobs.pop(0)
+
+
 @pytest.mark.asyncio
-async def test_gemini_batch_match_provider_runtime_methods_require_api_wiring():
+async def test_gemini_batch_match_provider_submit_creates_inline_batch():
     from app.services.gemini_batch_match_provider import GeminiBatchMatchProvider
 
-    provider = GeminiBatchMatchProvider()
+    batches = _FakeBatchesClient()
+    provider = GeminiBatchMatchProvider(
+        client=SimpleNamespace(batches=batches),
+        model="gemini-test-model",
+    )
 
-    with pytest.raises(RuntimeError, match="Gemini batch submit API wiring is required"):
-        await provider.submit(requests=[], display_name="batch")
-    with pytest.raises(RuntimeError, match="Gemini batch poll API wiring is required"):
-        await provider.poll(provider_batch_id="batch-id")
-    with pytest.raises(RuntimeError, match="Gemini batch output API wiring is required"):
-        await provider.fetch_output(provider_batch_id="batch-id")
+    provider_batch_id = await provider.submit(
+        requests=[
+            {
+                "request_key": "request-0001",
+                "profile_text": "Senior Python engineer.",
+                "jobs": [{"application_id": "app-1", "title": "Backend Engineer"}],
+            }
+        ],
+        display_name="batch-match-test",
+    )
+
+    assert provider_batch_id == "batches/provider-123"
+    assert len(batches.created_calls) == 1
+    created = batches.created_calls[0]
+    assert created["model"] == "gemini-test-model"
+    assert created["config"]["display_name"] == "batch-match-test"
+    assert created["src"][0]["metadata"] == {"request_key": "request-0001"}
+    prompt = created["src"][0]["contents"][0]["parts"][0]["text"]
+    assert "Senior Python engineer." in prompt
+    assert "app-1" in prompt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("JOB_STATE_RUNNING", (False, False, None)),
+        ("JOB_STATE_SUCCEEDED", (True, False, None)),
+        ("JOB_STATE_FAILED", (True, True, "provider error")),
+        ("JOB_STATE_CANCELLED", (True, True, "provider error")),
+        ("JOB_STATE_EXPIRED", (True, True, "provider error")),
+        ("JOB_STATE_PARTIALLY_SUCCEEDED", (True, True, "provider error")),
+    ],
+)
+async def test_gemini_batch_match_provider_poll_maps_job_state(state, expected):
+    from app.services.gemini_batch_match_provider import GeminiBatchMatchProvider
+
+    batches = _FakeBatchesClient(
+        get_jobs=[SimpleNamespace(state=state, error=SimpleNamespace(message="provider error"))]
+    )
+    provider = GeminiBatchMatchProvider(
+        client=SimpleNamespace(batches=batches),
+        model="gemini-test-model",
+    )
+
+    status = await provider.poll(provider_batch_id="batches/provider-123")
+
+    assert (status.ready, status.failed, status.error) == expected
+    assert batches.get_calls == ["batches/provider-123"]
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_match_provider_fetch_output_parses_inline_responses():
+    from app.services.gemini_batch_match_provider import GeminiBatchMatchProvider
+
+    batch_job = SimpleNamespace(
+        dest=SimpleNamespace(
+            inlined_responses=[
+                SimpleNamespace(
+                    metadata={"request_key": "request-0001"},
+                    response=SimpleNamespace(
+                        candidates=[
+                            SimpleNamespace(
+                                content=SimpleNamespace(
+                                    parts=[
+                                        SimpleNamespace(
+                                            text='''{
+                                              "results": [
+                                                {
+                                                  "application_id": "app-1",
+                                                  "score": 0.91,
+                                                  "summary": "Strong fit",
+                                                  "rationale": "Relevant backend work.",
+                                                  "strengths": ["Python"],
+                                                  "gaps": ["None"]
+                                                }
+                                              ]
+                                            }'''
+                                        )
+                                    ]
+                                )
+                            )
+                        ]
+                    ),
+                    error=None,
+                )
+            ]
+        )
+    )
+    batches = _FakeBatchesClient(get_jobs=[batch_job])
+    provider = GeminiBatchMatchProvider(
+        client=SimpleNamespace(batches=batches),
+        model="gemini-test-model",
+    )
+
+    output = await provider.fetch_output(provider_batch_id="batches/provider-123")
+
+    assert len(output.requests) == 1
+    request = output.requests[0]
+    assert request.request_key == "request-0001"
+    assert request.error is None
+    assert len(request.results) == 1
+    result = request.results[0]
+    assert result.application_id == "app-1"
+    assert result.score == 0.91
+    assert result.summary == "Strong fit"
+    assert result.strengths == ["Python"]
+    assert result.gaps == ["None"]
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_match_provider_fetch_output_marks_request_errors():
+    from app.services.gemini_batch_match_provider import GeminiBatchMatchProvider
+
+    batch_job = SimpleNamespace(
+        dest=SimpleNamespace(
+            inlined_responses=[
+                SimpleNamespace(
+                    metadata={"request_key": "request-0001"},
+                    response=None,
+                    error=SimpleNamespace(message="safety block"),
+                ),
+                SimpleNamespace(
+                    metadata={"request_key": "request-0002"},
+                    response=SimpleNamespace(
+                        candidates=[
+                            SimpleNamespace(
+                                content=SimpleNamespace(
+                                    parts=[SimpleNamespace(text="not json")]
+                                )
+                            )
+                        ]
+                    ),
+                    error=None,
+                ),
+            ]
+        )
+    )
+    batches = _FakeBatchesClient(get_jobs=[batch_job])
+    provider = GeminiBatchMatchProvider(
+        client=SimpleNamespace(batches=batches),
+        model="gemini-test-model",
+    )
+
+    output = await provider.fetch_output(provider_batch_id="batches/provider-123")
+
+    assert [(request.request_key, request.error) for request in output.requests] == [
+        ("request-0001", "safety block"),
+        ("request-0002", "provider returned invalid JSON"),
+    ]


### PR DESCRIPTION
## Summary
- wire the configured Gemini batch match provider to the google-genai Batch API using inline requests
- parse inline batch responses into the existing ProviderBatchOutput contract
- add a manual canary enqueue helper and runbook for one-profile validation before enabling automatic enqueueing

## Verification
- uv run pytest tests/unit/test_gemini_batch_match_provider.py tests/unit/test_batch_match_provider.py tests/unit/test_enqueue_batch_match_canary.py tests/unit/test_batch_match_packing.py tests/unit/test_worker_payloads.py tests/unit/test_worker_config.py tests/unit/test_config.py
- uv run pytest tests/unit
- uv run ruff check app scripts tests/unit
- uv run python -m py_compile app/services/gemini_batch_match_provider.py app/services/batch_match_provider.py scripts/enqueue_batch_match_canary.py tests/unit/test_gemini_batch_match_provider.py tests/unit/test_batch_match_provider.py tests/unit/test_enqueue_batch_match_canary.py
- uv run python scripts/alembic_safe.py heads