### PR TITLE
Tighten Gemini batch output contract

### DIFF
--- a/app/services/batch_match_service.py
+++ b/app/services/batch_match_service.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -62,6 +63,9 @@ class _ImportCounters:
     imported: int = 0
     retryable_failed: int = 0
     terminal_failed: int = 0
+
+
+_TERMINAL_PROVIDER_CORRELATION_ERRORS = {"provider returned unknown application_id"}
 
 
 async def run_batch_match_tick(
@@ -309,12 +313,17 @@ async def _select_unscored_application_rows(
     limit: int,
 ) -> list[tuple[Application, Job]]:
     posted_cutoff = datetime.now(UTC) - timedelta(days=DISPLAY_JOB_MAX_AGE_DAYS)
-    active_item_app_ids = (
+    blocked_item_app_ids = (
         select(LLMMatchBatchItem.application_id)
         .join(LLMMatchBatch, LLMMatchBatchItem.batch_id == LLMMatchBatch.id)
         .where(
-            LLMMatchBatchItem.status == ITEM_STATUS_SUBMITTED,
-            col(LLMMatchBatch.status).in_(ACTIVE_BATCH_STATUSES),
+            or_(
+                and_(
+                    LLMMatchBatchItem.status == ITEM_STATUS_SUBMITTED,
+                    col(LLMMatchBatch.status).in_(ACTIVE_BATCH_STATUSES),
+                ),
+                LLMMatchBatchItem.status == ITEM_STATUS_TERMINAL_FAILED,
+            )
         )
     )
     result = await session.execute(
@@ -326,7 +335,7 @@ async def _select_unscored_application_rows(
             col(Application.status).in_(("pending_review", "auto_rejected")),
             Job.is_active.is_(True),
             (col(Job.posted_at).is_(None)) | (Job.posted_at >= posted_cutoff),
-            col(Application.id).notin_(active_item_app_ids),
+            col(Application.id).notin_(blocked_item_app_ids),
         )
         .order_by(
             Job.posted_at.desc().nullslast(),
@@ -446,10 +455,11 @@ async def _import_provider_output(
         )
         return counters
     for request_key, error in request_correlation_errors.items():
-        counters.retryable_failed += _mark_items_retryable(
-            _items_by_request_key(items, request_key),
-            error,
-        )
+        request_items = _items_by_request_key(items, request_key)
+        if _is_terminal_provider_correlation_error(error):
+            counters.terminal_failed += _mark_items_terminal(request_items, error)
+        else:
+            counters.retryable_failed += _mark_items_retryable(request_items, error)
 
     seen_item_ids: set[uuid.UUID] = set()
 
@@ -466,10 +476,18 @@ async def _import_provider_output(
             continue
         correlation_error = _request_correlation_error(request_items, request.results)
         if correlation_error is not None:
+            mark_item = (
+                _mark_item_terminal
+                if _is_terminal_provider_correlation_error(correlation_error)
+                else _mark_item_retryable
+            )
             for item in request_items:
                 if item.status == ITEM_STATUS_SUBMITTED:
-                    _mark_item_retryable(item, correlation_error)
-                    counters.retryable_failed += 1
+                    mark_item(item, correlation_error)
+                    if _is_terminal_provider_correlation_error(correlation_error):
+                        counters.terminal_failed += 1
+                    else:
+                        counters.retryable_failed += 1
                     seen_item_ids.add(item.id)
             continue
         for result in request.results:
@@ -716,10 +734,26 @@ def _mark_items_retryable(
     return count
 
 
+def _is_terminal_provider_correlation_error(error: str) -> bool:
+    return error in _TERMINAL_PROVIDER_CORRELATION_ERRORS
+
+
 def _mark_item_terminal(item: LLMMatchBatchItem, error: str) -> None:
     item.status = ITEM_STATUS_TERMINAL_FAILED
     item.error = error
     item.updated_at = datetime.now(UTC)
+
+
+def _mark_items_terminal(
+    items: Iterable[LLMMatchBatchItem],
+    error: str,
+) -> int:
+    count = 0
+    for item in items:
+        if item.status == ITEM_STATUS_SUBMITTED:
+            _mark_item_terminal(item, error)
+            count += 1
+    return count
 
 
 async def _mark_submitted_items_retryable(

--- a/app/services/gemini_batch_match_provider.py
+++ b/app/services/gemini_batch_match_provider.py
@@ -95,14 +95,61 @@ class GeminiBatchMatchProvider:
 
 
 def _inline_request(request: dict) -> dict:
+    jobs = list(request.get("jobs") or [])
     payload = build_gemini_batch_request(
         request_key=str(request["request_key"]),
         profile_text=str(request.get("profile_text") or ""),
-        jobs=list(request.get("jobs") or []),
+        jobs=jobs,
     )
     return {
         **payload["request"],
+        "config": {
+            "response_mime_type": "application/json",
+            "response_json_schema": _response_json_schema(
+                [str(job.get("application_id", "")) for job in jobs]
+            ),
+        },
         "metadata": {"request_key": payload["key"]},
+    }
+
+
+def _response_json_schema(application_ids: list[str]) -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "results": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "application_id": {
+                            "type": "string",
+                            "enum": application_ids,
+                        },
+                        "score": {"type": "number"},
+                        "summary": {"type": "string"},
+                        "rationale": {"type": "string"},
+                        "strengths": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "gaps": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                    "required": [
+                        "application_id",
+                        "score",
+                        "summary",
+                        "rationale",
+                        "strengths",
+                        "gaps",
+                    ],
+                },
+            },
+        },
+        "required": ["results"],
     }
 
 
@@ -251,9 +298,28 @@ def _build_prompt(*, profile_text: str, jobs: list[dict]) -> str:
 
 Score the candidate profile against every job below.
 
-Return only a top-level JSON object with a "results" array. Include exactly one """
-        f"""result per application_id from this list:
-{application_ids_json}.
+Return only a top-level JSON object with this exact shape:
+{{
+  "results": [
+    {{
+      "application_id": "one value copied from allowed_application_ids",
+      "score": 0.0,
+      "summary": "short summary",
+      "rationale": "brief rationale",
+      "strengths": ["strength"],
+      "gaps": ["gap"]
+    }}
+  ]
+}}
+
+allowed_application_ids:
+{application_ids_json}
+
+Include exactly one result per application_id from allowed_application_ids.
+For application_id, treat the value as an opaque identifier. Copy it exactly from """
+        f"""allowed_application_ids. Do not invent, shorten, normalize, or replace """
+        f"""application_id. Do not use a job title, company name, array index, """
+        f"""or any other ID.
 
 Each result must include:
 - application_id

--- a/tests/integration/test_batch_match_service.py
+++ b/tests/integration/test_batch_match_service.py
@@ -477,7 +477,7 @@ async def test_duplicate_provider_result_ids_mark_request_retryable_without_part
 
 
 @pytest.mark.asyncio
-async def test_unknown_provider_result_id_marks_request_retryable_without_partial_import(
+async def test_unknown_provider_result_id_marks_request_terminal_without_retry_loop(
     db_session,
 ):
     from app.services.batch_match_provider import (
@@ -526,15 +526,27 @@ async def test_unknown_provider_result_id_marks_request_retryable_without_partia
     result = await run_batch_match_tick(db_session, profile_id=profile.id, provider=second_provider)
 
     assert result.imported == 0
-    assert result.retryable_failed == 2
+    assert result.retryable_failed == 0
+    assert result.terminal_failed == 2
     for app in apps:
         refreshed = await db_session.get(Application, app.id)
         assert refreshed is not None
         assert refreshed.match_score is None
 
     items = await _batch_items_for_batch(db_session, original_batch.id)
-    assert {item.status for item in items} == {"retryable_failed"}
+    assert {item.status for item in items} == {"terminal_failed"}
     assert {item.error for item in items} == {"provider returned unknown application_id"}
+
+    retry_provider = FakeBatchMatchProvider(ready=False, provider_batch_id="batch-2")
+    retry_result = await run_batch_match_tick(
+        db_session,
+        profile_id=profile.id,
+        provider=retry_provider,
+    )
+
+    assert retry_result.selected == 0
+    assert retry_result.submitted == 0
+    assert retry_provider.submitted_requests == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_gemini_batch_match_provider.py
+++ b/tests/unit/test_gemini_batch_match_provider.py
@@ -63,6 +63,9 @@ def test_build_gemini_batch_request_prompt_contains_profile_and_application_ids(
     assert "Candidate profile text goes here." in prompt
     assert "app-alpha" in prompt
     assert "app-beta" in prompt
+    assert "allowed_application_ids" in prompt
+    assert "Copy it exactly" in prompt
+    assert "Do not invent, shorten, normalize, or replace application_id" in prompt
     assert "top-level JSON object" in prompt
     assert '"results"' in prompt
     assert "exactly one result per application_id" in prompt
@@ -111,6 +114,11 @@ async def test_gemini_batch_match_provider_submit_creates_inline_batch():
     assert created["model"] == "gemini-test-model"
     assert created["config"]["display_name"] == "batch-match-test"
     assert created["src"][0]["metadata"] == {"request_key": "request-0001"}
+    assert created["src"][0]["config"]["response_mime_type"] == "application/json"
+    schema = created["src"][0]["config"]["response_json_schema"]
+    assert schema["properties"]["results"]["items"]["properties"]["application_id"]["enum"] == [
+        "app-1"
+    ]
     prompt = created["src"][0]["contents"][0]["parts"][0]["text"]
     assert "Senior Python engineer." in prompt
     assert "app-1" in prompt


### PR DESCRIPTION
## Summary
- Add explicit allowed_application_ids instructions to Gemini batch prompts.
- Send JSON response schema with application_id enum for each inline batch request.
- Treat unknown provider application_id correlation errors as terminal and exclude those terminal-failed items from future batch selection.

## Verification
- uv run pytest tests/unit/test_gemini_batch_match_provider.py
- uv run pytest tests/unit
- uv run ruff check app/services/gemini_batch_match_provider.py app/services/batch_match_service.py tests/unit/test_gemini_batch_match_provider.py tests/integration/test_batch_match_service.py
- uv run python -m py_compile app/services/gemini_batch_match_provider.py app/services/batch_match_service.py tests/unit/test_gemini_batch_match_provider.py tests/integration/test_batch_match_service.py

## Local limitation
- Focused integration test could not run locally because testcontainers could not connect to a Docker socket: FileNotFoundError on Docker /version.