### PR TITLE
fix: avoid Gemini batch response schema corruption

### DIFF
--- a/app/services/gemini_batch_match_provider.py
+++ b/app/services/gemini_batch_match_provider.py
@@ -105,51 +105,13 @@ def _inline_request(request: dict) -> dict:
         **payload["request"],
         "config": {
             "response_mime_type": "application/json",
-            "response_json_schema": _response_json_schema(
-                [str(job.get("application_id", "")) for job in jobs]
-            ),
+            # Do not send response_json_schema here. In real Gemini batch canaries,
+            # constrained decoding turned the nested results schema into malformed
+            # JSON with repeated `results` keys and string field names instead of
+            # result objects. The prompt already carries the allowed IDs, and the
+            # importer validates/correlates every result before writing scores.
         },
         "metadata": {"request_key": payload["key"]},
-    }
-
-
-def _response_json_schema(application_ids: list[str]) -> dict:
-    return {
-        "type": "object",
-        "properties": {
-            "results": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "application_id": {
-                            "type": "string",
-                            "enum": application_ids,
-                        },
-                        "score": {"type": "number"},
-                        "summary": {"type": "string"},
-                        "rationale": {"type": "string"},
-                        "strengths": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "gaps": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                    },
-                    "required": [
-                        "application_id",
-                        "score",
-                        "summary",
-                        "rationale",
-                        "strengths",
-                        "gaps",
-                    ],
-                },
-            },
-        },
-        "required": ["results"],
     }
 
 

--- a/tests/unit/test_gemini_batch_match_provider.py
+++ b/tests/unit/test_gemini_batch_match_provider.py
@@ -115,10 +115,7 @@ async def test_gemini_batch_match_provider_submit_creates_inline_batch():
     assert created["config"]["display_name"] == "batch-match-test"
     assert created["src"][0]["metadata"] == {"request_key": "request-0001"}
     assert created["src"][0]["config"]["response_mime_type"] == "application/json"
-    schema = created["src"][0]["config"]["response_json_schema"]
-    assert schema["properties"]["results"]["items"]["properties"]["application_id"]["enum"] == [
-        "app-1"
-    ]
+    assert "response_json_schema" not in created["src"][0]["config"]
     prompt = created["src"][0]["contents"][0]["parts"][0]["text"]
     assert "Senior Python engineer." in prompt
     assert "app-1" in prompt


### PR DESCRIPTION
## Summary
- remove Gemini batch response_json_schema after production canary produced malformed JSON with repeated results keys
- keep JSON MIME mode and rely on prompt plus importer correlation validation

## Testing
- uv run ruff check app/services/gemini_batch_match_provider.py tests/unit/test_gemini_batch_match_provider.py
- uv run pytest tests/unit/test_gemini_batch_match_provider.py tests/unit/test_batch_match_provider.py -q