### PR TITLE
feat: reduce batch match LLM spend

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
     batch_match_max_request_chars: int = 60000
     batch_match_poll_interval_seconds: int = 60
     batch_match_max_items_per_batch: int = 100
+    batch_match_candidate_pool_multiplier: int = 3
 
     cors_allowed_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]
     # Absolute base URL Google sees as redirect_uri host. Cloud Run forwards HTTP to

--- a/app/config.py
+++ b/app/config.py
@@ -34,6 +34,8 @@ class Settings(BaseSettings):
     batch_match_poll_interval_seconds: int = 60
     batch_match_max_items_per_batch: int = 100
     batch_match_candidate_pool_multiplier: int = 3
+    batch_match_manual_sync_max_items: int = 50
+    batch_match_cron_max_items: int = 100
 
     cors_allowed_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]
     # Absolute base URL Google sees as redirect_uri host. Cloud Run forwards HTTP to

--- a/app/scheduler/tasks.py
+++ b/app/scheduler/tasks.py
@@ -240,7 +240,13 @@ async def run_daily_maintenance() -> dict:
     }
 
 
-async def fetch_one_slug(*, provider: str, slug: str, session_factory) -> dict:
+async def fetch_one_slug(
+    *,
+    provider: str,
+    slug: str,
+    session_factory,
+    batch_match_max_items: int | None = None,
+) -> dict:
     """Fetch one provider slug, upsert jobs, and enqueue match work_queue rows."""
     import httpx
 
@@ -310,6 +316,7 @@ async def fetch_one_slug(*, provider: str, slug: str, session_factory) -> dict:
             batch_matches_enqueued = await _enqueue_batch_match_for_affected_profiles(
                 job.id,
                 session,
+                max_items=batch_match_max_items,
             )
             if batch_matches_enqueued:
                 matches_enqueued += batch_matches_enqueued
@@ -353,7 +360,12 @@ async def fetch_one_slug(*, provider: str, slug: str, session_factory) -> dict:
     }
 
 
-async def _enqueue_batch_match_for_affected_profiles(job_id, session) -> int:
+async def _enqueue_batch_match_for_affected_profiles(
+    job_id,
+    session,
+    *,
+    max_items: int | None = None,
+) -> int:
     from app.config import get_settings
     from app.models.application import Application
     from app.worker.queue_service import enqueue
@@ -378,7 +390,14 @@ async def _enqueue_batch_match_for_affected_profiles(job_id, session) -> int:
         row_id = await enqueue(
             session,
             job_type="batch-match",
-            payload={"profile_id": str(profile_id)},
+            payload={
+                key: value
+                for key, value in {
+                    "profile_id": str(profile_id),
+                    "max_items": max_items,
+                }.items()
+                if value is not None
+            },
             dedupe_key=f"batch-match:{profile_id}",
             on_conflict="upsert_reset_not_before",
         )

--- a/app/services/batch_match_service.py
+++ b/app/services/batch_match_service.py
@@ -41,6 +41,7 @@ from app.services.batch_match_provider import (
 from app.services.match_service import (
     DISPLAY_JOB_MAX_AGE_DAYS,
     DeterministicRejectionFields,
+    candidate_priority_score,
     deterministic_rejection_fields,
     format_profile_text,
 )
@@ -161,10 +162,15 @@ async def _build_and_submit(
     if profile is None:
         return BatchMatchTickResult()
 
+    candidate_pool_limit = max(
+        settings.batch_match_max_items_per_batch,
+        settings.batch_match_max_items_per_batch
+        * max(1, settings.batch_match_candidate_pool_multiplier),
+    )
     rows = await _select_unscored_application_rows(
         session,
         profile_id=profile_id,
-        limit=settings.batch_match_max_items_per_batch,
+        limit=candidate_pool_limit,
     )
     selected = len(rows)
     if not rows:
@@ -177,6 +183,13 @@ async def _build_and_submit(
             deterministic_rejected += 1
             continue
         survivors.append(_job_context(app, job))
+
+    survivors = _prioritize_batch_jobs(
+        profile,
+        rows_by_application_id={app.id: job for app, job in rows},
+        survivors=survivors,
+        limit=settings.batch_match_max_items_per_batch,
+    )
 
     if not survivors:
         await session.commit()
@@ -379,6 +392,25 @@ async def _create_batch_with_items(
                 )
             )
     return batch
+
+
+def _prioritize_batch_jobs(
+    profile: UserProfile,
+    *,
+    rows_by_application_id: dict[uuid.UUID, Job],
+    survivors: list[BatchJobContext],
+    limit: int,
+) -> list[BatchJobContext]:
+    if limit < 1 or len(survivors) <= limit:
+        return survivors
+    return sorted(
+        survivors,
+        key=lambda survivor: candidate_priority_score(
+            profile,
+            rows_by_application_id[survivor.application_id],
+        ),
+        reverse=True,
+    )[:limit]
 
 
 def _apply_deterministic_reject_if_needed(

--- a/app/services/batch_match_service.py
+++ b/app/services/batch_match_service.py
@@ -79,6 +79,7 @@ async def run_batch_match_tick(
     *,
     profile_id: uuid.UUID,
     provider: BatchMatchProvider,
+    max_items: int | None = None,
 ) -> BatchMatchTickResult:
     active = await _get_active_batch(session, profile_id)
     if active is not None and active.status in (
@@ -94,6 +95,7 @@ async def run_batch_match_tick(
             session,
             profile_id=profile_id,
             provider=provider,
+            max_items=max_items,
         )
         return _combine_tick_results(import_result, build_result)
     if active is not None and active.status == BATCH_STATUS_BUILDING:
@@ -108,12 +110,18 @@ async def run_batch_match_tick(
                 session,
                 profile_id=profile_id,
                 provider=provider,
+                max_items=max_items,
             )
             return _combine_tick_results(fail_result, build_result)
         return BatchMatchTickResult(requeued=True)
     if active is not None:
         return BatchMatchTickResult(requeued=True)
-    return await _build_and_submit(session, profile_id=profile_id, provider=provider)
+    return await _build_and_submit(
+        session,
+        profile_id=profile_id,
+        provider=provider,
+        max_items=max_items,
+    )
 
 
 def _is_stale_building_batch(batch: LLMMatchBatch) -> bool:
@@ -161,16 +169,17 @@ async def _build_and_submit(
     *,
     profile_id: uuid.UUID,
     provider: BatchMatchProvider,
+    max_items: int | None = None,
 ) -> BatchMatchTickResult:
     settings = get_settings()
+    effective_max_items = max_items or settings.batch_match_max_items_per_batch
     profile = await session.get(UserProfile, profile_id)
     if profile is None:
         return BatchMatchTickResult()
 
     candidate_pool_limit = max(
-        settings.batch_match_max_items_per_batch,
-        settings.batch_match_max_items_per_batch
-        * max(1, settings.batch_match_candidate_pool_multiplier),
+        effective_max_items,
+        effective_max_items * max(1, settings.batch_match_candidate_pool_multiplier),
     )
     rows = await _select_unscored_application_rows(
         session,
@@ -193,7 +202,7 @@ async def _build_and_submit(
         profile,
         rows_by_application_id={app.id: job for app, job in rows},
         survivors=survivors,
-        limit=settings.batch_match_max_items_per_batch,
+        limit=effective_max_items,
     )
 
     if not survivors:

--- a/app/services/batch_match_service.py
+++ b/app/services/batch_match_service.py
@@ -66,7 +66,12 @@ class _ImportCounters:
     terminal_failed: int = 0
 
 
-_TERMINAL_PROVIDER_CORRELATION_ERRORS = {"provider returned unknown application_id"}
+_TERMINAL_PROVIDER_CORRELATION_ERRORS = {
+    "provider returned unknown application_id",
+    "provider returned duplicate application_id",
+    "provider returned duplicate request_key",
+    "provider returned unknown request_key",
+}
 
 
 async def run_batch_match_tick(
@@ -481,10 +486,16 @@ async def _import_provider_output(
         _provider_output_correlation_errors(items, output)
     )
     if batch_correlation_error is not None:
-        counters.retryable_failed += _mark_items_retryable(
-            items.values(),
-            batch_correlation_error,
-        )
+        if _is_terminal_provider_correlation_error(batch_correlation_error):
+            counters.terminal_failed += _mark_items_terminal(
+                items.values(),
+                batch_correlation_error,
+            )
+        else:
+            counters.retryable_failed += _mark_items_retryable(
+                items.values(),
+                batch_correlation_error,
+            )
         return counters
     for request_key, error in request_correlation_errors.items():
         request_items = _items_by_request_key(items, request_key)

--- a/app/services/job_sync_service.py
+++ b/app/services/job_sync_service.py
@@ -23,6 +23,7 @@ from sqlalchemy import and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from app.config import get_settings
 from app.models.company import Company
 from app.models.slug_fetch import SlugFetch
 from app.models.user_profile import UserProfile
@@ -87,6 +88,7 @@ async def prune_and_enqueue(profile: UserProfile, session: AsyncSession) -> dict
     Returns the same summary shape as `sync_profile` but with `matched_now=0`,
     so callers can treat the two functions interchangeably for telemetry.
     """
+    settings = get_settings()
     pruned = await _prune_invalid_provider_slugs(profile, session)
 
     stale = await slug_registry_service.list_stale_for_profile(profile, session, ttl_hours=6)
@@ -95,7 +97,11 @@ async def prune_and_enqueue(profile: UserProfile, session: AsyncSession) -> dict
         row_id = await enqueue(
             session,
             job_type="fetch-slug",
-            payload=FetchSlugPayload(provider=provider, slug=slug).model_dump(),
+            payload=FetchSlugPayload(
+                provider=provider,
+                slug=slug,
+                batch_match_max_items=settings.batch_match_manual_sync_max_items,
+            ).model_dump(exclude_none=True),
             dedupe_key=f"fetch-slug:{provider}:{slug}",
         )
         if row_id is not None:
@@ -117,6 +123,7 @@ async def prune_and_enqueue(profile: UserProfile, session: AsyncSession) -> dict
 
 async def sync_active_profiles(session: AsyncSession) -> dict:
     """Cron/scheduler sweep: enqueue distinct stale provider slugs for active profiles."""
+    settings = get_settings()
     active_profiles = (
         (
             await session.execute(
@@ -148,7 +155,11 @@ async def sync_active_profiles(session: AsyncSession) -> dict:
         row_id = await enqueue(
             session,
             job_type="fetch-slug",
-            payload=FetchSlugPayload(provider=provider, slug=slug).model_dump(),
+            payload=FetchSlugPayload(
+                provider=provider,
+                slug=slug,
+                batch_match_max_items=settings.batch_match_cron_max_items,
+            ).model_dump(exclude_none=True),
             dedupe_key=f"fetch-slug:{provider}:{slug}",
         )
         if row_id is not None:

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -161,7 +161,11 @@ def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
     return any(term in text for term in terms)
 
 
-def _contract_type_rejection(profile: UserProfile, job: Job, threshold: float) -> DeterministicRejectionFields | None:
+def _contract_type_rejection(
+    profile: UserProfile,
+    job: Job,
+    threshold: float,
+) -> DeterministicRejectionFields | None:
     _ = profile
     text = _normalized_text(job.contract_type, job.title, job.description or job.description_raw)
     term = next((term for term in _HARD_MISMATCH_CONTRACT_TERMS if term in text), None)
@@ -178,9 +182,16 @@ def _contract_type_rejection(profile: UserProfile, job: Job, threshold: float) -
     }
 
 
-def _seniority_rejection(profile: UserProfile, job: Job, threshold: float) -> DeterministicRejectionFields | None:
+def _seniority_rejection(
+    profile: UserProfile,
+    job: Job,
+    threshold: float,
+) -> DeterministicRejectionFields | None:
     profile_seniority = (profile.seniority or "").lower()
-    if "senior" not in profile_seniority and "staff" not in profile_seniority and "principal" not in profile_seniority:
+    if not any(
+        seniority in profile_seniority
+        for seniority in ("senior", "staff", "principal")
+    ):
         return None
     match = _JUNIOR_TITLE_RE.search(job.title or "")
     if match is None:
@@ -209,7 +220,11 @@ def _profile_role_families(profile: UserProfile) -> set[str]:
     return role_families_for_text(" ".join(profile.target_roles or []))
 
 
-def _role_family_rejection(profile: UserProfile, job: Job, threshold: float) -> DeterministicRejectionFields | None:
+def _role_family_rejection(
+    profile: UserProfile,
+    job: Job,
+    threshold: float,
+) -> DeterministicRejectionFields | None:
     target_families = _profile_role_families(profile)
     if not target_families:
         return None
@@ -237,7 +252,9 @@ def candidate_priority_score(profile: UserProfile, job: Job) -> float:
     if target_families and job_families:
         score += 4.0 if target_families & job_families else -2.0
 
-    profile_tokens = set(re.findall(r"[a-z0-9+#.]{3,}", " ".join(profile.target_roles or []).lower()))
+    profile_tokens = set(
+        re.findall(r"[a-z0-9+#.]{3,}", " ".join(profile.target_roles or []).lower())
+    )
     title_tokens = set(re.findall(r"[a-z0-9+#.]{3,}", (job.title or "").lower()))
     score += min(2.0, len(profile_tokens & title_tokens) * 0.5)
 
@@ -248,7 +265,8 @@ def candidate_priority_score(profile: UserProfile, job: Job) -> float:
         score += 1.0
 
     description_text = (job.description or job.description_raw or "").lower()
-    score += min(2.0, sum(1 for term in _ENGINEERING_SKILL_TERMS if term in description_text) * 0.25)
+    skill_hits = sum(1 for term in _ENGINEERING_SKILL_TERMS if term in description_text)
+    score += min(2.0, skill_hits * 0.25)
     if job.contract_type and "full" in job.contract_type.lower():
         score += 0.5
     return score

--- a/app/services/match_service.py
+++ b/app/services/match_service.py
@@ -1,5 +1,6 @@
 """Match service helpers for profile formatting and application listing."""
 
+import re
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, TypedDict
@@ -54,6 +55,205 @@ def deterministic_rejection_score(threshold: float) -> float:
     return max(0.0, min(0.29, threshold - 0.01))
 
 
+_HARD_MISMATCH_CONTRACT_TERMS = (
+    "internship",
+    "intern",
+    "temporary",
+    "temp",
+    "part-time",
+    "part time",
+    "contract",
+    "1099",
+    "commission-only",
+    "commission only",
+    "volunteer",
+    "unpaid",
+)
+
+_JUNIOR_TITLE_RE = re.compile(
+    r"\b(intern(ship)?|new grad|new-grad|graduate|campus|entry[- ]level|junior|jr\.?|associate)\b",
+    re.IGNORECASE,
+)
+
+_ROLE_FAMILY_TERMS: dict[str, tuple[str, ...]] = {
+    "engineering": (
+        "engineer",
+        "developer",
+        "software",
+        "backend",
+        "front end",
+        "frontend",
+        "full stack",
+        "fullstack",
+        "platform",
+        "infrastructure",
+        "sre",
+        "devops",
+        "data engineer",
+        "machine learning",
+        "ml engineer",
+        "ai engineer",
+        "security engineer",
+        "architect",
+    ),
+    "product": ("product manager", "product lead", "product owner"),
+    "design": ("designer", "design", "ux", "ui"),
+    "data": ("data scientist", "analyst", "analytics", "bi "),
+    "sales": (
+        "account executive",
+        "sales",
+        "business development",
+        "bdr",
+        "sdr",
+        "enterprise account",
+        "strategic account",
+        "revenue",
+        "quota",
+    ),
+    "customer_success": (
+        "customer success",
+        "solutions consultant",
+        "implementation consultant",
+        "support specialist",
+    ),
+    "recruiting": ("recruiter", "talent acquisition", "sourcer"),
+    "marketing": ("marketing", "growth manager", "content", "brand"),
+    "finance": ("finance", "accounting", "controller", "fp&a"),
+    "legal": ("counsel", "legal", "attorney", "paralegal"),
+    "operations": ("operations", "chief of staff", "program manager"),
+}
+
+_NON_TECH_ROLE_FAMILIES = {
+    "sales",
+    "customer_success",
+    "recruiting",
+    "marketing",
+    "finance",
+    "legal",
+}
+
+_ENGINEERING_SKILL_TERMS = (
+    "python",
+    "typescript",
+    "javascript",
+    "java",
+    "go",
+    "rust",
+    "postgres",
+    "kubernetes",
+    "docker",
+    "api",
+    "distributed",
+    "platform",
+    "backend",
+    "infrastructure",
+    "aws",
+    "gcp",
+    "azure",
+)
+
+
+def _normalized_text(*parts: str | None) -> str:
+    return " ".join(part or "" for part in parts).lower()
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    return any(term in text for term in terms)
+
+
+def _contract_type_rejection(profile: UserProfile, job: Job, threshold: float) -> DeterministicRejectionFields | None:
+    _ = profile
+    text = _normalized_text(job.contract_type, job.title, job.description or job.description_raw)
+    term = next((term for term in _HARD_MISMATCH_CONTRACT_TERMS if term in text), None)
+    if term is None:
+        return None
+    gap = f"Non-target employment type: {term}"
+    return {
+        "score": deterministic_rejection_score(threshold),
+        "summary": "Deterministic mismatch: employment type",
+        "rationale": gap,
+        "strengths": [],
+        "gaps": [gap],
+        "policy": "contract_type",
+    }
+
+
+def _seniority_rejection(profile: UserProfile, job: Job, threshold: float) -> DeterministicRejectionFields | None:
+    profile_seniority = (profile.seniority or "").lower()
+    if "senior" not in profile_seniority and "staff" not in profile_seniority and "principal" not in profile_seniority:
+        return None
+    match = _JUNIOR_TITLE_RE.search(job.title or "")
+    if match is None:
+        return None
+    gap = f"Role seniority is {match.group(0).lower()}, below target seniority"
+    return {
+        "score": deterministic_rejection_score(threshold),
+        "summary": "Deterministic mismatch: seniority",
+        "rationale": gap,
+        "strengths": [],
+        "gaps": [gap],
+        "policy": "seniority",
+    }
+
+
+def role_families_for_text(text: str) -> set[str]:
+    lowered = text.lower()
+    return {
+        family
+        for family, terms in _ROLE_FAMILY_TERMS.items()
+        if _contains_any(lowered, terms)
+    }
+
+
+def _profile_role_families(profile: UserProfile) -> set[str]:
+    return role_families_for_text(" ".join(profile.target_roles or []))
+
+
+def _role_family_rejection(profile: UserProfile, job: Job, threshold: float) -> DeterministicRejectionFields | None:
+    target_families = _profile_role_families(profile)
+    if not target_families:
+        return None
+    job_families = role_families_for_text(job.title or "")
+    if not job_families:
+        return None
+    if "engineering" in target_families and job_families <= _NON_TECH_ROLE_FAMILIES:
+        gap = "Job title is outside target role families"
+        return {
+            "score": deterministic_rejection_score(threshold),
+            "summary": "Deterministic mismatch: role family",
+            "rationale": gap,
+            "strengths": [],
+            "gaps": [gap],
+            "policy": "role_family",
+        }
+    return None
+
+
+def candidate_priority_score(profile: UserProfile, job: Job) -> float:
+    """Cheap ordering score for deciding which uncertain jobs deserve LLM spend first."""
+    score = 0.0
+    target_families = _profile_role_families(profile)
+    job_families = role_families_for_text(job.title or "")
+    if target_families and job_families:
+        score += 4.0 if target_families & job_families else -2.0
+
+    profile_tokens = set(re.findall(r"[a-z0-9+#.]{3,}", " ".join(profile.target_roles or []).lower()))
+    title_tokens = set(re.findall(r"[a-z0-9+#.]{3,}", (job.title or "").lower()))
+    score += min(2.0, len(profile_tokens & title_tokens) * 0.5)
+
+    if (job.workplace_type or "").lower() == "remote" and profile.remote_ok:
+        score += 1.0
+    location_text = (job.location or "").lower()
+    if any((loc or "").lower() in location_text for loc in profile.target_locations or []):
+        score += 1.0
+
+    description_text = (job.description or job.description_raw or "").lower()
+    score += min(2.0, sum(1 for term in _ENGINEERING_SKILL_TERMS if term in description_text) * 0.25)
+    if job.contract_type and "full" in job.contract_type.lower():
+        score += 0.5
+    return score
+
+
 def deterministic_rejection_fields(
     profile: UserProfile,
     job: Job,
@@ -82,6 +282,18 @@ def deterministic_rejection_fields(
             "gaps": [gap],
             "policy": "remote_office",
         }
+
+    contract_verdict = _contract_type_rejection(profile, job, threshold)
+    if contract_verdict is not None:
+        return contract_verdict
+
+    seniority_verdict = _seniority_rejection(profile, job, threshold)
+    if seniority_verdict is not None:
+        return seniority_verdict
+
+    role_family_verdict = _role_family_rejection(profile, job, threshold)
+    if role_family_verdict is not None:
+        return role_family_verdict
 
     return None
 

--- a/app/worker/handlers/batch_match.py
+++ b/app/worker/handlers/batch_match.py
@@ -31,6 +31,7 @@ class BatchMatchHandler:
             session,
             profile_id=payload.profile_id,
             provider=provider,
+            max_items=payload.max_items,
         )
         await log.ainfo(
             "worker.batch_match.done",
@@ -47,7 +48,14 @@ class BatchMatchHandler:
             settings = get_settings()
             return EnqueueAfterDone(
                 job_type="batch-match",
-                payload={"profile_id": str(payload.profile_id)},
+                payload={
+                    key: value
+                    for key, value in {
+                        "profile_id": str(payload.profile_id),
+                        "max_items": payload.max_items,
+                    }.items()
+                    if value is not None
+                },
                 dedupe_key=f"batch-match:{payload.profile_id}",
                 not_before_seconds=settings.batch_match_poll_interval_seconds,
             )

--- a/app/worker/handlers/fetch_slug.py
+++ b/app/worker/handlers/fetch_slug.py
@@ -23,6 +23,7 @@ class FetchSlugHandler:
             counts = await fetch_one_slug(
                 provider=payload.provider,
                 slug=payload.slug,
+                batch_match_max_items=payload.batch_match_max_items,
                 session_factory=get_session_factory(),
             )
         except TransientFetchError as exc:

--- a/app/worker/payloads.py
+++ b/app/worker/payloads.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 class FetchSlugPayload(BaseModel):
     provider: str
     slug: str
+    batch_match_max_items: int | None = None
 
 
 class MatchPayload(BaseModel):
@@ -19,6 +20,7 @@ class GenerateCoverLetterPayload(BaseModel):
 
 class BatchMatchPayload(BaseModel):
     profile_id: uuid.UUID
+    max_items: int | None = None
 
 
 class MaintenancePayload(BaseModel):

--- a/tests/integration/test_batch_match_service.py
+++ b/tests/integration/test_batch_match_service.py
@@ -97,6 +97,8 @@ async def add_unscored_app_for_profile(
     profile: UserProfile,
     *,
     title: str = "Backend Engineer",
+    description: str = "Build Python APIs for marketplace systems.",
+    created_at: datetime | None = None,
 ) -> Application:
     company_id = profile.target_company_ids[0]
     job = Job(
@@ -107,7 +109,7 @@ async def add_unscored_app_for_profile(
         company_id=company_id,
         location="Remote - United States",
         workplace_type="remote",
-        description="Build Python APIs for marketplace systems.",
+        description=description,
         apply_url=f"https://example.com/job/{uuid.uuid4()}",
         is_active=True,
     )
@@ -122,6 +124,7 @@ async def add_unscored_app_for_profile(
         match_score=None,
         match_strengths=[],
         match_gaps=[],
+        created_at=created_at or datetime.now(UTC),
     )
     db_session.add(app)
     await db_session.commit()
@@ -173,6 +176,61 @@ async def test_build_submits_batch_for_profile_unscored_apps(db_session):
     items = await _batch_items(db_session)
     assert len(items) == 3
     assert {item.application_id for item in items} == {app.id for app in apps}
+
+
+@pytest.mark.asyncio
+async def test_build_prioritizes_high_signal_survivors_before_newer_weak_matches(
+    db_session,
+    monkeypatch,
+):
+    import app.config as cfg
+    from app.services.batch_match_provider import FakeBatchMatchProvider
+    from app.services.batch_match_service import run_batch_match_tick
+
+    monkeypatch.setenv("BATCH_MATCH_MAX_ITEMS_PER_BATCH", "2")
+    monkeypatch.setattr(cfg, "_settings", None)
+    profile, _ = await seed_profile_with_unscored_apps(db_session, count=0)
+    profile.target_roles = ["Senior Backend Engineer"]
+    profile.seniority = "senior"
+    db_session.add(profile)
+    await db_session.commit()
+
+    weak_newer = await add_unscored_app_for_profile(
+        db_session,
+        profile,
+        title="Operations Analyst",
+        description="Coordinate spreadsheets and internal process reporting.",
+        created_at=datetime.now(UTC),
+    )
+    weak_second = await add_unscored_app_for_profile(
+        db_session,
+        profile,
+        title="Program Coordinator",
+        description="Track internal projects and organize status meetings.",
+        created_at=datetime.now(UTC) - timedelta(hours=1),
+    )
+    strong_older = await add_unscored_app_for_profile(
+        db_session,
+        profile,
+        title="Senior Backend Engineer",
+        description="Build Python APIs, PostgreSQL services, and distributed platform systems.",
+        created_at=datetime.now(UTC) - timedelta(days=1),
+    )
+
+    provider = FakeBatchMatchProvider(ready=False)
+
+    result = await run_batch_match_tick(db_session, profile_id=profile.id, provider=provider)
+
+    assert result.selected == 3
+    assert result.submitted == 2
+    submitted_ids = [
+        job["application_id"]
+        for request in provider.submitted_requests
+        for job in request["jobs"]
+    ]
+    assert str(strong_older.id) in submitted_ids
+    assert len(submitted_ids) == 2
+    assert str(weak_newer.id) not in submitted_ids or str(weak_second.id) not in submitted_ids
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_batch_match_service.py
+++ b/tests/integration/test_batch_match_service.py
@@ -198,15 +198,15 @@ async def test_build_prioritizes_high_signal_survivors_before_newer_weak_matches
     weak_newer = await add_unscored_app_for_profile(
         db_session,
         profile,
-        title="Operations Analyst",
-        description="Coordinate spreadsheets and internal process reporting.",
+        title="Backend Developer",
+        description="Maintain internal tools and update operational dashboards.",
         created_at=datetime.now(UTC),
     )
     weak_second = await add_unscored_app_for_profile(
         db_session,
         profile,
-        title="Program Coordinator",
-        description="Track internal projects and organize status meetings.",
+        title="Software Engineer",
+        description="Support legacy services and handle routine maintenance requests.",
         created_at=datetime.now(UTC) - timedelta(hours=1),
     )
     strong_older = await add_unscored_app_for_profile(

--- a/tests/integration/test_batch_match_service.py
+++ b/tests/integration/test_batch_match_service.py
@@ -523,14 +523,15 @@ async def test_duplicate_provider_result_ids_mark_request_retryable_without_part
     result = await run_batch_match_tick(db_session, profile_id=profile.id, provider=second_provider)
 
     assert result.imported == 0
-    assert result.retryable_failed == 2
+    assert result.retryable_failed == 0
+    assert result.terminal_failed == 2
     for app in apps:
         refreshed = await db_session.get(Application, app.id)
         assert refreshed is not None
         assert refreshed.match_score is None
 
     items = await _batch_items_for_batch(db_session, original_batch.id)
-    assert {item.status for item in items} == {"retryable_failed"}
+    assert {item.status for item in items} == {"terminal_failed"}
     assert {item.error for item in items} == {"provider returned duplicate application_id"}
 
 
@@ -662,14 +663,15 @@ async def test_unknown_provider_request_key_marks_batch_retryable_without_partia
     result = await run_batch_match_tick(db_session, profile_id=profile.id, provider=second_provider)
 
     assert result.imported == 0
-    assert result.retryable_failed == 2
+    assert result.retryable_failed == 0
+    assert result.terminal_failed == 2
     for app in apps:
         refreshed = await db_session.get(Application, app.id)
         assert refreshed is not None
         assert refreshed.match_score is None
 
     items = await _batch_items_for_batch(db_session, original_batch.id)
-    assert {item.status for item in items} == {"retryable_failed"}
+    assert {item.status for item in items} == {"terminal_failed"}
     assert {item.error for item in items} == {"provider returned unknown request_key"}
 
 
@@ -728,14 +730,15 @@ async def test_duplicate_provider_result_ids_split_across_requests_mark_retryabl
     result = await run_batch_match_tick(db_session, profile_id=profile.id, provider=second_provider)
 
     assert result.imported == 0
-    assert result.retryable_failed == 2
+    assert result.retryable_failed == 0
+    assert result.terminal_failed == 2
     for app in apps:
         refreshed = await db_session.get(Application, app.id)
         assert refreshed is not None
         assert refreshed.match_score is None
 
     items = await _batch_items_for_batch(db_session, original_batch.id)
-    assert {item.status for item in items} == {"retryable_failed"}
+    assert {item.status for item in items} == {"terminal_failed"}
     assert {item.error for item in items} == {"provider returned duplicate application_id"}
 
 
@@ -794,14 +797,15 @@ async def test_duplicate_provider_request_blocks_mark_retryable_without_partial_
     result = await run_batch_match_tick(db_session, profile_id=profile.id, provider=second_provider)
 
     assert result.imported == 0
-    assert result.retryable_failed == 2
+    assert result.retryable_failed == 0
+    assert result.terminal_failed == 2
     for app in apps:
         refreshed = await db_session.get(Application, app.id)
         assert refreshed is not None
         assert refreshed.match_score is None
 
     items = await _batch_items_for_batch(db_session, original_batch.id)
-    assert {item.status for item in items} == {"retryable_failed"}
+    assert {item.status for item in items} == {"terminal_failed"}
     assert {item.error for item in items} == {"provider returned duplicate request_key"}
 
 

--- a/tests/integration/test_cron_sync_enqueues.py
+++ b/tests/integration/test_cron_sync_enqueues.py
@@ -74,4 +74,8 @@ async def test_cron_sync_enqueues_fetch_slug_work_rows(db_session):
     )
     assert len(rows) == 1
     assert rows[0].dedupe_key == "fetch-slug:greenhouse:co"
-    assert rows[0].payload == {"provider": "greenhouse", "slug": "co"}
+    assert rows[0].payload == {
+        "provider": "greenhouse",
+        "slug": "co",
+        "batch_match_max_items": 100,
+    }

--- a/tests/integration/test_fetch_slug_batch_match.py
+++ b/tests/integration/test_fetch_slug_batch_match.py
@@ -115,11 +115,19 @@ def _greenhouse_fixture(slug: str, external_id: int = 9001) -> dict:
     }
 
 
-def _fetch_row(slug: str) -> WorkQueue:
+def _fetch_row(slug: str, *, batch_match_max_items: int | None = None) -> WorkQueue:
     return WorkQueue(
         id=1,
         job_type="fetch-slug",
-        payload={"provider": "greenhouse", "slug": slug},
+        payload={
+            key: value
+            for key, value in {
+                "provider": "greenhouse",
+                "slug": slug,
+                "batch_match_max_items": batch_match_max_items,
+            }.items()
+            if value is not None
+        },
         status=WorkQueueStatus.IN_PROGRESS,
         attempts=1,
         claimed_by="w1",
@@ -163,7 +171,11 @@ async def test_enqueue_batch_match_for_affected_profiles_when_enabled(db_session
     )
     await _seed_application(db_session, job_id=other_job.id, profile_id=other_job_profile.id)
 
-    enqueued = await _enqueue_batch_match_for_affected_profiles(job.id, db_session)
+    enqueued = await _enqueue_batch_match_for_affected_profiles(
+        job.id,
+        db_session,
+        max_items=50,
+    )
     await db_session.commit()
 
     rows = (
@@ -173,9 +185,12 @@ async def test_enqueue_batch_match_for_affected_profiles_when_enabled(db_session
     ).scalars().all()
 
     assert enqueued == 2
-    assert {(row.payload["profile_id"], row.dedupe_key) for row in rows} == {
-        (str(first_profile.id), f"batch-match:{first_profile.id}"),
-        (str(second_profile.id), f"batch-match:{second_profile.id}"),
+    assert {
+        (row.payload["profile_id"], row.payload["max_items"], row.dedupe_key)
+        for row in rows
+    } == {
+        (str(first_profile.id), 50, f"batch-match:{first_profile.id}"),
+        (str(second_profile.id), 50, f"batch-match:{second_profile.id}"),
     }
 
 
@@ -250,7 +265,10 @@ async def test_fetch_slug_enqueues_batch_match_instead_of_match_when_enabled(
         respx.get(f"{GREENHOUSE_BOARDS_BASE}/{slug}/jobs").mock(
             return_value=httpx.Response(200, json=_greenhouse_fixture(slug))
         )
-        await FetchSlugHandler()(db_session, _fetch_row(slug))
+        await FetchSlugHandler()(
+            db_session,
+            _fetch_row(slug, batch_match_max_items=50),
+        )
 
     batch_match_rows = (
         await db_session.execute(
@@ -267,7 +285,7 @@ async def test_fetch_slug_enqueues_batch_match_instead_of_match_when_enabled(
 
     assert match_count == 0
     assert [(row.payload, row.dedupe_key) for row in batch_match_rows] == [
-        ({"profile_id": str(profile.id)}, f"batch-match:{profile.id}")
+        ({"profile_id": str(profile.id), "max_items": 50}, f"batch-match:{profile.id}")
     ]
 
 

--- a/tests/integration/test_handler_batch_match.py
+++ b/tests/integration/test_handler_batch_match.py
@@ -7,11 +7,18 @@ from app.models.work_queue import WorkQueue, WorkQueueStatus
 from app.worker.handlers import HANDLERS
 
 
-def _batch_match_row(profile_id: uuid.UUID) -> WorkQueue:
+def _batch_match_row(profile_id: uuid.UUID, *, max_items: int | None = None) -> WorkQueue:
     return WorkQueue(
         id=1,
         job_type="batch-match",
-        payload={"profile_id": str(profile_id)},
+        payload={
+            key: value
+            for key, value in {
+                "profile_id": str(profile_id),
+                "max_items": max_items,
+            }.items()
+            if value is not None
+        },
         status=WorkQueueStatus.IN_PROGRESS,
         attempts=1,
         claimed_by="w1",
@@ -52,16 +59,20 @@ async def test_batch_match_handler_calls_service_with_parsed_profile_id(db_sessi
         "app.worker.handlers.batch_match.log.ainfo",
         AsyncMock(),
     ) as mock_log:
-        follow_up = await BatchMatchHandler()(db_session, _batch_match_row(profile_id))
+        follow_up = await BatchMatchHandler()(
+            db_session,
+            _batch_match_row(profile_id, max_items=50),
+        )
 
     mock_provider_factory.assert_called_once_with()
     assert mock_tick.call_count == 1
     _, kwargs = mock_tick.call_args
     assert kwargs["profile_id"] == profile_id
     assert kwargs["provider"] is provider
+    assert kwargs["max_items"] == 50
     assert follow_up is not None
     assert follow_up.job_type == "batch-match"
-    assert follow_up.payload == {"profile_id": str(profile_id)}
+    assert follow_up.payload == {"profile_id": str(profile_id), "max_items": 50}
     assert follow_up.dedupe_key == f"batch-match:{profile_id}"
     assert follow_up.not_before_seconds is not None
     mock_log.assert_awaited_once_with(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -46,3 +46,6 @@ def test_batch_matching_defaults(monkeypatch):
     assert settings.batch_match_max_request_chars == 60000
     assert settings.batch_match_poll_interval_seconds == 60
     assert settings.batch_match_max_items_per_batch == 100
+    assert settings.batch_match_candidate_pool_multiplier == 3
+    assert settings.batch_match_manual_sync_max_items == 50
+    assert settings.batch_match_cron_max_items == 100

--- a/tests/unit/test_job_sync_service.py
+++ b/tests/unit/test_job_sync_service.py
@@ -78,8 +78,8 @@ async def test_sync_active_profiles_aggregates_shared_enqueue_contract():
     mock_list_stale.assert_awaited_once_with(session, ttl_hours=6)
     assert mock_enqueue.await_count == 2
     assert [call.kwargs["payload"] for call in mock_enqueue.await_args_list] == [
-        {"provider": "greenhouse", "slug": "airbnb"},
-        {"provider": "greenhouse", "slug": "stripe"},
+        {"provider": "greenhouse", "slug": "airbnb", "batch_match_max_items": 100},
+        {"provider": "greenhouse", "slug": "stripe", "batch_match_max_items": 100},
     ]
     assert [call.kwargs["dedupe_key"] for call in mock_enqueue.await_args_list] == [
         "fetch-slug:greenhouse:airbnb",

--- a/tests/unit/test_match_service.py
+++ b/tests/unit/test_match_service.py
@@ -168,6 +168,15 @@ def test_candidate_priority_scores_strong_engineering_jobs_above_weak_matches():
     assert candidate_priority_score(profile, strong) > candidate_priority_score(profile, weak)
 
 
+def test_provider_correlation_errors_are_terminal_to_prevent_paid_retry_loops():
+    from app.services.batch_match_service import _is_terminal_provider_correlation_error
+
+    assert _is_terminal_provider_correlation_error("provider returned unknown application_id")
+    assert _is_terminal_provider_correlation_error("provider returned duplicate application_id")
+    assert _is_terminal_provider_correlation_error("provider returned duplicate request_key")
+    assert _is_terminal_provider_correlation_error("provider returned unknown request_key")
+
+
 @pytest.mark.asyncio
 async def test_list_applications_filters_out_jobs_older_than_10_days():
     from app.services.match_service import list_applications

--- a/tests/unit/test_match_service.py
+++ b/tests/unit/test_match_service.py
@@ -24,20 +24,23 @@ def _make_profile() -> UserProfile:
 def _make_job(
     job_id: uuid.UUID | None = None,
     *,
+    title: str = "Software Engineer",
     description: str = "A great job.",
     location: str | None = "Remote",
     workplace_type: str | None = "remote",
+    contract_type: str | None = None,
 ) -> Job:
     return Job(
         id=job_id or uuid.uuid4(),
         source="adzuna",
         external_id=str(uuid.uuid4()),
-        title="Software Engineer",
+        title=title,
         company_name="Acme Corp",
         apply_url="https://example.com/apply",
         location=location,
         workplace_type=workplace_type,
         description=description,
+        contract_type=contract_type,
     )
 
 
@@ -90,6 +93,79 @@ def test_remote_policy_does_not_cap_matching_target_location():
 
     assert adjusted.score == 0.92
     assert adjusted.gaps == original_gaps
+
+
+def test_contract_type_hard_rejects_internship_for_senior_profile():
+    from app.services.match_service import deterministic_rejection_fields
+
+    profile = _make_profile()
+    job = _make_job(
+        title="Software Engineering Intern",
+        contract_type="internship",
+        location="Remote - United States",
+    )
+
+    fields = deterministic_rejection_fields(profile, job, 0.65)
+
+    assert fields is not None
+    assert fields["policy"] == "contract_type"
+    assert fields["score"] < 0.65
+    assert "internship" in fields["gaps"][0].lower()
+
+
+def test_seniority_hard_rejects_new_grad_for_senior_profile():
+    from app.services.match_service import deterministic_rejection_fields
+
+    profile = _make_profile()
+    job = _make_job(title="New Grad Software Engineer", location="Remote - United States")
+
+    fields = deterministic_rejection_fields(profile, job, 0.65)
+
+    assert fields is not None
+    assert fields["policy"] == "seniority"
+    assert fields["score"] < 0.65
+    assert "new grad" in fields["gaps"][0].lower()
+
+
+def test_role_family_hard_rejects_sales_role_for_engineering_profile():
+    from app.services.match_service import deterministic_rejection_fields
+
+    profile = _make_profile()
+    profile.target_roles = ["Senior Backend Engineer", "Platform Engineer"]
+    job = _make_job(
+        title="Enterprise Account Executive",
+        description="Own quota and close enterprise SaaS deals.",
+        location="Remote - United States",
+    )
+
+    fields = deterministic_rejection_fields(profile, job, 0.65)
+
+    assert fields is not None
+    assert fields["policy"] == "role_family"
+    assert fields["score"] < 0.65
+    assert "outside target role families" in fields["gaps"][0]
+
+
+def test_candidate_priority_scores_strong_engineering_jobs_above_weak_matches():
+    from app.services.match_service import candidate_priority_score
+
+    profile = _make_profile()
+    profile.target_roles = ["Senior Backend Engineer"]
+    profile.target_locations = ["San Francisco"]
+    strong = _make_job(
+        title="Senior Backend Engineer",
+        description="Build Python APIs, distributed systems, PostgreSQL, and platform services.",
+        location="Remote - United States",
+        workplace_type="remote",
+    )
+    weak = _make_job(
+        title="Operations Analyst",
+        description="Coordinate internal processes and produce spreadsheets.",
+        location="Remote - United States",
+        workplace_type="remote",
+    )
+
+    assert candidate_priority_score(profile, strong) > candidate_priority_score(profile, weak)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_worker_payloads.py
+++ b/tests/unit/test_worker_payloads.py
@@ -16,8 +16,19 @@ def test_fetch_slug_payload():
     p = FetchSlugPayload(provider="greenhouse", slug="openai")
     assert p.provider == "greenhouse"
     assert p.slug == "openai"
+    assert p.batch_match_max_items is None
     with pytest.raises(ValidationError):
         FetchSlugPayload(provider="greenhouse")
+
+
+def test_fetch_slug_payload_accepts_batch_match_limit():
+    p = FetchSlugPayload(
+        provider="greenhouse",
+        slug="openai",
+        batch_match_max_items=50,
+    )
+
+    assert p.batch_match_max_items == 50
 
 
 def test_match_payload_requires_application_id():
@@ -49,6 +60,7 @@ def test_batch_match_payload_requires_profile_id():
 def test_batch_match_payload_parses_profile_id():
     profile_id = uuid.uuid4()
 
-    payload = BatchMatchPayload(profile_id=str(profile_id))
+    payload = BatchMatchPayload(profile_id=str(profile_id), max_items=50)
 
     assert payload.profile_id == profile_id
+    assert payload.max_items == 50


### PR DESCRIPTION
## Summary
- add deterministic pre-LLM hard rejects for obvious job/profile mismatches
- prioritize high-signal batch candidates from a larger cheap local pool before provider submission
- terminalize provider correlation/output contract failures to avoid paid retry loops
- add separate manual sync and cron batch limits and preserve them through fetch-slug/batch-match requeues

## Test Plan
- uv run ruff check app tests
- uv run pytest tests/unit -q
- sg docker -c 'uv run pytest tests/integration -q'