### PR TITLE
fix: send one job per batch match request

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
     batch_match_dry_run: bool = False
     batch_match_provider: str = "fake"
     batch_match_prompt_version: str = "batch-match-v1"
-    batch_match_max_apps_per_request: int = 10
+    batch_match_max_apps_per_request: int = 1
     batch_match_max_request_chars: int = 60000
     batch_match_poll_interval_seconds: int = 60
     batch_match_max_items_per_batch: int = 100

--- a/app/services/batch_match_packing.py
+++ b/app/services/batch_match_packing.py
@@ -118,19 +118,6 @@ def pack_provider_requests(
         raise ValueError("max_apps_per_request must be at least 1")
 
     groups: list[PackedProviderRequest] = []
-    current: list[BatchJobContext] = []
-
-    def flush() -> None:
-        if not current:
-            return
-        groups.append(
-            PackedProviderRequest(
-                request_key=f"request-{len(groups) + 1:04d}",
-                jobs=list(current),
-                estimated_chars=estimate_request_chars(profile_text=profile_text, jobs=current),
-            )
-        )
-        current.clear()
 
     for original_job in jobs:
         job = _truncate_job_to_request_budget(
@@ -138,13 +125,11 @@ def pack_provider_requests(
             job=original_job,
             max_request_chars=max_request_chars,
         )
-        candidate = [*current, job]
-        if current and (
-            len(candidate) > max_apps_per_request
-            or estimate_request_chars(profile_text=profile_text, jobs=candidate)
-            > max_request_chars
-        ):
-            flush()
-        current.append(job)
-    flush()
+        groups.append(
+            PackedProviderRequest(
+                request_key=f"request-{len(groups) + 1:04d}",
+                jobs=[job],
+                estimated_chars=estimate_request_chars(profile_text=profile_text, jobs=[job]),
+            )
+        )
     return groups

--- a/app/services/batch_match_service.py
+++ b/app/services/batch_match_service.py
@@ -602,8 +602,8 @@ def _provider_output_correlation_errors(
         repeated_request_key = request.request_key in seen_request_keys
         seen_request_keys.add(request.request_key)
 
-        if repeated_request_key and request.request_key not in request_errors:
-            request_errors[request.request_key] = "provider returned duplicate request_key"
+        if repeated_request_key:
+            return "provider returned duplicate request_key", {}
     return None, request_errors
 
 

--- a/tests/integration/test_batch_match_service.py
+++ b/tests/integration/test_batch_match_service.py
@@ -172,8 +172,8 @@ async def test_build_submits_batch_for_profile_unscored_apps(db_session):
     assert result.selected == 3
     assert result.submitted == 3
     assert result.imported == 0
-    assert len(provider.submitted_requests) == 1
-    assert len(provider.submitted_requests[0]["jobs"]) == 3
+    assert len(provider.submitted_requests) == 3
+    assert [len(request["jobs"]) for request in provider.submitted_requests] == [1, 1, 1]
 
     batch = (await db_session.execute(select(LLMMatchBatch))).scalar_one()
     assert batch.status == "submitted"
@@ -391,7 +391,12 @@ async def test_import_partial_provider_output(db_session):
                             rationale="Strong Python match",
                             strengths=["Python"],
                             gaps=[],
-                        ),
+                        )
+                    ],
+                ),
+                ProviderRequestResult(
+                    request_key="request-0002",
+                    results=[
                         ProviderJobResult(
                             application_id=str(apps[1].id),
                             score=None,
@@ -399,7 +404,7 @@ async def test_import_partial_provider_output(db_session):
                             rationale="Provider returned null score",
                             strengths=[],
                             gaps=[],
-                        ),
+                        )
                     ],
                 )
             ]
@@ -511,7 +516,12 @@ async def test_duplicate_provider_result_ids_import_by_request_position(
                             rationale="Strong Python match",
                             strengths=["Python"],
                             gaps=[],
-                        ),
+                        )
+                    ],
+                ),
+                ProviderRequestResult(
+                    request_key="request-0002",
+                    results=[
                         ProviderJobResult(
                             application_id=str(apps[0].id),
                             score=0.7,
@@ -519,7 +529,7 @@ async def test_duplicate_provider_result_ids_import_by_request_position(
                             rationale="Duplicate result",
                             strengths=["APIs"],
                             gaps=[],
-                        ),
+                        )
                     ],
                 )
             ]
@@ -569,7 +579,12 @@ async def test_corrupted_provider_result_ids_import_by_request_position(db_sessi
                             rationale="First by position",
                             strengths=["Python"],
                             gaps=[],
-                        ),
+                        )
+                    ],
+                ),
+                ProviderRequestResult(
+                    request_key="request-0002",
+                    results=[
                         ProviderJobResult(
                             application_id=str(uuid.uuid4()),
                             score=0.7,
@@ -577,7 +592,12 @@ async def test_corrupted_provider_result_ids_import_by_request_position(db_sessi
                             rationale="Second by position",
                             strengths=["APIs"],
                             gaps=[],
-                        ),
+                        )
+                    ],
+                ),
+                ProviderRequestResult(
+                    request_key="request-0003",
+                    results=[
                         ProviderJobResult(
                             application_id="not-a-uuid",
                             score=0.6,
@@ -585,7 +605,7 @@ async def test_corrupted_provider_result_ids_import_by_request_position(db_sessi
                             rationale="Third by position",
                             strengths=["Platform"],
                             gaps=[],
-                        ),
+                        )
                     ],
                 )
             ]
@@ -601,7 +621,10 @@ async def test_corrupted_provider_result_ids_import_by_request_position(db_sessi
         uuid.UUID(job["application_id"]): (0.8 - index * 0.1, summary)
         for index, (job, summary) in enumerate(
             zip(
-                first_provider.submitted_requests[0]["jobs"],
+                [
+                    request["jobs"][0]
+                    for request in first_provider.submitted_requests
+                ],
                 ["First result", "Second result", "Third result"],
                 strict=True,
             )
@@ -645,7 +668,12 @@ async def test_unknown_provider_result_id_imports_by_request_position(
                             rationale="Strong Python match",
                             strengths=["Python"],
                             gaps=[],
-                        ),
+                        )
+                    ],
+                ),
+                ProviderRequestResult(
+                    request_key="request-0002",
+                    results=[
                         ProviderJobResult(
                             application_id=str(uuid.uuid4()),
                             score=0.7,
@@ -653,7 +681,7 @@ async def test_unknown_provider_result_id_imports_by_request_position(
                             rationale="Not from this request",
                             strengths=["APIs"],
                             gaps=[],
-                        ),
+                        )
                     ],
                 )
             ]
@@ -1080,3 +1108,4 @@ async def test_below_threshold_import_preserves_user_owned_status(db_session):
     assert refreshed is not None
     assert refreshed.match_score == 0.2
     assert refreshed.status == "applied"
+

--- a/tests/unit/test_batch_match_packing.py
+++ b/tests/unit/test_batch_match_packing.py
@@ -21,17 +21,20 @@ def _job(index: int, description: str = "Build APIs") -> BatchJobContext:
     )
 
 
-def test_pack_provider_requests_caps_at_ten_apps():
+def test_pack_provider_requests_sends_one_job_per_provider_request():
     groups = pack_provider_requests(
         profile_text="Python backend engineer",
-        jobs=[_job(i) for i in range(1, 12)],
+        jobs=[_job(i) for i in range(1, 4)],
         max_apps_per_request=10,
         max_request_chars=100000,
     )
 
-    assert [len(group.jobs) for group in groups] == [10, 1]
-    assert groups[0].request_key == "request-0001"
-    assert groups[1].request_key == "request-0002"
+    assert [len(group.jobs) for group in groups] == [1, 1, 1]
+    assert [group.request_key for group in groups] == [
+        "request-0001",
+        "request-0002",
+        "request-0003",
+    ]
 
 
 def test_pack_provider_requests_respects_char_budget():
@@ -48,7 +51,7 @@ def test_pack_provider_requests_respects_char_budget():
     )
 
     assert two_job_budget < three_job_estimate
-    assert [len(group.jobs) for group in groups] == [2, 1]
+    assert [len(group.jobs) for group in groups] == [1, 1, 1]
 
 
 def test_estimate_request_chars_includes_request_and_job_overhead():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -42,7 +42,7 @@ def test_batch_matching_defaults(monkeypatch):
     assert settings.batch_match_dry_run is False
     assert settings.batch_match_provider == "fake"
     assert settings.batch_match_prompt_version == "batch-match-v1"
-    assert settings.batch_match_max_apps_per_request == 10
+    assert settings.batch_match_max_apps_per_request == 1
     assert settings.batch_match_max_request_chars == 60000
     assert settings.batch_match_poll_interval_seconds == 60
     assert settings.batch_match_max_items_per_batch == 100


### PR DESCRIPTION
## Summary
- emit exactly one application/job per provider request in batch matching
- change the default max apps per provider request from 10 to 1
- treat duplicate provider request keys as whole-batch unsafe correlation errors
- update unit/integration coverage for one-job request behavior

## Test Plan
- uv run pytest tests/unit tests/integration/test_batch_match_service.py -q
- uv run ruff check app tests/unit/test_batch_match_packing.py tests/unit/test_config.py tests/integration/test_batch_match_service.py

## Context
This intentionally steps back from sub-request packing optimization to reduce hallucination/correlation risk in Gemini batch outputs. Total batch item count remains capped separately, but every provider sub-request now contains only one job.