### PR TITLE
Tolerate handlers without terminal hooks

### DIFF
--- a/app/worker/main.py
+++ b/app/worker/main.py
@@ -64,7 +64,9 @@ def _compute_backoff(attempts: int, settings: WorkerSettings) -> int:
 
 
 async def _terminal_failure(handler, session_factory, job_row, error: str) -> None:
-    await handler.on_terminal_failure(session_factory, job_row, error)
+    terminal_hook = getattr(handler, "on_terminal_failure", None)
+    if terminal_hook is not None:
+        await terminal_hook(session_factory, job_row, error)
     async with session_factory() as session:
         await mark_failed(session, job_row.id, error=error, worker_id=_worker_id)
         await session.commit()

--- a/tests/integration/test_worker_lifecycle.py
+++ b/tests/integration/test_worker_lifecycle.py
@@ -151,6 +151,47 @@ async def test_worker_short_circuits_when_attempts_over_cap(db_session, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_worker_marks_terminal_failure_when_handler_has_no_hook(db_session, monkeypatch):
+    from app.worker.handlers import HANDLERS
+
+    _disable_default_lanes(monkeypatch)
+
+    class NoTerminalHook:
+        max_attempts = 2
+        called = 0
+
+        async def __call__(self, session, row):
+            NoTerminalHook.called += 1
+
+    monkeypatch.setitem(HANDLERS, "test-no-terminal-hook", NoTerminalHook())
+
+    await enqueue(db_session, job_type="test-no-terminal-hook", payload={})
+    await db_session.execute(
+        text("UPDATE work_queue SET attempts=3 WHERE job_type='test-no-terminal-hook'")
+    )
+    await db_session.commit()
+
+    async def stop_soon():
+        await asyncio.sleep(1.5)
+        worker_main._shutdown.set()
+
+    await asyncio.gather(worker_main.run(), stop_soon())
+
+    row = (
+        await db_session.execute(
+            text(
+                "SELECT status, last_error, not_before "
+                "FROM work_queue WHERE job_type='test-no-terminal-hook'"
+            )
+        )
+    ).first()
+    assert row[0] == "failed"
+    assert "max_attempts" in (row[1] or "")
+    assert row[2] is None
+    assert NoTerminalHook.called == 0
+
+
+@pytest.mark.asyncio
 async def test_worker_runs_terminal_hook_on_generic_exception(db_session, monkeypatch):
     from app.worker.handlers import HANDLERS
 

--- a/tests/unit/test_worker_terminal_failure.py
+++ b/tests/unit/test_worker_terminal_failure.py
@@ -1,0 +1,45 @@
+import pytest
+
+
+class _SessionContext:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def commit(self):
+        self.committed = True
+
+
+def _session_factory():
+    return _SessionContext()
+
+
+@pytest.mark.asyncio
+async def test_terminal_failure_marks_failed_when_handler_has_no_hook(monkeypatch):
+    from app.worker import main as worker_main
+
+    calls = []
+
+    async def fake_mark_failed(session, job_id, *, error, worker_id):
+        calls.append({"job_id": job_id, "error": error, "worker_id": worker_id})
+
+    monkeypatch.setattr(worker_main, "mark_failed", fake_mark_failed)
+
+    class NoTerminalHook:
+        pass
+
+    class JobRow:
+        id = 123
+
+    await worker_main._terminal_failure(
+        NoTerminalHook(),
+        _session_factory,
+        JobRow(),
+        "boom",
+    )
+
+    assert calls == [
+        {"job_id": 123, "error": "boom", "worker_id": worker_main._worker_id}
+    ]


### PR DESCRIPTION
## Summary
- make worker terminal-failure hooks optional at runtime
- add unit coverage for handlers without terminal failure hooks
- add worker lifecycle regression coverage for max-attempt terminal failure without a hook

## Verification
- uv run pytest tests/unit/test_worker_terminal_failure.py
- uv run pytest tests/unit/test_worker_terminal_failure.py tests/unit/test_worker_config.py tests/unit/test_worker_payloads.py tests/unit/test_handler_registry.py
- uv run pytest tests/unit
- uv run ruff check app/worker/main.py tests/unit/test_worker_terminal_failure.py tests/integration/test_worker_lifecycle.py
- uv run python -m py_compile app/worker/main.py tests/unit/test_worker_terminal_failure.py tests/integration/test_worker_lifecycle.py

Note: local integration test execution is blocked on this machine because testcontainers cannot connect to a Docker socket; CI should run the integration suite.