### PR TITLE
ops: make clone preflight and batch canaries safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,22 @@ Guidance for AI coding agents working in this repo. Keep only non-obvious behavi
 ## Setup
 
 ```bash
-docker compose up -d db
-uv sync --dev
+cp .env.example .env
+make preflight ARGS=--skip-db                  # read-only toolchain/clone check
+docker compose up -d --wait db
+make preflight                                 # includes local DB readiness
+uv sync --locked --dev
 make migrate ARGS="upgrade head"                # wraps alembic; refuses non-local DATABASE_URL without I_KNOW_ITS_PROD=1
 uv run uvicorn app.main:app --reload --port 8000
-cd frontend && npm install && npm run dev   # :5173, proxies /api + /health to :8000
+cd frontend && npm ci && npm run dev         # :5173, proxies /api + /health to :8000
 ```
+
+`make preflight` is the canonical read-only clone doctor; see
+`./scripts/preflight.sh --help`. It does not install dependencies or print env
+values; it only validates required keys and refuses remote or unknown Docker
+endpoints before daemon/Compose operations. `uv` owns Python provisioning, so a
+system `python3` is not a prerequisite. Use the committed `uv.lock` and `frontend/package-lock.json`; do not
+replace locked fresh-clone setup with unlocked installs.
 
 Required env: `DATABASE_URL`, `GOOGLE_API_KEY`. Full list: `app/config.py::Settings`.
 
@@ -50,6 +60,12 @@ Matching runs through the worker queue. `match` jobs score one `Application` dir
 ### Worker queue and cron
 
 No in-process scheduler. Cron endpoints are thin enqueuers protected by `X-Cron-Secret`: `POST /internal/cron/sync`, `POST /internal/cron/generation-reconcile`, and `POST /internal/cron/maintenance`. They are triggered by `supercronic` on the Hetzner box (`panibrat-infra/supercronic.crontab`). Long-running work is processed by the always-on `python -m app.worker` process through Postgres `work_queue`.
+
+The nightly GitHub Actions catalog validation only probes curated ATS catalog entries; it is independent of the production cron path that syncs stale slugs for active profiles.
+
+Deployment boundary diagnosis is in [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
+Runtime deploy, migration, rollback, queue, and scheduler procedures remain
+owned by the infra repository runbooks linked there.
 
 `work_queue` job types are `fetch-slug`, `match`, `batch-match`, `generate-cover-letter`, and `maintenance`. The worker owns claiming, lease timeouts, transient retry/backoff, terminal failure handling, and lease-checked finalization.
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 # Makefile — developer convenience targets for job-application-agent.
 #
-# Prerequisites: uv, Python 3.12+, DATABASE_URL in env or .env
+# Prerequisites: uv, Node ^20.19 or >=22.12, Docker/Compose, required .env keys
 #
 # Quick start:
 #   make smoke-token        # print a 90-day JWT for smoke@panibrat.com
 #   make seed-smoke-user    # seed smoke user into DATABASE_URL
 #   make smoke              # run golden-path smoke test (needs SMOKE_BASE_URL + SMOKE_BEARER_TOKEN)
 
-.PHONY: migrate migrate-status smoke-token seed-smoke-user smoke help
+.PHONY: preflight migrate migrate-status smoke-token seed-smoke-user smoke help
+
+# Read-only clone/toolchain/local-db doctor. Use ARGS=--skip-db before starting db.
+preflight:
+	@./scripts/preflight.sh $(ARGS)
 
 # ---------------------------------------------------------------------------
 # migrate
@@ -71,6 +75,7 @@ smoke:
 # ---------------------------------------------------------------------------
 help:
 	@echo "Available targets:"
+	@echo "  preflight        Read-only clone/toolchain/local-db checks (ARGS=--skip-db available)"
 	@echo "  smoke-token      Print a 90-day JWT for smoke@panibrat.com"
 	@echo "  seed-smoke-user  Seed smoke user into DATABASE_URL (idempotent)"
 	@echo "  smoke            Run golden-path smoke test against SMOKE_BASE_URL"

--- a/README.md
+++ b/README.md
@@ -24,17 +24,29 @@ FastAPI · SQLModel · LangGraph · Google Gemini · React + Vite · Postgres ·
 
 ## Quickstart
 
+Prerequisites are Docker with the Compose plugin, `uv`, and Node `^20.19` or
+`>=22.12`. `uv` provisions the Python version declared by the project; a system
+`python3` is not required. From a fresh clone:
+
 ```bash
-docker compose up -d db
 cp .env.example .env        # set GOOGLE_API_KEY at minimum
-uv sync --dev
+make preflight ARGS=--skip-db
+docker compose up -d --wait db
+make preflight              # read-only; also checks local Postgres connectivity
+uv sync --locked --dev
 make migrate ARGS="upgrade head"
 uv run uvicorn app.main:app --reload --port 8000
 
 # Frontend (separate terminal)
-cd frontend && npm install && npm run dev
+cd frontend && npm ci && npm run dev
 # → http://localhost:5173
 ```
+
+`make preflight` installs nothing, validates required `.env` keys without
+printing their values, and never contacts production. It refuses remote or
+unknown Docker endpoints before daemon or Compose operations. See
+`./scripts/preflight.sh --help` for checks and exit semantics. Keep backend and frontend installs reproducible with `uv sync
+--locked --dev` and `npm ci`; commit lockfile updates when dependencies change.
 
 Sign-in uses Google OAuth — set `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` (see `app/config.py::Settings`).
 
@@ -53,7 +65,7 @@ cd frontend && npm run build            # build to app/static/
 ## Docs
 
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) explains why the app is split across API, worker, queue, LLM, and infra boundaries.
-- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) explains deployment ownership between this repo and `panibrat-infra`.
+- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) contains the canonical `git`/`gh` commands for tracing and troubleshooting releases across this repo and `panibrat-infra`.
 - [`docs/runbooks/`](docs/runbooks/) contains narrow operational procedures.
 - `AGENTS.md` documents non-obvious development guardrails for AI coding agents.
 

--- a/app/services/batch_match_service.py
+++ b/app/services/batch_match_service.py
@@ -82,6 +82,7 @@ async def run_batch_match_tick(
     profile_id: uuid.UUID,
     provider: BatchMatchProvider,
     max_items: int | None = None,
+    max_candidates: int | None = None,
 ) -> BatchMatchTickResult:
     active = await _get_active_batch(session, profile_id)
     if active is not None and active.status in (
@@ -98,6 +99,7 @@ async def run_batch_match_tick(
             profile_id=profile_id,
             provider=provider,
             max_items=max_items,
+            max_candidates=max_candidates,
         )
         return _combine_tick_results(import_result, build_result)
     if active is not None and active.status == BATCH_STATUS_BUILDING:
@@ -113,6 +115,7 @@ async def run_batch_match_tick(
                 profile_id=profile_id,
                 provider=provider,
                 max_items=max_items,
+                max_candidates=max_candidates,
             )
             return _combine_tick_results(fail_result, build_result)
         return BatchMatchTickResult(requeued=True)
@@ -123,6 +126,7 @@ async def run_batch_match_tick(
         profile_id=profile_id,
         provider=provider,
         max_items=max_items,
+        max_candidates=max_candidates,
     )
 
 
@@ -172,6 +176,7 @@ async def _build_and_submit(
     profile_id: uuid.UUID,
     provider: BatchMatchProvider,
     max_items: int | None = None,
+    max_candidates: int | None = None,
 ) -> BatchMatchTickResult:
     settings = get_settings()
     effective_max_items = max_items or settings.batch_match_max_items_per_batch
@@ -183,6 +188,10 @@ async def _build_and_submit(
         effective_max_items,
         effective_max_items * max(1, settings.batch_match_candidate_pool_multiplier),
     )
+    if max_candidates is not None:
+        candidate_pool_limit = min(candidate_pool_limit, max_candidates)
+    if candidate_pool_limit < 1:
+        return BatchMatchTickResult()
     rows = await _select_unscored_application_rows(
         session,
         profile_id=profile_id,

--- a/app/worker/enqueue_intents.py
+++ b/app/worker/enqueue_intents.py
@@ -51,11 +51,15 @@ async def enqueue_batch_match(
     profile_id: UUID | str,
     *,
     max_items: int | None = None,
+    max_candidates: int | None = None,
     not_before_seconds: int = 0,
+    return_existing_on_conflict: bool = True,
 ) -> int | None:
     payload: dict = {"profile_id": str(profile_id)}
     if max_items is not None:
         payload["max_items"] = max_items
+    if max_candidates is not None:
+        payload["max_candidates"] = max_candidates
     not_before = None
     if not_before_seconds > 0:
         not_before = datetime.now(UTC) + timedelta(seconds=not_before_seconds)
@@ -65,6 +69,7 @@ async def enqueue_batch_match(
         payload=payload,
         dedupe_key=batch_match_dedupe_key(profile_id),
         not_before=not_before,
+        return_existing_on_conflict=return_existing_on_conflict,
     )
 
 

--- a/app/worker/handlers/batch_match.py
+++ b/app/worker/handlers/batch_match.py
@@ -1,4 +1,5 @@
 """batch-match handler: advance one profile's LLM batch matching tick."""
+
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,6 +10,7 @@ from app.services.batch_match_provider import get_batch_match_provider
 from app.services.batch_match_service import run_batch_match_tick
 from app.worker.handlers import HANDLERS, EnqueueAfterDone
 from app.worker.payloads import BatchMatchPayload
+from app.worker.queue_service import update_payload
 
 log = structlog.get_logger()
 
@@ -27,12 +29,21 @@ class BatchMatchHandler:
 
     async def __call__(self, session: AsyncSession, row: WorkQueue) -> EnqueueAfterDone | None:
         payload = BatchMatchPayload(**row.payload)
+        # Reserve a bounded workflow's entire remaining candidate budget before
+        # any domain/provider side effect. A process crash can then only make the
+        # canary stop early; replay can never reuse an already-spent budget. On a
+        # successful tick we refund the unselected portion below.
+        if payload.max_candidates:
+            await _checkpoint_budget(session, row, payload, remaining_candidates=0)
+            await session.commit()
+
         provider = get_batch_match_provider()
         result = await run_batch_match_tick(
             session,
             profile_id=payload.profile_id,
             provider=provider,
             max_items=payload.max_items,
+            max_candidates=payload.max_candidates,
         )
         await log.ainfo(
             "worker.batch_match.done",
@@ -45,22 +56,60 @@ class BatchMatchHandler:
             terminal_failed=result.terminal_failed,
             requeued=result.requeued,
         )
+        remaining_candidates = payload.max_candidates
+        if remaining_candidates is not None:
+            remaining_candidates = max(0, remaining_candidates - result.selected)
+            await _checkpoint_budget(
+                session,
+                row,
+                payload,
+                remaining_candidates=remaining_candidates,
+            )
         if result.requeued or result.submitted:
             settings = get_settings()
             return EnqueueAfterDone(
                 job_type=JobType.BATCH_MATCH,
-                payload={
-                    key: value
-                    for key, value in {
-                        "profile_id": str(payload.profile_id),
-                        "max_items": payload.max_items,
-                    }.items()
-                    if value is not None
-                },
+                payload=_payload_dict(payload, max_candidates=remaining_candidates),
                 dedupe_key=batch_match_dedupe_key(payload.profile_id),
                 not_before_seconds=settings.batch_match_poll_interval_seconds,
             )
         return None
+
+
+def _payload_dict(
+    payload: BatchMatchPayload,
+    *,
+    max_candidates: int | None,
+) -> dict[str, str | int]:
+    return {
+        key: value
+        for key, value in {
+            "profile_id": str(payload.profile_id),
+            "max_items": payload.max_items,
+            "max_candidates": max_candidates,
+        }.items()
+        if value is not None
+    }
+
+
+async def _checkpoint_budget(
+    session: AsyncSession,
+    row: WorkQueue,
+    payload: BatchMatchPayload,
+    *,
+    remaining_candidates: int,
+) -> None:
+    if row.id is None or not row.claimed_by:
+        raise RuntimeError("bounded batch-match row must have an owned queue lease")
+    checkpoint = _payload_dict(payload, max_candidates=remaining_candidates)
+    await update_payload(
+        session,
+        row.id,
+        payload=checkpoint,
+        worker_id=row.claimed_by,
+    )
+    # Keep terminal logging/finalization state consistent with the durable row.
+    row.payload = checkpoint
 
 
 HANDLERS[JobType.BATCH_MATCH] = BatchMatchHandler()

--- a/app/worker/payloads.py
+++ b/app/worker/payloads.py
@@ -1,7 +1,7 @@
 """Per-job-type payload Pydantic models. Spec § Job-type taxonomy."""
 import uuid
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class FetchSlugPayload(BaseModel):
@@ -20,7 +20,10 @@ class GenerateCoverLetterPayload(BaseModel):
 
 class BatchMatchPayload(BaseModel):
     profile_id: uuid.UUID
-    max_items: int | None = None
+    max_items: int | None = Field(default=None, gt=0)
+    # Optional lifetime candidate budget. The handler decrements this by every
+    # candidate inspected so a bounded manual workflow cannot fan out forever.
+    max_candidates: int | None = Field(default=None, ge=0)
 
 
 class MaintenancePayload(BaseModel):

--- a/app/worker/queue_service.py
+++ b/app/worker/queue_service.py
@@ -21,9 +21,13 @@ async def enqueue(
     dedupe_key: str | None = None,
     on_conflict: Literal["do_nothing", "upsert_reset_not_before"] = "do_nothing",
     not_before: datetime | None = None,
+    return_existing_on_conflict: bool = True,
 ) -> int | None:
-    """Insert a pending queue row, returning either the new row id or the live
-    row id that blocked a deduped insert.
+    """Insert a pending queue row.
+
+    Return the inserted id. On a live dedupe conflict, return the blocking row id
+    by default; callers that must prove they inserted a new row can set
+    ``return_existing_on_conflict=False`` and receive ``None`` instead.
     """
     params = {
         "job_type": job_type,
@@ -78,7 +82,7 @@ async def enqueue(
     row = result.first()
     if row is not None:
         return row[0]
-    if dedupe_key is None:
+    if dedupe_key is None or not return_existing_on_conflict:
         return None
 
     existing = await session.execute(
@@ -200,6 +204,34 @@ async def mark_done(session: AsyncSession, job_id: int, *, worker_id: str) -> No
     )
     if result.rowcount == 0:
         raise StaleLease(f"mark_done: row {job_id} no longer owned by {worker_id}")
+
+
+async def update_payload(
+    session: AsyncSession,
+    job_id: int,
+    *,
+    payload: dict[str, Any],
+    worker_id: str,
+) -> None:
+    """Checkpoint a leased row's payload without weakening lease ownership."""
+    result = await session.execute(
+        text(
+            """
+            UPDATE work_queue
+            SET payload = CAST(:payload AS jsonb)
+            WHERE id = :id
+              AND claimed_by = :worker_id
+              AND status = 'in_progress'
+            """
+        ),
+        {
+            "id": job_id,
+            "payload": json.dumps(payload, default=str),
+            "worker_id": worker_id,
+        },
+    )
+    if result.rowcount == 0:
+        raise StaleLease(f"update_payload: row {job_id} no longer owned by {worker_id}")
 
 
 async def mark_failed(

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,34 +1,202 @@
-# Deployment Reference
+# Deployment and Release Troubleshooting
 
-Production runtime is owned jointly by this app repo and the `panibrat-infra` repo.
+Production is jointly owned by this application repository and
+[`panibrat-infra`](https://github.com/maksym-panibrat/panibrat-infra). This repo
+owns application code, migrations, CI, and the Docker image. The infra repo owns
+the pinned production image, host Compose services, release migration execution,
+Caddy, scheduler, secrets, observability, deploy health checks, and rollback.
 
-This repo owns application code, tests, migrations, and the Docker image. The infra repo owns the host runtime: compose services, Caddy, cron wiring, release migration execution, rollback, secrets, and observability.
+## Release path
 
-## Why deployment is split this way
+A normal release crosses these boundaries in order:
 
-- The app repo can stay focused on product behavior and schema changes.
-- The infra repo can make host-level changes without mixing them into application PRs.
-- Deploy and rollback procedures stay next to the compose files and secrets model they operate on.
-- Production verification can use the real host, proxy, scheduler, and logging context.
+1. A push to this repo's `main` starts the **CI** workflow (`.github/workflows/ci.yml`).
+2. After backend, frontend, and browser jobs pass, `build-and-push` builds the
+   image, verifies its runtime imports, and pushes both the immutable commit tag
+   and `:main` to `ghcr.io/maksym-panibrat/job-application-agent`.
+3. The same job sends a `repository_dispatch` with event type
+   `bump-app-image`, app `job-search`, and the application commit SHA to
+   `panibrat-infra`.
+4. Infra's **bump** workflow (`.github/workflows/bump.yml`) changes the
+   `x-job-search-image` pin in `compose.yml` and opens a
+   `deploy(job-search): bump to <sha>` PR. An operator reviews and merges it;
+   deployment is deliberately not automatic before that merge.
+5. The merge to infra `main` starts infra's **deploy** workflow
+   (`.github/workflows/deploy.yml`). It invokes the infra-owned deploy script,
+   which pauses scheduled work, ensures Postgres is healthy, runs the release
+   migration, replaces API and worker containers, checks health/routing, and
+   then attempts to resume scheduling. Not every failure is a rollback: an
+   abort before cutover (for example, scheduler-stop or database-readiness
+   failure) exits without changing the app image, while migration, worker, API
+   health, and route-gate failures enter the current image/crontab rollback
+   block. A scheduler restart can also fail after the app has passed acceptance,
+   in which case the app is not rolled back. Always inspect the failed run and
+   verify scheduler state explicitly.
 
-## Normal release shape
+A manual `workflow_dispatch` of app CI is not build-only. For the selected ref,
+`build-and-push` pushes the immutable SHA **and overwrites `:main`**, then sends
+the same infra `bump-app-image` dispatch. That can open an infra bump PR for a
+feature-branch SHA. Diagnose and review it by the workflow run's actual SHA; do
+not assume either the mutable tag or a manual run represents app `main`.
 
-At a high level:
+## Trace one release end to end
 
-1. This repo builds and publishes an application image from `main`.
-2. The infra repo updates the image tag used by production.
-3. The infra deploy runs migrations through the guarded release path, starts the app services, checks health, and restores scheduled work.
+Set the immutable application SHA you expect to deploy:
 
-Exact workflow names, compose service names, host paths, and rollback commands are intentionally not duplicated here. Use `panibrat-infra/docs/runbooks/` and the workflow files in both repos as the current source of truth.
+```bash
+APP_SHA=$(git rev-parse HEAD)
+git show --stat --oneline "$APP_SHA"
+```
 
-## Application guarantees expected by infra
+### 1. App CI and image build
 
-- The API exposes a cheap health check.
-- Long-running work is handled by the worker, not inline web requests.
-- Cron endpoints enqueue work only; they do not perform the full job synchronously.
-- Migrations can run before the new API/worker image starts.
-- Runtime secrets are read from environment variables defined in `app/config.py`.
+```bash
+gh run list --repo maksym-panibrat/job-application-agent \
+  --workflow ci.yml --commit "$APP_SHA" --limit 10 \
+  --json databaseId,headSha,status,conclusion,url
+APP_RUN_ID=... # copy the matching databaseId from the list
+gh run view "$APP_RUN_ID" --repo maksym-panibrat/job-application-agent
+gh run view "$APP_RUN_ID" --repo maksym-panibrat/job-application-agent --log-failed
+```
 
-## Local checks before merge
+The `build-and-push` job cannot run until all required test jobs pass. If tests
+passed but no image exists, inspect its `Login to GHCR`, `Build and push`, and
+runtime-import verification output. To verify the immutable tag from a machine
+already authorized for this private package:
 
-Run the relevant backend and frontend tests for the code touched. Common checks are documented in the README; exact test coverage should come from the changed code and CI, not from a stale checklist here.
+```bash
+docker manifest inspect \
+  "ghcr.io/maksym-panibrat/job-application-agent:$APP_SHA" >/dev/null
+```
+
+Do not diagnose production from the mutable `:main` tag; infra pins the commit
+SHA.
+
+### 2. Dispatch into infra
+
+The dispatch is the final step of app `build-and-push`. If the image exists but
+no infra run appears, inspect that step for token permission, repository, event
+type, and payload failures:
+
+```bash
+gh run view "$APP_RUN_ID" --repo maksym-panibrat/job-application-agent --log
+
+gh run list --repo maksym-panibrat/panibrat-infra \
+  --workflow bump.yml --event repository_dispatch --limit 20 \
+  --json databaseId,createdAt,status,conclusion,url
+BUMP_RUN_ID=...
+gh run view "$BUMP_RUN_ID" --repo maksym-panibrat/panibrat-infra --log-failed
+```
+
+A failed or missing dispatch does not mean the image build failed; these are
+separate boundaries. Never paste dispatch credentials or workflow environment
+values into tickets or logs.
+
+### 3. Infra bump PR
+
+```bash
+gh pr list --repo maksym-panibrat/panibrat-infra --state all \
+  --search "deploy(job-search): bump to $APP_SHA in:title"
+INFRA_PR=...
+gh pr view "$INFRA_PR" --repo maksym-panibrat/panibrat-infra
+gh pr diff "$INFRA_PR" --repo maksym-panibrat/panibrat-infra
+```
+
+A normal bump changes only the job-search image pin. If the image declares a
+required infra bundle, the bump workflow intentionally opens a blocked draft;
+follow the coordinated-deploy section of the infra deploy runbook rather than
+merging it directly. If the PR exists but production has not changed, verify
+that it was reviewed and merged—opening the PR is not a deployment.
+
+### 4. Infra deploy and migration boundary
+
+```bash
+gh run list --repo maksym-panibrat/panibrat-infra \
+  --workflow deploy.yml --branch main --limit 20 \
+  --json databaseId,headSha,createdAt,status,conclusion,url
+DEPLOY_RUN_ID=...
+gh run view "$DEPLOY_RUN_ID" --repo maksym-panibrat/panibrat-infra
+gh run view "$DEPLOY_RUN_ID" --repo maksym-panibrat/panibrat-infra --log-failed
+```
+
+For job-search, the release migration runs after the image is pulled and local
+Postgres is healthy, but **before** the new API and worker are started. A failure
+or timeout in `alembic-upgrade` is therefore a migration/deploy failure, not an
+API-health failure. The current merged infra script routes that failure through
+its previous-image/previous-crontab rollback block; this is different from an
+earlier database-readiness abort, which occurs before cutover and does not invoke
+that block. Inspect migration output, rollback output, and the actual database
+revision rather than assuming either succeeded. Do not run an ad-hoc production
+migration from an application checkout.
+
+If migration succeeds but container startup or route checks fail, inspect the
+same deploy run for API/worker state and rollback output. A rollback attempt is
+not proof of rollback success or schema compatibility. Runtime service names,
+host commands, timeout behavior, and rollback mechanics are intentionally
+maintained in infra, not duplicated here.
+
+### Required checks after any failed deploy
+
+Whether the run says `aborting cutover`, `engaging rollback`, or fails after the
+app becomes healthy, verify all of these from the current infra runbook and host
+evidence before retrying:
+
+- immutable image actually running for both API and worker;
+- Alembic revision/schema compatibility with that image;
+- rollback overlay and previous-crontab state, when the rollback block ran;
+- `supercronic` container state **and** whether the operator/deploy pause flag is
+  present; and
+- fresh scheduler execution evidence after scheduling is expected to resume.
+
+Do not infer scheduler recovery from the deploy workflow conclusion. In the
+current infra script, some pre-cutover exits happen after scheduler handling,
+and scheduler restart failure can happen after app acceptance without triggering
+an image rollback.
+
+## Health is not queue completion
+
+The API's `/health` response proves the web process can answer a cheap request.
+Infra's deploy gate uses the API container's Docker healthcheck and separately
+requires the worker container to be running. Neither condition proves that a
+sync, match, batch import, cover-letter generation, or maintenance job finished.
+
+After an apparently healthy deploy, verify asynchronous behavior separately:
+
+- API availability and queue-depth emission;
+- a current `worker.started` event;
+- queue depth and oldest in-progress age returning to expected levels;
+- `worker.job_done` throughput by job type;
+- no sustained `worker.job_failed` or terminal-hook failures;
+- scheduler completion events when the release affects cron-driven work.
+
+The canonical queries and dataset routing are in
+`panibrat-infra/docs/runbooks/observability.md`; deploy mechanics are in
+`panibrat-infra/docs/runbooks/deploy.md`; recovery is in
+`panibrat-infra/docs/runbooks/rollback.md`; and scheduler checks are in
+`panibrat-infra/docs/runbooks/cron.md`. Use those current infra-owned runbooks
+for host/runtime diagnosis.
+
+## Catalog validation is a separate signal
+
+The scheduled `validate-catalog` workflow in this repo probes curated public ATS
+catalog entries. It does **not** deploy, enqueue production sync, call the
+production cron path, or prove that active profiles were synchronized. Diagnose
+production catalog freshness through scheduler, API, worker, and queue evidence;
+do not treat a green catalog-validation run as production-sync confirmation.
+
+## Before merging application changes
+
+Use the clone doctor and locked installs, then run checks appropriate to the
+change:
+
+```bash
+make preflight
+uv sync --locked --dev
+uv run ruff check app/ tests/
+uv run pytest tests/unit/
+(cd frontend && npm ci && npm test && npm run build)
+```
+
+Production migrations are applied only by the infra release path. For local
+migration work, use `make migrate ARGS="..."`; its guard refuses write commands
+against non-local database hosts unless explicitly overridden.

--- a/docs/runbooks/batch-match-canary.md
+++ b/docs/runbooks/batch-match-canary.md
@@ -19,14 +19,78 @@ Run the unit/integration tests that cover:
 - batch request construction;
 - provider-result import;
 - malformed, duplicate, missing, or unknown provider result keys;
-- worker retry/failure behavior for batch-match jobs.
+- worker retry/failure behavior for batch-match jobs;
+- the canary CLI bounds, payload, idle-profile guard, and candidate budget.
 
 Use current test file names from `tests/`; do not rely on this runbook for an exhaustive test list.
 
 ## Production canary
 
-1. Enable batch matching for a low-volume profile or narrow cohort.
-2. Confirm worker logs show batch jobs being submitted, polled, and imported.
-3. Confirm scored applications move only into expected review/rejection states for that code version.
-4. Check logs for batch-match warnings or failed imports before widening rollout.
-5. Disable or narrow the rollout if correlation errors appear.
+### Safety gate: isolated and disposable only
+
+Use a dedicated synthetic canary account/profile. It must not belong to a real
+user, and nobody may use its UI, trigger a sync/rematch, or otherwise mutate it
+while the canary is running. Disable its normal search/sync activity before the
+run. The required `--ack-isolated-canary-profile` flag is an operator assertion
+that these conditions hold; it is not permission to repurpose a low-volume real
+profile.
+
+Canary rows are disposable. Capture a run-labeled baseline as **evidence only**
+(application IDs and relevant status/score fields, plus the code/image SHA and
+timestamp). Do not clear scores or rewrite user decisions to manufacture a
+cohort. In particular, never mutate `applied` or `dismissed` rows.
+
+There is currently no audited compare-and-swap restoration tool. Therefore:
+
+- do not run ad-hoc restoration SQL;
+- do not replay a baseline over rows that may have changed;
+- if unexpected rows change, stop rollout, preserve the evidence, and quarantine
+  or dispose of the synthetic data through an approved account/data lifecycle;
+- do not use this procedure on data that must be restored.
+
+### Enqueue one bounded run
+
+The script requires an explicit item limit from 1 through the hard maximum of
+10. It sends both `max_items` and a lifetime `max_candidates` budget through the
+normal typed worker payload. Before each tick, the handler atomically reserves
+that row's remaining budget by checkpointing zero under the current queue lease;
+a successful tick refunds only the candidates it did not inspect. A crash or
+finalization replay can therefore stop a canary early but cannot reuse budget
+already exposed to deterministic writes or provider submission. Production jobs
+that do not carry `max_candidates` retain their normal behavior.
+
+```bash
+uv run python scripts/enqueue_batch_match_canary.py \
+  --profile-id <synthetic-profile-uuid> \
+  --max-items 3 \
+  --ack-isolated-canary-profile
+```
+
+`--email <synthetic-account-email>` may be used instead of `--profile-id`.
+Before inserting anything, the script refuses to proceed if that profile has a
+pending/in-progress `batch-match` queue row or an active provider batch. A
+concurrent dedupe conflict is also a refusal: the script uses insert-only
+conflict behavior and never resets or upserts an existing queue row. Investigate
+and wait for the profile to become idle; do not delete or rewrite queue/batch
+rows to force the canary through.
+
+### Evaluate
+
+1. Confirm the command reports the intended profile, `max_items`, and equal
+   `max_candidates`. Save the output under the run label.
+2. Confirm worker logs show submission, polling, and import. Correlate evidence
+   by profile, local batch, provider batch, request key, and application ID.
+3. Report `selected`, `deterministic_rejected`, provider `submitted`, `imported`,
+   `retryable_failed`, and `terminal_failed`. `selected` includes candidates
+   handled by deterministic policy; it must never exceed the acknowledged
+   candidate budget for the run.
+4. Reconcile every provider request key and application ID. Duplicate, unknown,
+   missing, or otherwise uncorrelated results are failures; never accept guessed
+   or partial mappings.
+5. Compare final synthetic application fields with the evidence baseline and the
+   expected threshold outcome. Confirm rows outside the bounded synthetic cohort
+   did not change.
+6. Do not widen rollout while there are correlation errors, terminal failures,
+   unexplained count differences, status disagreement, budget overruns, or
+   unexplained score deltas. Keep real-user activity off the profile until the
+   investigation is closed; do not attempt ad-hoc row restoration.

--- a/scripts/enqueue_batch_match_canary.py
+++ b/scripts/enqueue_batch_match_canary.py
@@ -1,4 +1,4 @@
-"""Enqueue one manual batch-match canary job for a user profile."""
+"""Enqueue one mechanically bounded batch-match canary for an isolated profile."""
 
 from __future__ import annotations
 
@@ -10,22 +10,81 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from sqlmodel import select
+from sqlalchemy import or_
+from sqlmodel import col, select
 
+from app.contracts.workflow import JobType, batch_match_dedupe_key
 from app.database import get_session_factory
+from app.models.llm_match_batch import ACTIVE_BATCH_STATUSES, LLMMatchBatch
 from app.models.user import User
 from app.models.user_profile import UserProfile
-from app.worker.queue_service import enqueue
+from app.models.work_queue import WorkQueue, WorkQueueStatus
+from app.worker.enqueue_intents import enqueue_batch_match
+
+CANARY_MAX_ITEMS = 10
 
 
-async def enqueue_batch_match_canary(session, *, profile_id: uuid.UUID) -> int | None:
-    row_id = await enqueue(
-        session,
-        job_type="batch-match",
-        payload={"profile_id": str(profile_id)},
-        dedupe_key=f"batch-match:{profile_id}",
-        on_conflict="upsert_reset_not_before",
+class CanaryRefused(RuntimeError):
+    """The requested profile is not idle enough for an isolated canary."""
+
+
+async def _assert_no_active_provider_batch(session, *, profile_id: uuid.UUID) -> None:
+    batch_result = await session.execute(
+        select(LLMMatchBatch.id)
+        .where(
+            LLMMatchBatch.profile_id == profile_id,
+            col(LLMMatchBatch.status).in_(ACTIVE_BATCH_STATUSES),
+        )
+        .limit(1)
     )
+    if batch_result.scalar_one_or_none() is not None:
+        raise CanaryRefused("profile already has an active provider batch")
+
+
+async def _assert_profile_idle(session, *, profile_id: uuid.UUID) -> None:
+    queue_result = await session.execute(
+        select(WorkQueue.id)
+        .where(
+            WorkQueue.job_type == JobType.BATCH_MATCH,
+            col(WorkQueue.status).in_(
+                (WorkQueueStatus.PENDING, WorkQueueStatus.IN_PROGRESS)
+            ),
+            or_(
+                col(WorkQueue.dedupe_key) == batch_match_dedupe_key(profile_id),
+                col(WorkQueue.payload)["profile_id"].as_string() == str(profile_id),
+            ),
+        )
+        .limit(1)
+    )
+    if queue_result.scalar_one_or_none() is not None:
+        raise CanaryRefused("profile already has pending/in-progress batch-match queue work")
+
+    await _assert_no_active_provider_batch(session, profile_id=profile_id)
+
+
+async def enqueue_batch_match_canary(
+    session,
+    *,
+    profile_id: uuid.UUID,
+    max_items: int,
+) -> int:
+    await _assert_profile_idle(session, profile_id=profile_id)
+    row_id = await enqueue_batch_match(
+        session,
+        profile_id,
+        max_items=max_items,
+        max_candidates=max_items,
+        return_existing_on_conflict=False,
+    )
+    if row_id is None:
+        raise CanaryRefused("concurrent batch-match queue work appeared; nothing was changed")
+    try:
+        # Close the race where an older queue row finishes and creates a provider
+        # batch between the initial idle check and our insert.
+        await _assert_no_active_provider_batch(session, profile_id=profile_id)
+    except CanaryRefused:
+        await session.rollback()
+        raise
     await session.commit()
     return row_id
 
@@ -43,7 +102,7 @@ async def lookup_profile_id_by_email(session, *, email: str) -> uuid.UUID:
     return profile_id
 
 
-async def main(*, profile_id_arg: str | None, email: str | None) -> None:
+async def main(*, profile_id_arg: str | None, email: str | None, max_items: int) -> None:
     factory = get_session_factory()
     async with factory() as session:
         profile_id = (
@@ -51,8 +110,30 @@ async def main(*, profile_id_arg: str | None, email: str | None) -> None:
             if profile_id_arg is not None
             else await lookup_profile_id_by_email(session, email=email or "")
         )
-        row_id = await enqueue_batch_match_canary(session, profile_id=profile_id)
-    print(f"enqueued batch-match row_id={row_id} profile_id={profile_id}")
+        if await session.get(UserProfile, profile_id) is None:
+            raise SystemExit(f"No profile found for profile ID {profile_id}")
+        try:
+            row_id = await enqueue_batch_match_canary(
+                session,
+                profile_id=profile_id,
+                max_items=max_items,
+            )
+        except CanaryRefused as exc:
+            raise SystemExit(f"Canary refused: {exc}") from exc
+    print(
+        f"enqueued bounded batch-match row_id={row_id} profile_id={profile_id} "
+        f"max_items={max_items} max_candidates={max_items}"
+    )
+
+
+def _canary_item_count(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if not 1 <= value <= CANARY_MAX_ITEMS:
+        raise argparse.ArgumentTypeError(f"must be between 1 and {CANARY_MAX_ITEMS}")
+    return value
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -60,9 +141,27 @@ def _parser() -> argparse.ArgumentParser:
     target = parser.add_mutually_exclusive_group(required=True)
     target.add_argument("--profile-id", dest="profile_id_arg", help="User profile UUID")
     target.add_argument("--email", help="Account email to resolve to user_profiles.id")
+    parser.add_argument(
+        "--max-items",
+        type=_canary_item_count,
+        required=True,
+        help=f"maximum applications inspected and submitted (required; 1-{CANARY_MAX_ITEMS})",
+    )
+    parser.add_argument(
+        "--ack-isolated-canary-profile",
+        action="store_true",
+        required=True,
+        help="confirm this is a disposable synthetic profile with no concurrent real-user activity",
+    )
     return parser
 
 
 if __name__ == "__main__":
     args = _parser().parse_args()
-    asyncio.run(main(profile_id_arg=args.profile_id_arg, email=args.email))
+    asyncio.run(
+        main(
+            profile_id_arg=args.profile_id_arg,
+            email=args.email,
+            max_items=args.max_items,
+        )
+    )

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Read-only fresh-clone checks. This script never installs dependencies or contacts production.
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/preflight.sh [--skip-db]
+
+Check the local toolchain, lockfiles, required .env keys, Docker Compose, and
+(unless skipped) the repository's local Postgres container and connectivity.
+No dependencies are installed, no environment values are printed, and no
+production endpoint is contacted. Remote Docker endpoints are refused before
+daemon or Compose operations. uv owns Python interpreter provisioning.
+
+Options:
+  --skip-db  Check Docker/Compose but not local db container state/connectivity.
+             Useful before: docker compose up -d --wait db
+  -h, --help Show this help.
+
+Exit status:
+  0  every requested check passed
+  1  one or more checks failed
+  2  invalid command-line usage
+EOF
+}
+
+skip_db=0
+case "${1:-}" in
+  "") ;;
+  --skip-db) skip_db=1 ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage >&2; exit 2 ;;
+esac
+if (( $# > 1 )); then
+  usage >&2
+  exit 2
+fi
+
+repo_root=${PREFLIGHT_ROOT:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"}
+cd "$repo_root" || {
+  printf 'FAIL repository root is not accessible\n' >&2
+  exit 1
+}
+
+failures=0
+pass() { printf 'PASS %s\n' "$1"; }
+fail() {
+  printf 'FAIL %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+has_command() {
+  if command -v "$1" >/dev/null 2>&1; then
+    return 0
+  fi
+  fail "$1 is not installed or not on PATH"
+  return 1
+}
+node_version_supported() {
+  local actual=$1 major minor
+  IFS=. read -r major minor _ <<<"$actual"
+  [[ $major =~ ^[0-9]+$ && $minor =~ ^[0-9]+$ ]] || return 1
+  (( (major == 20 && minor >= 19) || (major == 22 && minor >= 12) || major > 22 ))
+}
+env_value() {
+  local key=$1 line value
+  while IFS= read -r line || [[ -n $line ]]; do
+    if [[ $line =~ ^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=(.*)$ ]]; then
+      value=${BASH_REMATCH[2]}
+      value="${value#"${value%%[![:space:]]*}"}"
+      value="${value%"${value##*[![:space:]]}"}"
+      if [[ $value == \"*\" && $value == *\" ]]; then
+        value=${value:1:${#value}-2}
+      elif [[ $value == \'*\' && $value == *\' ]]; then
+        value=${value:1:${#value}-2}
+      fi
+      printf '%s' "$value"
+      return 0
+    fi
+  done < .env
+  return 1
+}
+is_placeholder() {
+  local value=${1,,}
+  [[ -z $value ||
+     $value == your-* ||
+     $value == *changeme* ||
+     $value == *change-me* ||
+     $value == *replace-me* ||
+     $value == *replace_this* ||
+     $value == \<*\> ||
+     $value == "..." ]]
+}
+docker_endpoint_is_local() {
+  case "$1" in
+    unix://*|npipe://*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+docker_endpoint() {
+  local context
+  # Docker gives DOCKER_CONTEXT precedence over DOCKER_HOST when both are set.
+  if [[ -n ${DOCKER_CONTEXT:-} ]]; then
+    docker context inspect --format '{{.Endpoints.docker.Host}}' "$DOCKER_CONTEXT" 2>/dev/null
+    return
+  fi
+  if [[ -n ${DOCKER_HOST:-} ]]; then
+    printf '%s' "$DOCKER_HOST"
+    return 0
+  fi
+  context=$(docker context show 2>/dev/null)
+  [[ -n $context ]] || return 1
+  docker context inspect --format '{{.Endpoints.docker.Host}}' "$context" 2>/dev/null
+}
+
+printf 'Local clone preflight (read-only)\n'
+
+docker_ok=0
+compose_ok=0
+if has_command docker; then
+  if ! docker --version >/dev/null 2>&1; then
+    fail "Docker exists but could not report its version"
+  else
+    endpoint=$(docker_endpoint || true)
+    if ! docker_endpoint_is_local "$endpoint"; then
+      fail "refusing non-local or unknown Docker endpoint (expected unix:// or npipe://)"
+    elif docker info >/dev/null 2>&1; then
+      pass "Docker CLI can reach a verified local daemon"
+      docker_ok=1
+    else
+      fail "Docker is installed but the verified local daemon is unavailable"
+    fi
+  fi
+  if (( docker_ok )); then
+    if docker compose version >/dev/null 2>&1; then
+      pass "Docker Compose plugin is available"
+      compose_ok=1
+    else
+      fail "Docker Compose plugin is unavailable (expected: docker compose)"
+    fi
+  fi
+fi
+
+if has_command uv; then
+  if uv --version >/dev/null 2>&1; then
+    pass "uv is available (it will provision the locked Python interpreter)"
+  else
+    fail "uv exists but could not report its version"
+  fi
+fi
+
+if has_command node; then
+  node_version=$(node -p 'process.versions.node' 2>/dev/null || true)
+  if node_version_supported "$node_version"; then
+    pass "Node $node_version satisfies the frontend toolchain"
+  else
+    fail "Node ^20.19 or >=22.12 is required (found ${node_version:-unknown})"
+  fi
+fi
+
+if has_command npm; then
+  if npm --version >/dev/null 2>&1; then
+    pass "npm is available"
+  else
+    fail "npm exists but could not report its version"
+  fi
+fi
+
+if [[ -f .env ]]; then
+  for required_key in DATABASE_URL GOOGLE_API_KEY; do
+    required_value=$(env_value "$required_key" || true)
+    if is_placeholder "$required_value"; then
+      fail ".env key $required_key is missing, empty, or still a placeholder"
+    else
+      pass ".env key $required_key is configured (value not printed)"
+    fi
+  done
+else
+  fail ".env is missing; create it with: cp .env.example .env"
+fi
+
+if [[ -f uv.lock ]]; then
+  pass "uv.lock exists"
+else
+  fail "uv.lock is missing; locked backend setup cannot be reproduced"
+fi
+if [[ -f frontend/package-lock.json ]]; then
+  pass "frontend/package-lock.json exists"
+else
+  fail "frontend/package-lock.json is missing; npm ci cannot be used"
+fi
+
+if (( skip_db )); then
+  printf 'SKIP local db state/connectivity (--skip-db)\n'
+elif (( docker_ok && compose_ok )); then
+  running_services=$(docker compose ps --status running --services db 2>/dev/null || true)
+  if [[ $running_services == *"db"* ]]; then
+    pass "local Compose db service is running"
+    retry_attempts=${PREFLIGHT_DB_RETRY_ATTEMPTS:-10}
+    retry_delay=${PREFLIGHT_DB_RETRY_DELAY:-1}
+    db_ready=0
+    if ! [[ $retry_attempts =~ ^[1-9][0-9]*$ ]]; then
+      retry_attempts=10
+    fi
+    for (( attempt=1; attempt<=retry_attempts; attempt++ )); do
+      if docker compose exec -T db pg_isready -U jobagent -d jobagent >/dev/null 2>&1; then
+        db_ready=1
+        break
+      fi
+      if (( attempt < retry_attempts )); then
+        sleep "$retry_delay"
+      fi
+    done
+    if (( db_ready )); then
+      pass "local Postgres accepts connections"
+    else
+      fail "local db stayed unready after $retry_attempts bounded pg_isready attempts"
+    fi
+  else
+    fail "local Compose db is not running; start it with: docker compose up -d --wait db"
+  fi
+else
+  fail "local db checks require a reachable Docker daemon and Compose plugin"
+fi
+
+printf '\nLocked dependency setup (guidance only; not run):\n'
+printf '  uv sync --locked --dev\n'
+printf '  (cd frontend && npm ci)\n'
+
+if (( failures > 0 )); then
+  printf '\nPreflight failed: %d check(s) need attention.\n' "$failures" >&2
+  exit 1
+fi
+printf '\nPreflight passed.\n'

--- a/tests/integration/test_batch_match_service.py
+++ b/tests/integration/test_batch_match_service.py
@@ -264,6 +264,57 @@ async def test_deterministic_reject_is_not_submitted(db_session):
 
 
 @pytest.mark.asyncio
+async def test_candidate_cap_bounds_deterministic_prefilter_writes(db_session):
+    from app.services.batch_match_provider import FakeBatchMatchProvider
+    from app.services.batch_match_service import run_batch_match_tick
+
+    profile, apps = await seed_profile_with_unscored_apps(db_session, count=5)
+    for app in apps:
+        job = await db_session.get(Job, app.job_id)
+        assert job is not None
+        job.location = "Toronto, Canada"
+        job.workplace_type = "remote"
+        job.description = "Remote role open only to candidates based in Canada."
+        db_session.add(job)
+    await db_session.commit()
+
+    result = await run_batch_match_tick(
+        db_session,
+        profile_id=profile.id,
+        provider=FakeBatchMatchProvider(ready=False),
+        max_items=3,
+        max_candidates=2,
+    )
+
+    assert result.selected == 2
+    assert result.deterministic_rejected == 2
+    assert result.submitted == 0
+    refreshed = [await db_session.get(Application, app.id) for app in apps]
+    assert sum(app is not None and app.match_score is not None for app in refreshed) == 2
+
+
+@pytest.mark.asyncio
+async def test_zero_remaining_candidate_budget_does_not_select_or_write(db_session):
+    from app.services.batch_match_provider import FakeBatchMatchProvider
+    from app.services.batch_match_service import run_batch_match_tick
+
+    profile, apps = await seed_profile_with_unscored_apps(db_session, count=3)
+
+    result = await run_batch_match_tick(
+        db_session,
+        profile_id=profile.id,
+        provider=FakeBatchMatchProvider(ready=False),
+        max_items=3,
+        max_candidates=0,
+    )
+
+    assert result.selected == 0
+    assert result.submitted == 0
+    refreshed = [await db_session.get(Application, app.id) for app in apps]
+    assert all(app is not None and app.match_score is None for app in refreshed)
+
+
+@pytest.mark.asyncio
 async def test_poll_requeues_when_provider_is_not_ready(db_session):
     from app.services.batch_match_provider import FakeBatchMatchProvider
     from app.services.batch_match_service import run_batch_match_tick

--- a/tests/integration/test_enqueue_batch_match_canary.py
+++ b/tests/integration/test_enqueue_batch_match_canary.py
@@ -1,0 +1,90 @@
+import uuid
+
+import pytest
+from sqlmodel import select
+
+from app.contracts.workflow import JobType, batch_match_dedupe_key
+from app.models.llm_match_batch import BATCH_STATUS_SUBMITTED, LLMMatchBatch
+from app.models.user import User
+from app.models.user_profile import UserProfile
+from app.models.work_queue import WorkQueue, WorkQueueStatus
+from scripts.enqueue_batch_match_canary import CanaryRefused, enqueue_batch_match_canary
+
+
+async def _profile(db_session) -> UserProfile:
+    user = User(email=f"canary-{uuid.uuid4()}@example.test")
+    db_session.add(user)
+    await db_session.flush()
+    profile = UserProfile(user_id=user.id, full_name="Synthetic Canary")
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+    return profile
+
+
+@pytest.mark.asyncio
+async def test_canary_writes_exact_bounded_payload(db_session):
+    profile = await _profile(db_session)
+
+    row_id = await enqueue_batch_match_canary(
+        db_session,
+        profile_id=profile.id,
+        max_items=4,
+    )
+
+    row = (await db_session.execute(select(WorkQueue).where(WorkQueue.id == row_id))).scalar_one()
+    assert row.job_type == JobType.BATCH_MATCH
+    assert row.dedupe_key == batch_match_dedupe_key(profile.id)
+    assert row.payload == {
+        "profile_id": str(profile.id),
+        "max_items": 4,
+        "max_candidates": 4,
+    }
+
+
+@pytest.mark.asyncio
+async def test_canary_refuses_live_queue_row_without_reset(db_session):
+    profile = await _profile(db_session)
+    existing = WorkQueue(
+        job_type=JobType.BATCH_MATCH,
+        payload={"profile_id": str(profile.id), "max_items": 2},
+        status=WorkQueueStatus.PENDING,
+        dedupe_key=batch_match_dedupe_key(profile.id),
+    )
+    db_session.add(existing)
+    await db_session.commit()
+
+    with pytest.raises(CanaryRefused, match="pending/in-progress"):
+        await enqueue_batch_match_canary(
+            db_session,
+            profile_id=profile.id,
+            max_items=4,
+        )
+
+    await db_session.refresh(existing)
+    assert existing.payload == {"profile_id": str(profile.id), "max_items": 2}
+    assert existing.status == WorkQueueStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_canary_refuses_active_provider_batch(db_session):
+    profile = await _profile(db_session)
+    batch = LLMMatchBatch(
+        profile_id=profile.id,
+        provider="fake",
+        model="fake-model",
+        prompt_version="canary-test",
+        status=BATCH_STATUS_SUBMITTED,
+    )
+    db_session.add(batch)
+    await db_session.commit()
+
+    with pytest.raises(CanaryRefused, match="active provider batch"):
+        await enqueue_batch_match_canary(
+            db_session,
+            profile_id=profile.id,
+            max_items=4,
+        )
+
+    rows = (await db_session.execute(select(WorkQueue))).scalars().all()
+    assert rows == []

--- a/tests/integration/test_enqueue_intents.py
+++ b/tests/integration/test_enqueue_intents.py
@@ -20,7 +20,7 @@ async def test_enqueue_intents_write_canonical_job_types_payloads_and_keys(db_se
 
     await enqueue_fetch_slug(db_session, provider="greenhouse", slug="openai")
     await enqueue_match(db_session, aid)
-    await enqueue_batch_match(db_session, pid, max_items=7)
+    await enqueue_batch_match(db_session, pid, max_items=7, max_candidates=5)
     await enqueue_cover_letter(db_session, aid)
     await db_session.commit()
 
@@ -39,6 +39,7 @@ async def test_enqueue_intents_write_canonical_job_types_payloads_and_keys(db_se
     assert by_type[JobType.BATCH_MATCH].payload == {
         "profile_id": str(pid),
         "max_items": 7,
+        "max_candidates": 5,
     }
     assert by_type[JobType.BATCH_MATCH].dedupe_key == f"batch-match:{pid}"
 

--- a/tests/integration/test_handler_batch_match.py
+++ b/tests/integration/test_handler_batch_match.py
@@ -7,7 +7,12 @@ from app.models.work_queue import WorkQueue, WorkQueueStatus
 from app.worker.handlers import HANDLERS
 
 
-def _batch_match_row(profile_id: uuid.UUID, *, max_items: int | None = None) -> WorkQueue:
+def _batch_match_row(
+    profile_id: uuid.UUID,
+    *,
+    max_items: int | None = None,
+    max_candidates: int | None = None,
+) -> WorkQueue:
     return WorkQueue(
         id=1,
         job_type="batch-match",
@@ -16,6 +21,7 @@ def _batch_match_row(profile_id: uuid.UUID, *, max_items: int | None = None) -> 
             for key, value in {
                 "profile_id": str(profile_id),
                 "max_items": max_items,
+                "max_candidates": max_candidates,
             }.items()
             if value is not None
         },
@@ -49,19 +55,27 @@ async def test_batch_match_handler_calls_service_with_parsed_profile_id(db_sessi
         requeued=True,
     )
 
-    with patch(
-        "app.worker.handlers.batch_match.run_batch_match_tick",
-        AsyncMock(return_value=result),
-    ) as mock_tick, patch(
-        "app.worker.handlers.batch_match.get_batch_match_provider",
-        return_value=provider,
-    ) as mock_provider_factory, patch(
-        "app.worker.handlers.batch_match.log.ainfo",
-        AsyncMock(),
-    ) as mock_log:
+    with (
+        patch(
+            "app.worker.handlers.batch_match.run_batch_match_tick",
+            AsyncMock(return_value=result),
+        ) as mock_tick,
+        patch(
+            "app.worker.handlers.batch_match.get_batch_match_provider",
+            return_value=provider,
+        ) as mock_provider_factory,
+        patch(
+            "app.worker.handlers.batch_match.update_payload",
+            AsyncMock(),
+        ) as mock_update_payload,
+        patch(
+            "app.worker.handlers.batch_match.log.ainfo",
+            AsyncMock(),
+        ) as mock_log,
+    ):
         follow_up = await BatchMatchHandler()(
             db_session,
-            _batch_match_row(profile_id, max_items=50),
+            _batch_match_row(profile_id, max_items=50, max_candidates=10),
         )
 
     mock_provider_factory.assert_called_once_with()
@@ -70,11 +84,21 @@ async def test_batch_match_handler_calls_service_with_parsed_profile_id(db_sessi
     assert kwargs["profile_id"] == profile_id
     assert kwargs["provider"] is provider
     assert kwargs["max_items"] == 50
+    assert kwargs["max_candidates"] == 10
     assert follow_up is not None
     assert follow_up.job_type == "batch-match"
-    assert follow_up.payload == {"profile_id": str(profile_id), "max_items": 50}
+    assert follow_up.payload == {
+        "profile_id": str(profile_id),
+        "max_items": 50,
+        "max_candidates": 9,
+    }
     assert follow_up.dedupe_key == f"batch-match:{profile_id}"
     assert follow_up.not_before_seconds is not None
+    assert mock_update_payload.await_count == 2
+    checkpointed_budgets = [
+        call.kwargs["payload"]["max_candidates"] for call in mock_update_payload.await_args_list
+    ]
+    assert checkpointed_budgets == [0, 9]
     mock_log.assert_awaited_once_with(
         "worker.batch_match.done",
         profile_id=str(profile_id),
@@ -86,6 +110,53 @@ async def test_batch_match_handler_calls_service_with_parsed_profile_id(db_sessi
         terminal_failed=6,
         requeued=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_bounded_batch_match_reserves_budget_before_tick_side_effects(db_session):
+    from sqlmodel import select
+
+    from app.services.batch_match_provider import FakeBatchMatchProvider
+    from app.worker.handlers.batch_match import BatchMatchHandler
+    from app.worker.queue_service import claim_one, enqueue
+
+    profile_id = uuid.uuid4()
+    row_id = await enqueue(
+        db_session,
+        job_type="batch-match",
+        payload={
+            "profile_id": str(profile_id),
+            "max_items": 7,
+            "max_candidates": 7,
+        },
+        dedupe_key=f"batch-match:{profile_id}",
+    )
+    await db_session.commit()
+    claimed = await claim_one(db_session, worker_id="w1", visibility_timeout_s=600)
+    await db_session.commit()
+    assert claimed is not None
+
+    with (
+        patch(
+            "app.worker.handlers.batch_match.get_batch_match_provider",
+            return_value=FakeBatchMatchProvider(),
+        ),
+        patch(
+            "app.worker.handlers.batch_match.run_batch_match_tick",
+            AsyncMock(side_effect=RuntimeError("process stopped after reservation")),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="after reservation"):
+            await BatchMatchHandler()(db_session, claimed)
+
+    durable_row = (
+        await db_session.execute(select(WorkQueue).where(WorkQueue.id == row_id))
+    ).scalar_one()
+    assert durable_row.payload == {
+        "profile_id": str(profile_id),
+        "max_items": 7,
+        "max_candidates": 0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_queue_service.py
+++ b/tests/integration/test_queue_service.py
@@ -10,6 +10,7 @@ from app.worker.queue_service import (
     mark_done,
     mark_failed,
     release_with_backoff,
+    update_payload,
 )
 
 
@@ -54,6 +55,31 @@ async def test_enqueue_duplicate_dedupe_do_nothing_returns_existing_id(db_sessio
         )
     ).scalar_one()
     assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_can_refuse_to_return_existing_conflict(db_session):
+    first = await enqueue(
+        db_session,
+        job_type="batch-match",
+        payload={"profile_id": "profile", "max_items": 1},
+        dedupe_key="batch-match:profile",
+    )
+    second = await enqueue(
+        db_session,
+        job_type="batch-match",
+        payload={"profile_id": "profile", "max_items": 9},
+        dedupe_key="batch-match:profile",
+        return_existing_on_conflict=False,
+    )
+    await db_session.commit()
+
+    assert first is not None
+    assert second is None
+    row = (
+        await db_session.execute(select(WorkQueue).where(WorkQueue.id == first))
+    ).scalar_one()
+    assert row.payload == {"profile_id": "profile", "max_items": 1}
 
 
 @pytest.mark.asyncio
@@ -269,6 +295,38 @@ async def test_mark_done_requires_lease_owner(db_session):
     assert row.status == WorkQueueStatus.DONE
     assert row.completed_at is not None
     assert row.claimed_by is None
+
+
+@pytest.mark.asyncio
+async def test_update_payload_checkpoints_only_for_lease_owner(db_session):
+    row_id = await enqueue(db_session, job_type="batch-match", payload={"remaining": 10})
+    await db_session.commit()
+    claimed = await claim_one(db_session, worker_id="w1", visibility_timeout_s=600)
+    await db_session.commit()
+    assert claimed is not None
+    assert claimed.id is not None
+
+    with pytest.raises(StaleLease):
+        await update_payload(
+            db_session,
+            claimed.id,
+            payload={"remaining": 9},
+            worker_id="w2",
+        )
+    await db_session.rollback()
+
+    await update_payload(
+        db_session,
+        claimed.id,
+        payload={"remaining": 8},
+        worker_id="w1",
+    )
+    await db_session.commit()
+
+    row = (
+        await db_session.execute(select(WorkQueue).where(WorkQueue.id == row_id))
+    ).scalar_one()
+    assert row.payload == {"remaining": 8}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_enqueue_batch_match_canary.py
+++ b/tests/unit/test_enqueue_batch_match_canary.py
@@ -4,39 +4,221 @@ import pytest
 
 
 class _FakeSession:
-    def __init__(self) -> None:
+    def __init__(self, *query_results) -> None:
+        self._query_results = iter(query_results)
         self.committed = False
+        self.rolled_back = False
+
+    async def execute(self, statement):
+        del statement
+        return _FakeResult(next(self._query_results))
 
     async def commit(self) -> None:
         self.committed = True
 
+    async def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class _FakeResult:
+    def __init__(self, value) -> None:
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+
+@pytest.mark.parametrize("max_items", [1, 10])
+def test_parser_accepts_canary_bounds(max_items):
+    from scripts.enqueue_batch_match_canary import _parser
+
+    args = _parser().parse_args(
+        [
+            "--profile-id",
+            str(uuid.uuid4()),
+            "--max-items",
+            str(max_items),
+            "--ack-isolated-canary-profile",
+        ]
+    )
+
+    assert args.max_items == max_items
+    assert args.ack_isolated_canary_profile is True
+
+
+@pytest.mark.parametrize("max_items", ["0", "11", "not-a-number"])
+def test_parser_rejects_out_of_bounds_max_items(max_items):
+    from scripts.enqueue_batch_match_canary import _parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        _parser().parse_args(
+            [
+                "--profile-id",
+                str(uuid.uuid4()),
+                "--max-items",
+                max_items,
+                "--ack-isolated-canary-profile",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [[], ["--max-items", "1"]],
+)
+def test_parser_requires_limit_and_isolation_acknowledgment(extra_args):
+    from scripts.enqueue_batch_match_canary import _parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        _parser().parse_args(["--profile-id", str(uuid.uuid4()), *extra_args])
+
+    assert exc_info.value.code == 2
+
 
 @pytest.mark.asyncio
-async def test_enqueue_batch_match_canary_uses_batch_payload_and_dedupe(monkeypatch):
+async def test_enqueue_batch_match_canary_uses_exact_bounded_typed_payload(monkeypatch):
     from scripts import enqueue_batch_match_canary as script
 
     calls = []
 
-    async def fake_enqueue(session, **kwargs):
-        calls.append((session, kwargs))
+    async def fake_assert_idle(session, *, profile_id):
+        calls.append(("idle", session, profile_id))
+
+    async def fake_enqueue(session, profile_id, **kwargs):
+        calls.append(("enqueue", session, profile_id, kwargs))
         return 123
 
-    monkeypatch.setattr(script, "enqueue", fake_enqueue)
+    async def fake_assert_no_active_batch(session, *, profile_id):
+        calls.append(("active", session, profile_id))
+
+    monkeypatch.setattr(script, "_assert_profile_idle", fake_assert_idle)
+    monkeypatch.setattr(script, "_assert_no_active_provider_batch", fake_assert_no_active_batch)
+    monkeypatch.setattr(script, "enqueue_batch_match", fake_enqueue)
     session = _FakeSession()
     profile_id = uuid.uuid4()
 
-    row_id = await script.enqueue_batch_match_canary(session, profile_id=profile_id)
+    row_id = await script.enqueue_batch_match_canary(
+        session,
+        profile_id=profile_id,
+        max_items=7,
+    )
 
     assert row_id == 123
     assert session.committed is True
     assert calls == [
+        ("idle", session, profile_id),
         (
+            "enqueue",
             session,
+            profile_id,
             {
-                "job_type": "batch-match",
-                "payload": {"profile_id": str(profile_id)},
-                "dedupe_key": f"batch-match:{profile_id}",
-                "on_conflict": "upsert_reset_not_before",
+                "max_items": 7,
+                "max_candidates": 7,
+                "return_existing_on_conflict": False,
             },
-        )
+        ),
+        ("active", session, profile_id),
     ]
+
+
+@pytest.mark.asyncio
+async def test_canary_refuses_pending_or_in_progress_queue_work(monkeypatch):
+    from scripts import enqueue_batch_match_canary as script
+
+    enqueue_called = False
+
+    async def fake_enqueue(*args, **kwargs):
+        nonlocal enqueue_called
+        enqueue_called = True
+
+    monkeypatch.setattr(script, "enqueue_batch_match", fake_enqueue)
+    session = _FakeSession(42)
+
+    with pytest.raises(script.CanaryRefused, match="pending/in-progress"):
+        await script.enqueue_batch_match_canary(
+            session,
+            profile_id=uuid.uuid4(),
+            max_items=1,
+        )
+
+    assert enqueue_called is False
+    assert session.committed is False
+
+
+@pytest.mark.asyncio
+async def test_canary_refuses_active_provider_batch(monkeypatch):
+    from scripts import enqueue_batch_match_canary as script
+
+    enqueue_called = False
+
+    async def fake_enqueue(*args, **kwargs):
+        nonlocal enqueue_called
+        enqueue_called = True
+
+    monkeypatch.setattr(script, "enqueue_batch_match", fake_enqueue)
+    session = _FakeSession(None, uuid.uuid4())
+
+    with pytest.raises(script.CanaryRefused, match="active provider batch"):
+        await script.enqueue_batch_match_canary(
+            session,
+            profile_id=uuid.uuid4(),
+            max_items=1,
+        )
+
+    assert enqueue_called is False
+    assert session.committed is False
+
+
+@pytest.mark.asyncio
+async def test_canary_refuses_enqueue_conflict_without_resetting_existing_row(monkeypatch):
+    from scripts import enqueue_batch_match_canary as script
+
+    async def fake_assert_idle(session, *, profile_id):
+        pass
+
+    async def fake_enqueue(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(script, "_assert_profile_idle", fake_assert_idle)
+    monkeypatch.setattr(script, "enqueue_batch_match", fake_enqueue)
+    session = _FakeSession()
+
+    with pytest.raises(script.CanaryRefused, match="concurrent"):
+        await script.enqueue_batch_match_canary(
+            session,
+            profile_id=uuid.uuid4(),
+            max_items=1,
+        )
+
+    assert session.committed is False
+
+
+@pytest.mark.asyncio
+async def test_canary_rolls_back_if_provider_batch_appears_after_insert(monkeypatch):
+    from scripts import enqueue_batch_match_canary as script
+
+    async def fake_assert_idle(session, *, profile_id):
+        pass
+
+    async def fake_enqueue(*args, **kwargs):
+        return 123
+
+    async def fake_assert_no_active_batch(session, *, profile_id):
+        raise script.CanaryRefused("profile already has an active provider batch")
+
+    monkeypatch.setattr(script, "_assert_profile_idle", fake_assert_idle)
+    monkeypatch.setattr(script, "enqueue_batch_match", fake_enqueue)
+    monkeypatch.setattr(script, "_assert_no_active_provider_batch", fake_assert_no_active_batch)
+    session = _FakeSession()
+
+    with pytest.raises(script.CanaryRefused, match="active provider batch"):
+        await script.enqueue_batch_match_canary(
+            session,
+            profile_id=uuid.uuid4(),
+            max_items=1,
+        )
+
+    assert session.rolled_back is True
+    assert session.committed is False

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "preflight.sh"
+
+
+def _executable(path: Path, body: str) -> None:
+    path.write_text(f"#!/bin/sh\n{body}\n")
+    path.chmod(0o755)
+
+
+@pytest.fixture
+def clone_environment(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    root = tmp_path / "clone"
+    root.mkdir()
+    (root / "frontend").mkdir()
+    (root / ".env").write_text(
+        "DATABASE_URL=postgresql+asyncpg://jobagent:jobagent@localhost/jobagent\n"
+        "GOOGLE_API_KEY=value-that-must-not-be-printed\n"
+        "LANGSMITH_API_KEY=\n"
+    )
+    (root / "uv.lock").write_text('requires-python = ">=3.12"\n')
+    (root / "frontend" / "package-lock.json").write_text("{}\n")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _executable(
+        bin_dir / "docker",
+        """case "$*" in
+  "--version") echo "Docker version 27.0.0" ;;
+  "context show") echo "default" ;;
+  "context inspect --format {{.Endpoints.docker.Host}} default")
+    echo "unix:///var/run/docker.sock"
+    ;;
+  "info") exit 0 ;;
+  "compose version") echo "Docker Compose version v2.30.0" ;;
+  "compose ps --status running --services db") echo "db" ;;
+  "compose exec -T db pg_isready -U jobagent -d jobagent") exit 0 ;;
+  *) echo "unexpected docker arguments: $*" >&2; exit 9 ;;
+esac""",
+    )
+    _executable(bin_dir / "uv", 'test "$1" = "--version" && echo "uv 0.9.0"')
+    # A broken system Python must be irrelevant: uv provisions the project interpreter.
+    _executable(bin_dir / "python3", "exit 99")
+    _executable(bin_dir / "node", 'test "$1" = "-p" && echo "22.12.0"')
+    _executable(bin_dir / "npm", 'test "$1" = "--version" && echo "10.9.0"')
+
+    env = os.environ.copy()
+    env.pop("DOCKER_HOST", None)
+    env.pop("DOCKER_CONTEXT", None)
+    env.update(
+        {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "PREFLIGHT_ROOT": str(root),
+            "PREFLIGHT_DB_RETRY_DELAY": "0",
+            "PREFLIGHT_DB_RETRY_ATTEMPTS": "3",
+        }
+    )
+    return root, env
+
+
+def _run(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def test_preflight_passes_with_uv_owned_python_and_local_db(
+    clone_environment: tuple[Path, dict[str, str]],
+) -> None:
+    _, env = clone_environment
+
+    result = _run(env=env)
+
+    assert result.returncode == 0
+    assert "Preflight passed." in result.stdout
+    assert "local Postgres accepts connections" in result.stdout
+    assert "will provision the locked Python interpreter" in result.stdout
+    assert "uv sync --locked --dev" in result.stdout
+    assert "npm ci" in result.stdout
+    assert "value-that-must-not-be-printed" not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("DATABASE_URL", ""),
+        ("GOOGLE_API_KEY", ""),
+        ("GOOGLE_API_KEY", "your-google-ai-studio-key-here"),
+        ("GOOGLE_API_KEY", "changeme"),
+    ],
+)
+def test_preflight_rejects_missing_empty_or_placeholder_required_env_keys(
+    clone_environment: tuple[Path, dict[str, str]],
+    key: str,
+    value: str,
+) -> None:
+    root, env = clone_environment
+    values = {
+        "DATABASE_URL": "postgresql+asyncpg://jobagent:jobagent@localhost/jobagent",
+        "GOOGLE_API_KEY": "configured-local-key",
+    }
+    values[key] = value
+    (root / ".env").write_text("".join(f"{name}={item}\n" for name, item in values.items()))
+
+    result = _run("--skip-db", env=env)
+
+    assert result.returncode == 1
+    assert f".env key {key} is missing, empty, or still a placeholder" in result.stderr
+    if value:
+        assert value not in result.stdout + result.stderr
+
+
+def test_preflight_does_not_require_optional_empty_secrets(
+    clone_environment: tuple[Path, dict[str, str]],
+) -> None:
+    _, env = clone_environment
+
+    result = _run("--skip-db", env=env)
+
+    assert result.returncode == 0
+    assert "LANGSMITH_API_KEY" not in result.stdout + result.stderr
+
+
+def test_preflight_reports_missing_env(
+    clone_environment: tuple[Path, dict[str, str]],
+) -> None:
+    root, env = clone_environment
+    (root / ".env").unlink()
+
+    result = _run("--skip-db", env=env)
+
+    assert result.returncode == 1
+    assert ".env is missing" in result.stderr
+    assert "SKIP local db" in result.stdout
+
+
+def test_preflight_retries_database_from_starting_to_ready(
+    clone_environment: tuple[Path, dict[str, str]],
+    tmp_path: Path,
+) -> None:
+    _, env = clone_environment
+    count_file = tmp_path / "pg-attempts"
+    docker = Path(env["PATH"].split(":", maxsplit=1)[0]) / "docker"
+    _executable(
+        docker,
+        f"""case "$*" in
+  "--version"|"info"|"compose version") exit 0 ;;
+  "context show") echo default ;;
+  "context inspect --format {{{{.Endpoints.docker.Host}}}} default")
+    echo unix:///var/run/docker.sock
+    ;;
+  "compose ps --status running --services db") echo db ;;
+  "compose exec -T db pg_isready -U jobagent -d jobagent")
+    count=0
+    test -f "{count_file}" && count=$(tr -d '\\n' < "{count_file}")
+    count=$((count + 1))
+    printf '%s' "$count" > "{count_file}"
+    test "$count" -ge 2
+    ;;
+  *) exit 9 ;;
+esac""",
+    )
+
+    result = _run(env=env)
+
+    assert result.returncode == 0
+    assert "local Postgres accepts connections" in result.stdout
+    assert count_file.read_text() == "2"
+
+
+def test_preflight_fails_when_local_db_is_not_running(
+    clone_environment: tuple[Path, dict[str, str]],
+) -> None:
+    _, env = clone_environment
+    docker = Path(env["PATH"].split(":", maxsplit=1)[0]) / "docker"
+    _executable(
+        docker,
+        """case "$*" in
+  "--version"|"info"|"compose version") exit 0 ;;
+  "context show") echo default ;;
+  "context inspect --format {{.Endpoints.docker.Host}} default") echo unix:///var/run/docker.sock ;;
+  "compose ps --status running --services db") exit 0 ;;
+  *) exit 9 ;;
+esac""",
+    )
+
+    result = _run(env=env)
+
+    assert result.returncode == 1
+    assert "docker compose up -d --wait db" in result.stderr
+
+
+@pytest.mark.parametrize("remote_endpoint", ["tcp://prod.example:2376", "ssh://prod.example"])
+def test_preflight_refuses_remote_docker_before_daemon_or_compose_operations(
+    clone_environment: tuple[Path, dict[str, str]],
+    tmp_path: Path,
+    remote_endpoint: str,
+) -> None:
+    _, env = clone_environment
+    calls = tmp_path / "docker-calls"
+    docker = Path(env["PATH"].split(":", maxsplit=1)[0]) / "docker"
+    _executable(
+        docker,
+        f"""printf '%s\\n' "$*" >> "{calls}"
+case "$*" in
+  "--version") exit 0 ;;
+  *) exit 91 ;;
+esac""",
+    )
+    env["DOCKER_HOST"] = remote_endpoint
+
+    result = _run(env=env)
+
+    assert result.returncode == 1
+    assert "refusing non-local or unknown Docker endpoint" in result.stderr
+    docker_calls = calls.read_text().splitlines()
+    assert docker_calls == ["--version"]
+
+
+def test_preflight_refuses_remote_active_docker_context(
+    clone_environment: tuple[Path, dict[str, str]],
+) -> None:
+    _, env = clone_environment
+    docker = Path(env["PATH"].split(":", maxsplit=1)[0]) / "docker"
+    _executable(
+        docker,
+        """case "$*" in
+  "--version") exit 0 ;;
+  "context inspect --format {{.Endpoints.docker.Host}} production") echo ssh://prod.example ;;
+  *) exit 91 ;;
+esac""",
+    )
+    env["DOCKER_CONTEXT"] = "production"
+    env["DOCKER_HOST"] = "unix:///var/run/docker.sock"
+
+    result = _run("--skip-db", env=env)
+
+    assert result.returncode == 1
+    assert "refusing non-local or unknown Docker endpoint" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("version", "supported"),
+    [
+        ("20.18.9", False),
+        ("20.19.0", True),
+        ("21.9.0", False),
+        ("22.11.9", False),
+        ("22.12.0", True),
+        ("23.0.0", True),
+        ("24.0.0", True),
+    ],
+)
+def test_preflight_node_version_boundaries(
+    clone_environment: tuple[Path, dict[str, str]],
+    version: str,
+    supported: bool,
+) -> None:
+    _, env = clone_environment
+    node = Path(env["PATH"].split(":", maxsplit=1)[0]) / "node"
+    _executable(node, f'test "$1" = "-p" && echo "{version}"')
+
+    result = _run("--skip-db", env=env)
+
+    assert (result.returncode == 0) is supported
+    if not supported:
+        assert "Node ^20.19 or >=22.12 is required" in result.stderr
+
+
+def test_preflight_help_and_invalid_usage_have_documented_exit_codes() -> None:
+    help_result = _run("--help", env={"PATH": "/usr/bin:/bin"})
+    invalid_result = _run("--not-an-option", env={"PATH": "/usr/bin:/bin"})
+
+    assert help_result.returncode == 0
+    assert "No dependencies are installed" in help_result.stdout
+    assert "uv owns Python interpreter provisioning" in help_result.stdout
+    assert "0  every requested check passed" in help_result.stdout
+    assert invalid_result.returncode == 2
+    assert "Usage:" in invalid_result.stderr

--- a/tests/unit/test_worker_payloads.py
+++ b/tests/unit/test_worker_payloads.py
@@ -60,7 +60,21 @@ def test_batch_match_payload_requires_profile_id():
 def test_batch_match_payload_parses_profile_id():
     profile_id = uuid.uuid4()
 
-    payload = BatchMatchPayload(profile_id=str(profile_id), max_items=50)
+    payload = BatchMatchPayload(
+        profile_id=str(profile_id),
+        max_items=50,
+        max_candidates=10,
+    )
 
     assert payload.profile_id == profile_id
     assert payload.max_items == 50
+    assert payload.max_candidates == 10
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("max_items", 0), ("max_items", -1), ("max_candidates", -1)],
+)
+def test_batch_match_payload_rejects_invalid_bounds(field, value):
+    with pytest.raises(ValidationError):
+        BatchMatchPayload(profile_id=uuid.uuid4(), **{field: value})


### PR DESCRIPTION
## Summary
- add a local-only fresh-clone preflight for locked dependencies, environment keys, Compose, and Postgres readiness
- refuse remote Docker contexts before any daemon or Compose operation
- document the app-to-GHCR-to-infra deployment chain and symptom-driven diagnosis
- make batch-match canaries explicit, isolated, and mechanically bounded
- durably reserve candidate budget under the queue lease before provider/domain work so crashes fail closed

## Rationale
The app already had strong scripts and CI, but first-clone setup and cross-repository deployment diagnosis were scattered. The canary path also needed an enforceable blast-radius contract rather than operator prose.

## Verification
- unit suite: 347 passed
- affected integration suite: 52 passed
- Ruff on changed Python: passed
- shell syntax, `uv lock --check`, npm lockfile dry run, and `git diff --check`: passed

## Scope note
The existing dirty checkout files `docs/runbooks/index.md` and `docs/runbooks/production-runtime.md` were not used or modified; this branch was built from a clean `origin/main` worktree.
